### PR TITLE
feat: #10 - Coding guidelines in target repo

### DIFF
--- a/.claude/commands/bug.md
+++ b/.claude/commands/bug.md
@@ -11,7 +11,7 @@ issueJson: $3, default to empty JSON object if not provided (`{}`)
 
 - IMPORTANT: You're writing a plan to resolve a bug based on the `Bug` that will add value to the application.
 - IMPORTANT: The `Bug` describes the bug that will be resolved but remember we're not resolving the bug, we're creating the plan that will be used to resolve the bug based on the `Plan Format` below.
-- IMPORTANT: Planning and implementation must strictly adhere to the coding guidelines in `/guidelines`.
+- IMPORTANT: If a `guidelines/` directory exists in the target repository, planning and implementation must strictly adhere to those coding guidelines.
 - You're writing a plan to resolve a bug, it should be thorough and precise so we fix the root cause and prevent regressions.
 - Create the plan in the `specs/` directory with filename: `issue-{issueNumber}-adw-{adwId}-sdlc_planner-{descriptiveName}.md`
   - Replace `{descriptiveName}` with a short, descriptive name based on the bug (e.g., "fix-login-error", "resolve-timeout", "patch-memory-leak")
@@ -29,13 +29,13 @@ issueJson: $3, default to empty JSON object if not provided (`{}`)
   - IMPORTANT: When you fill out the `Plan Format: Relevant Files` section, add an instruction to read `.claude/commands/test_e2e.md`, and `.claude/commands/e2e-examples/test_basic_query.md` to understand how to create an E2E test file. List your new E2E test file to the `Plan Format: New Files` section.
   - To be clear, we're not creating a new E2E test file, we're creating a task to create a new E2E test file in the `Plan Format` below
 - Respect requested files in the `Relevant Files` section.
-- Start your research by reading the `README.md` file and the coding guidelines in `/guidelines`.
+- Start your research by reading the `README.md` file. If a `guidelines/` directory exists in the target repository, also read those coding guidelines.
 
 ## Relevant Files
 
 Focus on the following files:
 - `README.md` - Contains the project overview and instructions.
-- `guidelines/**` - Contains coding guidelines that must be followed.
+- `guidelines/**` - Contains coding guidelines that must be followed (target repository — may not exist in all repos). If present, read and follow these guidelines.
 - `src/app/**` - Contains Next.js App Router pages, layouts, and route handlers.
 - `src/components/**` - Contains React components.
 - `src/lib/**` - Contains utility functions and shared logic.
@@ -98,7 +98,7 @@ Execute every command to validate the bug is fixed with zero regressions.
 - `npm test` - Run tests to validate the bug is fixed with zero regressions
 
 ## Notes
-- IMPORTANT: strictly adhere to the coding guidelines in `/guidelines`. If necessary, refactor existing code to meet the coding guidelines as part of fixing the bug.
+- IMPORTANT: If a `guidelines/` directory exists in the target repository, strictly adhere to those coding guidelines. If necessary, refactor existing code to meet the coding guidelines as part of fixing the bug.
 <optionally list any additional notes or context that are relevant to the bug that will be helpful to the developer>
 ```
 

--- a/.claude/commands/chore.md
+++ b/.claude/commands/chore.md
@@ -11,7 +11,7 @@ issueJson: $3, default to empty JSON object if not provided (`{}`)
 
 - IMPORTANT: You're writing a plan to resolve a chore based on the `Chore` that will add value to the application.
 - IMPORTANT: The `Chore` describes the chore that will be resolved but remember we're not resolving the chore, we're creating the plan that will be used to resolve the chore based on the `Plan Format` below.
-- IMPORTANT: Planning and implementation must strictly adhere to the coding guidelines in `/guidelines`.
+- IMPORTANT: If a `guidelines/` directory exists in the target repository, planning and implementation must strictly adhere to those coding guidelines.
 - You're writing a plan to resolve a chore, it should be simple but we need to be thorough and precise so we don't miss anything or waste time with any second round of changes.
 - Create the plan in the `specs/` directory with filename: `issue-{issueNumber}-adw-{adwId}-sdlc_planner-{descriptive-name}.md`
   - Replace `{descriptive-name}` with a short, descriptive name based on the chore (e.g., "update-readme", "fix-tests", "refactor-auth")
@@ -20,7 +20,7 @@ issueJson: $3, default to empty JSON object if not provided (`{}`)
 - IMPORTANT: Replace every <placeholder> in the `Plan Format` with the requested value. Add as much detail as needed to accomplish the chore.
 - Consider the plan and the steps to accomplish the chore.
 - Respect requested files in the `Relevant Files` section.
-- Start your research by reading the `README.md` file and the coding guidelines in `/guidelines`.
+- Start your research by reading the `README.md` file. If a `guidelines/` directory exists in the target repository, also read those coding guidelines.
 - `adws/*.tsx` contain node tsx single file typescript scripts. So if you want to run them use `npx tsx <script_name>`.
 - When you finish creating the plan for the chore, follow the `Report` section to properly report the results of your work.
 
@@ -28,7 +28,7 @@ issueJson: $3, default to empty JSON object if not provided (`{}`)
 
 Focus on the following files:
 - `README.md` - Contains the project overview and instructions.
-- `guidelines/**` - Contains coding guidelines that must be followed.
+- `guidelines/**` - Contains coding guidelines that must be followed (target repository — may not exist in all repos). If present, read and follow these guidelines.
 - `src/app/**` - Contains Next.js App Router pages, layouts, and route handlers.
 - `src/components/**` - Contains React components.
 - `src/lib/**` - Contains utility functions and shared logic.
@@ -74,7 +74,7 @@ Execute every command to validate the chore is complete with zero regressions.
 - `npm test` - Run tests to validate the chore is complete with zero regressions
 
 ## Notes
-- IMPORTANT: strictly adhere to the coding guidelines in `/guidelines`. If necessary, refactor existing code to meet the coding guidelines as part of accomplishing the chore.
+- IMPORTANT: If a `guidelines/` directory exists in the target repository, strictly adhere to those coding guidelines. If necessary, refactor existing code to meet the coding guidelines as part of accomplishing the chore.
 <optionally list any additional notes or context that are relevant to the chore that will be helpful to the developer>
 ```
 

--- a/.claude/commands/feature.md
+++ b/.claude/commands/feature.md
@@ -27,14 +27,14 @@ issueJson: $3, default to empty JSON object if not provided (`{}`)
   - IMPORTANT: When you fill out the `Plan Format: Relevant Files` section, add an instruction to read `.claude/commands/test_e2e.md`, and `.claude/commands/e2e-examples/test_basic_query.md` to understand how to create an E2E test file. List your new E2E test file to the `Plan Format: New Files` section.
   - To be clear, we're not creating a new E2E test file, we're creating a task to create a new E2E test file in the `Plan Format` below
 - Respect requested files in the `Relevant Files` section.
-- IMPORTANT: Planning and implementation must strictly adhere to the coding guidelines in `/guidelines`.
-- Start your research by reading the `README.md` file and the coding guidelines in `/guidelines`.
+- IMPORTANT: If a `guidelines/` directory exists in the target repository, planning and implementation must strictly adhere to those coding guidelines.
+- Start your research by reading the `README.md` file. If a `guidelines/` directory exists in the target repository, also read those coding guidelines.
 
 ## Relevant Files
 
 Focus on the following files:
 - `README.md` - Contains the project overview and instructions.
-- `guidelines/**` - Contains coding guidelines that must be followed.
+- `guidelines/**` - Contains coding guidelines that must be followed (target repository — may not exist in all repos). If present, read and follow these guidelines.
 - `src/app/**` - Contains Next.js App Router pages, layouts, and route handlers.
 - `src/components/**` - Contains React components.
 - `src/lib/**` - Contains utility functions and shared logic.
@@ -118,7 +118,7 @@ Execute every command to validate the feature works correctly with zero regressi
 - `npm test` - Run tests to validate the feature works with zero regressions
 
 ## Notes
-- IMPORTANT: strictly adhere to the coding guidelines in `/guidelines`. If necessary, refactor existing code to meet the coding guidelines as part of implementing the feature.
+- IMPORTANT: If a `guidelines/` directory exists in the target repository, strictly adhere to those coding guidelines. If necessary, refactor existing code to meet the coding guidelines as part of implementing the feature.
 <optionally list any additional notes, future considerations, or context that are relevant to the feature that will be helpful to the developer>
 ```
 

--- a/.claude/commands/pr_review.md
+++ b/.claude/commands/pr_review.md
@@ -11,7 +11,7 @@ Create a new plan at `specs/issue-{issueNumber}-plan.md` (where `{issueNumber}` 
 
 - IMPORTANT: You're writing a plan to resolve a review based on the `PR-Review` that will add value to the application.
 - IMPORTANT: The `PR-Review` describes the review that will be resolved but remember we're not resolving the review, we're creating the plan that will be used to resolve the review based on the `Plan Format` below.
-- IMPORTANT: Planning and implementation must strictly adhere to the coding guidelines in `/guidelines`.
+- IMPORTANT: If a `guidelines/` directory exists in the target repository, planning and implementation must strictly adhere to those coding guidelines.
 - You're writing a plan to resolve a PR review, it should be simple but we need to be thorough and precise so we don't miss anything or waste time with any second round of changes.
 - Analyze each review comment carefully and understand what changes are required to resolve the review.
 - Create a revision plan at `specs/issue-{issueNumber}-plan.md` (where `{issueNumber}` is the issue number from the GitHub Issue) that addresses ALL review comments in the `PR-Review`.
@@ -20,7 +20,7 @@ Create a new plan at `specs/issue-{issueNumber}-plan.md` (where `{issueNumber}` 
 - IMPORTANT: Replace every <placeholder> in the `Plan Format` with the requested value. Add as much detail as needed to accomplish the review.
 - Consider the plan and the steps to accomplish the review.
 - Respect requested files in the `Relevant Files` section.
-- Start your research by reading the `README.md` file and the coding guidelines in `/guidelines`.
+- Start your research by reading the `README.md` file. If a `guidelines/` directory exists in the target repository, also read those coding guidelines.
 - `adws/*.tsx` contain node tsx single file typescript scripts. So if you want to run them use `npx tsx <script_name>`.
 - When you finish creating the plan for the review, follow the `Report` section to properly report the results of your work.
 
@@ -28,7 +28,7 @@ Create a new plan at `specs/issue-{issueNumber}-plan.md` (where `{issueNumber}` 
 
 Focus on the following files:
 - `README.md` - Contains the project overview and instructions.
-- `guidelines/**` - Contains coding guidelines that must be followed.
+- `guidelines/**` - Contains coding guidelines that must be followed (target repository — may not exist in all repos). If present, read and follow these guidelines.
 - `src/app/**` - Contains Next.js App Router pages, layouts, and route handlers.
 - `src/components/**` - Contains React components.
 - `src/lib/**` - Contains utility functions and shared logic.

--- a/specs/issue-10-adw-coding-guidelines-in-9qbluw-sdlc_planner-update-coding-guidelines-path.md
+++ b/specs/issue-10-adw-coding-guidelines-in-9qbluw-sdlc_planner-update-coding-guidelines-path.md
@@ -1,0 +1,114 @@
+# Feature: Update coding guidelines path references in slash commands
+
+## Metadata
+issueNumber: `10`
+adwId: `coding-guidelines-in-9qbluw`
+issueJson: `{"number":10,"title":"Coding guidelines in target repo","body":"Some of the claude skills / commands contain a reference to guidelines/coding_guidelines.md. These are in the TARGET git repo. Update the prompts to make sure that the model understands this.","state":"OPEN","author":"paysdoc","labels":[],"createdAt":"2026-02-25T07:39:55Z","comments":[],"actionableComment":null}`
+
+## Feature Description
+Several Claude slash commands (`.claude/commands/feature.md`, `.claude/commands/bug.md`, `.claude/commands/chore.md`, `.claude/commands/pr_review.md`) contain references to a `/guidelines` directory for coding guidelines. These guidelines do not exist in the ADW repository itself — they exist in the TARGET git repository that ADW operates on. The current prompts do not make this distinction clear, leading to confusion when the model tries to read guidelines that don't exist in the ADW repo, or when the model doesn't understand the guidelines are in the target repo's working directory.
+
+This feature updates all affected slash command prompts to:
+1. Clarify that `guidelines/` refers to the TARGET repository's coding guidelines directory
+2. Add conditional language so the model checks if the directory exists before trying to read from it
+3. Ensure the model understands these are target-repo-specific guidelines, not ADW-repo guidelines
+
+## User Story
+As an ADW operator
+I want the slash commands to clearly indicate that coding guidelines are located in the target repository
+So that the AI model correctly reads and applies the target repo's coding guidelines (when they exist) instead of failing to find them in the ADW repo
+
+## Problem Statement
+The slash commands (`/feature`, `/bug`, `/chore`, `/pr_review`) reference `/guidelines` as if it's always present and local to the current working directory. When ADW runs on an external target repo, Claude Code operates in that repo's directory via the `cwd` parameter. The `/guidelines` path resolves correctly in that context, but:
+1. The prompts don't explain that the guidelines are part of the TARGET repo, not the ADW repo
+2. There's no conditional handling for when the target repo doesn't have a `guidelines/` directory
+3. Previous plan specs have noted this confusion: "The `guidelines/` directory referenced in the original plan does not exist in the repository. This is a boilerplate reference and is non-blocking."
+
+## Solution Statement
+Update all four affected slash command files to:
+1. Replace absolute-looking `/guidelines` references with explicit language stating these are the **target repository's** coding guidelines
+2. Add conditional instructions: "if a `guidelines/` directory exists in the repository"
+3. Update the `Relevant Files` section to clarify that `guidelines/**` is a target-repo path that may or may not exist
+4. Update the Plan Format `Notes` sections with the same conditional language
+
+## Relevant Files
+Use these files to implement the feature:
+
+- `.claude/commands/feature.md` — Contains 4 references to `/guidelines` on lines 30, 31, 37, and 121. These need to be updated to clarify the guidelines are in the target repo and should be conditionally read.
+- `.claude/commands/bug.md` — Contains 4 references to `/guidelines` on lines 14, 32, 38, and 101. Same updates needed.
+- `.claude/commands/chore.md` — Contains 4 references to `/guidelines` on lines 14, 23, 31, and 77. Same updates needed.
+- `.claude/commands/pr_review.md` — Contains 3 references to `/guidelines` on lines 14, 23, and 31. Same updates needed.
+
+## Implementation Plan
+### Phase 1: Foundation
+Identify and document all exact locations in each command file that reference `/guidelines`. Determine the consistent replacement language to use across all files.
+
+### Phase 2: Core Implementation
+Update each of the four command files with consistent language that:
+- Replaces "the coding guidelines in `/guidelines`" with "the target repository's coding guidelines in `guidelines/` (if the directory exists)"
+- Updates the `Relevant Files` bullet for `guidelines/**` to include "(target repository — may not exist in all repos)"
+- Updates Plan Format `Notes` sections with conditional language
+
+### Phase 3: Integration
+Verify all changes are consistent across the four files. Run linting and tests to ensure no regressions.
+
+## Step by Step Tasks
+IMPORTANT: Execute every step in order, top to bottom.
+
+### Step 1: Update `.claude/commands/feature.md`
+- **Line 30**: Change `IMPORTANT: Planning and implementation must strictly adhere to the coding guidelines in \`/guidelines\`.` to `IMPORTANT: If a \`guidelines/\` directory exists in the target repository, planning and implementation must strictly adhere to those coding guidelines.`
+- **Line 31**: Change `Start your research by reading the \`README.md\` file and the coding guidelines in \`/guidelines\`.` to `Start your research by reading the \`README.md\` file. If a \`guidelines/\` directory exists in the target repository, also read those coding guidelines.`
+- **Line 37**: Change `\`guidelines/**\` - Contains coding guidelines that must be followed.` to `\`guidelines/**\` - Contains coding guidelines that must be followed (target repository — may not exist in all repos). If present, read and follow these guidelines.`
+- **Line 121**: Change `IMPORTANT: strictly adhere to the coding guidelines in \`/guidelines\`. If necessary, refactor existing code to meet the coding guidelines as part of implementing the feature.` to `IMPORTANT: If a \`guidelines/\` directory exists in the target repository, strictly adhere to those coding guidelines. If necessary, refactor existing code to meet the coding guidelines as part of implementing the feature.`
+
+### Step 2: Update `.claude/commands/bug.md`
+- **Line 14**: Change `IMPORTANT: Planning and implementation must strictly adhere to the coding guidelines in \`/guidelines\`.` to `IMPORTANT: If a \`guidelines/\` directory exists in the target repository, planning and implementation must strictly adhere to those coding guidelines.`
+- **Line 32**: Change `Start your research by reading the \`README.md\` file and the coding guidelines in \`/guidelines\`.` to `Start your research by reading the \`README.md\` file. If a \`guidelines/\` directory exists in the target repository, also read those coding guidelines.`
+- **Line 38**: Change `\`guidelines/**\` - Contains coding guidelines that must be followed.` to `\`guidelines/**\` - Contains coding guidelines that must be followed (target repository — may not exist in all repos). If present, read and follow these guidelines.`
+- **Line 101**: Change `IMPORTANT: strictly adhere to the coding guidelines in \`/guidelines\`. If necessary, refactor existing code to meet the coding guidelines as part of fixing the bug.` to `IMPORTANT: If a \`guidelines/\` directory exists in the target repository, strictly adhere to those coding guidelines. If necessary, refactor existing code to meet the coding guidelines as part of fixing the bug.`
+
+### Step 3: Update `.claude/commands/chore.md`
+- **Line 14**: Change `IMPORTANT: Planning and implementation must strictly adhere to the coding guidelines in \`/guidelines\`.` to `IMPORTANT: If a \`guidelines/\` directory exists in the target repository, planning and implementation must strictly adhere to those coding guidelines.`
+- **Line 23**: Change `Start your research by reading the \`README.md\` file and the coding guidelines in \`/guidelines\`.` to `Start your research by reading the \`README.md\` file. If a \`guidelines/\` directory exists in the target repository, also read those coding guidelines.`
+- **Line 31**: Change `\`guidelines/**\` - Contains coding guidelines that must be followed.` to `\`guidelines/**\` - Contains coding guidelines that must be followed (target repository — may not exist in all repos). If present, read and follow these guidelines.`
+- **Line 77**: Change `IMPORTANT: strictly adhere to the coding guidelines in \`/guidelines\`. If necessary, refactor existing code to meet the coding guidelines as part of accomplishing the chore.` to `IMPORTANT: If a \`guidelines/\` directory exists in the target repository, strictly adhere to those coding guidelines. If necessary, refactor existing code to meet the coding guidelines as part of accomplishing the chore.`
+
+### Step 4: Update `.claude/commands/pr_review.md`
+- **Line 14**: Change `IMPORTANT: Planning and implementation must strictly adhere to the coding guidelines in \`/guidelines\`.` to `IMPORTANT: If a \`guidelines/\` directory exists in the target repository, planning and implementation must strictly adhere to those coding guidelines.`
+- **Line 23**: Change `Start your research by reading the \`README.md\` file and the coding guidelines in \`/guidelines\`.` to `Start your research by reading the \`README.md\` file. If a \`guidelines/\` directory exists in the target repository, also read those coding guidelines.`
+- **Line 31**: Change `\`guidelines/**\` - Contains coding guidelines that must be followed.` to `\`guidelines/**\` - Contains coding guidelines that must be followed (target repository — may not exist in all repos). If present, read and follow these guidelines.`
+
+### Step 5: Run Validation Commands
+- Run `npm run lint` to check for code quality issues
+- Run `npm run build` to verify no build errors
+- Run `npm test` to validate no regressions
+
+## Testing Strategy
+### Unit Tests
+No new unit tests are required. The changes are to markdown prompt templates (`.claude/commands/*.md`), not to executable code. Existing tests should continue to pass unchanged.
+
+### Edge Cases
+- Target repo **has** a `guidelines/` directory — the model should read and follow those guidelines
+- Target repo **does not have** a `guidelines/` directory — the model should skip guideline reading gracefully without errors or confusion
+- ADW running on itself (self-referential) — no `guidelines/` directory exists in the ADW repo, so the conditional language prevents confusion
+
+## Acceptance Criteria
+- All four command files (feature.md, bug.md, chore.md, pr_review.md) are updated with consistent language
+- References to `/guidelines` are replaced with `guidelines/` (relative, not absolute-looking)
+- All references include conditional language ("if exists in the target repository")
+- The `Relevant Files` sections clarify that `guidelines/**` is a target-repo path
+- Plan Format `Notes` sections use conditional language
+- `npm run lint`, `npm run build`, and `npm test` all pass without errors
+
+## Validation Commands
+Execute every command to validate the feature works correctly with zero regressions.
+
+- `npm run lint` - Run linter to check for code quality issues
+- `npm run build` - Build the application to verify no build errors
+- `npm test` - Run tests to validate the feature works with zero regressions
+
+## Notes
+- No `guidelines/` directory exists in the ADW repository. The guidelines are exclusively a target-repo convention.
+- Previous specs (e.g., `specs/issue-2-plan.md` line 89, `specs/issue-0-adw-adw-unknown-sdlc_planner-fix-webhook-port-eaddrinuse.md` line 87) have already noted this confusion with comments like "The `guidelines/` directory referenced in the original plan does not exist in the repository. This is a boilerplate reference and is non-blocking."
+- The changes are purely to markdown prompt templates and do not affect any TypeScript code or runtime behavior.
+- No new libraries are needed.


### PR DESCRIPTION
## Summary

Resolves issue #10 where several ADW skills/commands referenced `guidelines/coding_guidelines.md` without making it clear that this file lives in the **target git repository** (not the ADW repo itself). This caused confusion when the model tried to load guidelines and couldn't locate the file.

## Plan

Implemented per spec: [specs/issue-10-adw-coding-guidelines-in-9qbluw-sdlc_planner-update-coding-guidelines-path.md](specs/issue-10-adw-coding-guidelines-in-9qbluw-sdlc_planner-update-coding-guidelines-path.md)

## Changes

- **`.claude/commands/bug.md`** — Updated coding guidelines reference to clarify it is in the target repo, made loading conditional
- **`.claude/commands/chore.md`** — Same conditional target-repo guidelines update
- **`.claude/commands/feature.md`** — Same conditional target-repo guidelines update
- **`.claude/commands/pr_review.md`** — Same conditional target-repo guidelines update
- **`specs/issue-10-adw-coding-guidelines-in-9qbluw-sdlc_planner-update-coding-guidelines-path.md`** — Implementation spec added

## What was done

- [x] Identified all commands that reference `guidelines/coding_guidelines.md`
- [x] Updated prompts to explicitly state the guidelines file is in the target repository
- [x] Made guidelines loading conditional (only when the file exists in the target repo)
- [x] Added implementation spec to `specs/`

Closes #10

---
ADW tracking ID: `9qbluw`