### PR TITLE
bug: #23 - Fix ADW classifier, plan agent, and worktree cleanup for external target repos

### DIFF
--- a/adws/__tests__/ensureGitignoreEntry.test.ts
+++ b/adws/__tests__/ensureGitignoreEntry.test.ts
@@ -12,7 +12,7 @@ vi.mock('../core/utils', () => ({
   log: vi.fn(),
 }));
 
-import { ensureGitignoreEntry } from '../phases/workflowLifecycle';
+import { ensureGitignoreEntry, ensureGitignoreEntries } from '../phases/workflowLifecycle';
 
 const WORKTREE = '/tmp/fake-worktree';
 const GITIGNORE = path.join(WORKTREE, '.gitignore');
@@ -25,11 +25,11 @@ describe('ensureGitignoreEntry', () => {
   it('creates .gitignore with entry when file does not exist', () => {
     vi.mocked(fs.existsSync).mockReturnValue(false);
 
-    ensureGitignoreEntry(WORKTREE, '.claude/commands/');
+    ensureGitignoreEntry(WORKTREE, '.claude/commands/bug.md');
 
     expect(fs.writeFileSync).toHaveBeenCalledWith(
       GITIGNORE,
-      expect.stringContaining('.claude/commands/'),
+      expect.stringContaining('.claude/commands/bug.md'),
       'utf-8',
     );
     expect(fs.writeFileSync).toHaveBeenCalledWith(
@@ -43,21 +43,21 @@ describe('ensureGitignoreEntry', () => {
     vi.mocked(fs.existsSync).mockReturnValue(true);
     vi.mocked(fs.readFileSync).mockReturnValue('node_modules/\ndist/\n');
 
-    ensureGitignoreEntry(WORKTREE, '.claude/commands/');
+    ensureGitignoreEntry(WORKTREE, '.claude/commands/bug.md');
 
     const written = vi.mocked(fs.writeFileSync).mock.calls[0][1] as string;
     expect(written).toContain('node_modules/');
     expect(written).toContain('dist/');
-    expect(written).toContain('.claude/commands/');
+    expect(written).toContain('.claude/commands/bug.md');
   });
 
   it('does not duplicate entry when it already exists', () => {
     vi.mocked(fs.existsSync).mockReturnValue(true);
     vi.mocked(fs.readFileSync).mockReturnValue(
-      'node_modules/\n.claude/commands/\n',
+      'node_modules/\n.claude/commands/bug.md\n',
     );
 
-    ensureGitignoreEntry(WORKTREE, '.claude/commands/');
+    ensureGitignoreEntry(WORKTREE, '.claude/commands/bug.md');
 
     expect(fs.writeFileSync).not.toHaveBeenCalled();
   });
@@ -67,22 +67,132 @@ describe('ensureGitignoreEntry', () => {
     vi.mocked(fs.existsSync).mockReturnValue(true);
     vi.mocked(fs.readFileSync).mockReturnValue(existing);
 
-    ensureGitignoreEntry(WORKTREE, '.claude/commands/');
+    ensureGitignoreEntry(WORKTREE, '.claude/commands/bug.md');
 
     const written = vi.mocked(fs.writeFileSync).mock.calls[0][1] as string;
     expect(written.startsWith(existing)).toBe(true);
-    expect(written).toContain('.claude/commands/');
+    expect(written).toContain('.claude/commands/bug.md');
   });
 
   it('adds newline before comment when existing content lacks trailing newline', () => {
     vi.mocked(fs.existsSync).mockReturnValue(true);
     vi.mocked(fs.readFileSync).mockReturnValue('node_modules/');
 
-    ensureGitignoreEntry(WORKTREE, '.claude/commands/');
+    ensureGitignoreEntry(WORKTREE, '.claude/commands/bug.md');
 
     const written = vi.mocked(fs.writeFileSync).mock.calls[0][1] as string;
     expect(written).toBe(
-      'node_modules/\n# ADW: copied slash commands (do not commit)\n.claude/commands/\n',
+      'node_modules/\n# ADW: copied slash commands (do not commit)\n.claude/commands/bug.md\n',
+    );
+  });
+
+  it('adds multiple file entries with comment header only once', () => {
+    const comment = '# ADW: copied slash commands (do not commit)';
+
+    // First call: file does not exist
+    vi.mocked(fs.existsSync).mockReturnValue(false);
+    ensureGitignoreEntry(WORKTREE, '.claude/commands/bug.md');
+
+    const afterFirst = vi.mocked(fs.writeFileSync).mock.calls[0][1] as string;
+    expect(afterFirst).toBe(`${comment}\n.claude/commands/bug.md\n`);
+
+    // Second call: simulate reading the file that was just written
+    vi.mocked(fs.existsSync).mockReturnValue(true);
+    vi.mocked(fs.readFileSync).mockReturnValue(afterFirst);
+    ensureGitignoreEntry(WORKTREE, '.claude/commands/feature.md');
+
+    const afterSecond = vi.mocked(fs.writeFileSync).mock.calls[1][1] as string;
+    expect(afterSecond).toBe(
+      `${comment}\n.claude/commands/bug.md\n.claude/commands/feature.md\n`,
+    );
+
+    // Verify comment appears exactly once
+    const commentOccurrences = afterSecond.split('\n').filter((line) => line === comment);
+    expect(commentOccurrences).toHaveLength(1);
+
+    // Verify both entries are present
+    expect(afterSecond).toContain('.claude/commands/bug.md');
+    expect(afterSecond).toContain('.claude/commands/feature.md');
+  });
+});
+
+describe('ensureGitignoreEntries', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('adds multiple file entries with a single comment header', () => {
+    vi.mocked(fs.existsSync).mockReturnValue(false);
+
+    const entries = [
+      '.claude/commands/bug.md',
+      '.claude/commands/feature.md',
+      '.claude/commands/chore.md',
+    ];
+    ensureGitignoreEntries(WORKTREE, entries);
+
+    const written = vi.mocked(fs.writeFileSync).mock.calls[0][1] as string;
+    const commentOccurrences = written.split('\n').filter(
+      (line) => line === '# ADW: copied slash commands (do not commit)',
+    );
+    expect(commentOccurrences).toHaveLength(1);
+    expect(written).toContain('.claude/commands/bug.md');
+    expect(written).toContain('.claude/commands/feature.md');
+    expect(written).toContain('.claude/commands/chore.md');
+  });
+
+  it('skips entries that already exist in .gitignore', () => {
+    vi.mocked(fs.existsSync).mockReturnValue(true);
+    vi.mocked(fs.readFileSync).mockReturnValue(
+      'node_modules/\n.claude/commands/bug.md\n',
+    );
+
+    ensureGitignoreEntries(WORKTREE, [
+      '.claude/commands/bug.md',
+      '.claude/commands/chore.md',
+    ]);
+
+    const written = vi.mocked(fs.writeFileSync).mock.calls[0][1] as string;
+    expect(written).toContain('.claude/commands/chore.md');
+    // bug.md should not appear in the appended section
+    const appendedSection = written.split('# ADW: copied slash commands (do not commit)\n').pop()!;
+    expect(appendedSection).not.toContain('.claude/commands/bug.md');
+  });
+
+  it('does not write when all entries already exist', () => {
+    vi.mocked(fs.existsSync).mockReturnValue(true);
+    vi.mocked(fs.readFileSync).mockReturnValue(
+      '.claude/commands/bug.md\n.claude/commands/feature.md\n',
+    );
+
+    ensureGitignoreEntries(WORKTREE, [
+      '.claude/commands/bug.md',
+      '.claude/commands/feature.md',
+    ]);
+
+    expect(fs.writeFileSync).not.toHaveBeenCalled();
+  });
+
+  it('does nothing for empty entries array', () => {
+    ensureGitignoreEntries(WORKTREE, []);
+
+    expect(fs.existsSync).not.toHaveBeenCalled();
+    expect(fs.readFileSync).not.toHaveBeenCalled();
+    expect(fs.writeFileSync).not.toHaveBeenCalled();
+  });
+
+  it('creates .gitignore when file does not exist', () => {
+    vi.mocked(fs.existsSync).mockReturnValue(false);
+
+    ensureGitignoreEntries(WORKTREE, [
+      '.claude/commands/bug.md',
+      '.claude/commands/feature.md',
+    ]);
+
+    expect(fs.writeFileSync).toHaveBeenCalledWith(
+      GITIGNORE,
+      '# ADW: copied slash commands (do not commit)\n.claude/commands/bug.md\n.claude/commands/feature.md\n',
+      'utf-8',
     );
   });
 });

--- a/adws/__tests__/ensureGitignoreEntry.test.ts
+++ b/adws/__tests__/ensureGitignoreEntry.test.ts
@@ -1,0 +1,88 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import * as fs from 'fs';
+import * as path from 'path';
+
+vi.mock('fs', () => ({
+  existsSync: vi.fn(),
+  readFileSync: vi.fn(),
+  writeFileSync: vi.fn(),
+}));
+
+vi.mock('../core/utils', () => ({
+  log: vi.fn(),
+}));
+
+import { ensureGitignoreEntry } from '../phases/workflowLifecycle';
+
+const WORKTREE = '/tmp/fake-worktree';
+const GITIGNORE = path.join(WORKTREE, '.gitignore');
+
+describe('ensureGitignoreEntry', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('creates .gitignore with entry when file does not exist', () => {
+    vi.mocked(fs.existsSync).mockReturnValue(false);
+
+    ensureGitignoreEntry(WORKTREE, '.claude/commands/');
+
+    expect(fs.writeFileSync).toHaveBeenCalledWith(
+      GITIGNORE,
+      expect.stringContaining('.claude/commands/'),
+      'utf-8',
+    );
+    expect(fs.writeFileSync).toHaveBeenCalledWith(
+      GITIGNORE,
+      expect.stringContaining('# ADW: copied slash commands (do not commit)'),
+      'utf-8',
+    );
+  });
+
+  it('appends entry to existing .gitignore that lacks it', () => {
+    vi.mocked(fs.existsSync).mockReturnValue(true);
+    vi.mocked(fs.readFileSync).mockReturnValue('node_modules/\ndist/\n');
+
+    ensureGitignoreEntry(WORKTREE, '.claude/commands/');
+
+    const written = vi.mocked(fs.writeFileSync).mock.calls[0][1] as string;
+    expect(written).toContain('node_modules/');
+    expect(written).toContain('dist/');
+    expect(written).toContain('.claude/commands/');
+  });
+
+  it('does not duplicate entry when it already exists', () => {
+    vi.mocked(fs.existsSync).mockReturnValue(true);
+    vi.mocked(fs.readFileSync).mockReturnValue(
+      'node_modules/\n.claude/commands/\n',
+    );
+
+    ensureGitignoreEntry(WORKTREE, '.claude/commands/');
+
+    expect(fs.writeFileSync).not.toHaveBeenCalled();
+  });
+
+  it('preserves existing content when appending', () => {
+    const existing = '# project ignores\nbuild/\ncoverage/\n';
+    vi.mocked(fs.existsSync).mockReturnValue(true);
+    vi.mocked(fs.readFileSync).mockReturnValue(existing);
+
+    ensureGitignoreEntry(WORKTREE, '.claude/commands/');
+
+    const written = vi.mocked(fs.writeFileSync).mock.calls[0][1] as string;
+    expect(written.startsWith(existing)).toBe(true);
+    expect(written).toContain('.claude/commands/');
+  });
+
+  it('adds newline before comment when existing content lacks trailing newline', () => {
+    vi.mocked(fs.existsSync).mockReturnValue(true);
+    vi.mocked(fs.readFileSync).mockReturnValue('node_modules/');
+
+    ensureGitignoreEntry(WORKTREE, '.claude/commands/');
+
+    const written = vi.mocked(fs.writeFileSync).mock.calls[0][1] as string;
+    expect(written).toBe(
+      'node_modules/\n# ADW: copied slash commands (do not commit)\n.claude/commands/\n',
+    );
+  });
+});

--- a/adws/__tests__/issueClassifier.test.ts
+++ b/adws/__tests__/issueClassifier.test.ts
@@ -5,6 +5,7 @@ import {
   classifyIssueForTrigger,
   classifyGitHubIssue,
   getWorkflowScript,
+  extractAdwCommandFromText,
 } from '../core/issueClassifier';
 import { adwCommandToIssueTypeMap, adwCommandToOrchestratorMap, issueTypeToOrchestratorMap, AdwSlashCommand, IssueClassSlashCommand, GitHubIssue } from '../core/dataTypes';
 
@@ -44,6 +45,52 @@ function createMockIssue(overrides: Partial<GitHubIssue> = {}): GitHubIssue {
     ...overrides,
   };
 }
+
+// ============================================================================
+// extractAdwCommandFromText
+// ============================================================================
+
+describe('extractAdwCommandFromText', () => {
+  it('returns /adw_init when text contains /adw_init', () => {
+    expect(extractAdwCommandFromText('/adw_init')).toBe('/adw_init');
+  });
+
+  it('returns /adw_plan_build_test when text contains /adw_plan_build_test (not /adw_plan)', () => {
+    expect(extractAdwCommandFromText('Please run /adw_plan_build_test on this')).toBe('/adw_plan_build_test');
+  });
+
+  it('returns /adw_sdlc when command is embedded in prose', () => {
+    expect(extractAdwCommandFromText('We need to run /adw_sdlc for this feature request')).toBe('/adw_sdlc');
+  });
+
+  it('returns null when no ADW command is present', () => {
+    expect(extractAdwCommandFromText('This is a regular issue with no commands')).toBeNull();
+  });
+
+  it('returns null for empty text', () => {
+    expect(extractAdwCommandFromText('')).toBeNull();
+  });
+
+  it('returns null for partial matches like /adw_unknown', () => {
+    expect(extractAdwCommandFromText('/adw_unknown')).toBeNull();
+  });
+
+  it('returns the first match when multiple commands are present', () => {
+    const result = extractAdwCommandFromText('/adw_init and also /adw_sdlc');
+    // Both are valid; the longest-first sort determines order, but /adw_sdlc is longer
+    // However, /adw_init appears first in the text. Since we sort by length descending
+    // and use .find(), /adw_sdlc will be checked first and found first.
+    expect(result).toBe('/adw_sdlc');
+  });
+
+  it('matches /adw_plan_build_test_review over /adw_plan_build_test', () => {
+    expect(extractAdwCommandFromText('/adw_plan_build_test_review')).toBe('/adw_plan_build_test_review');
+  });
+
+  it('matches /adw_plan when only /adw_plan is present', () => {
+    expect(extractAdwCommandFromText('run /adw_plan for this issue')).toBe('/adw_plan');
+  });
+});
 
 // ============================================================================
 // parseAdwClassificationOutput
@@ -210,6 +257,44 @@ describe('classifyWithAdwCommand', () => {
       'haiku'
     );
   });
+
+  it('returns immediately via regex pre-check when issueBody contains explicit /adw_init', async () => {
+    const result = await classifyWithAdwCommand(
+      'issue context',
+      42,
+      '/tmp/output.jsonl',
+      'Please run /adw_init on this repo',
+    );
+
+    expect(result).toEqual({
+      issueType: '/chore',
+      success: true,
+      adwCommand: '/adw_init',
+    });
+    // Should NOT call the agent at all
+    expect(runClaudeAgentWithCommand).not.toHaveBeenCalled();
+    expect(log).toHaveBeenCalledWith(
+      expect.stringContaining('regex pre-check'),
+      'success'
+    );
+  });
+
+  it('falls through to agent when issueBody has no explicit /adw_* command', async () => {
+    vi.mocked(runClaudeAgentWithCommand).mockResolvedValue({
+      output: '{"adwSlashCommand": "/adw_build"}',
+      success: true,
+    });
+
+    const result = await classifyWithAdwCommand(
+      'issue context',
+      42,
+      '/tmp/output.jsonl',
+      'This issue has no explicit command',
+    );
+
+    expect(result?.adwCommand).toBe('/adw_build');
+    expect(runClaudeAgentWithCommand).toHaveBeenCalledTimes(1);
+  });
 });
 
 // ============================================================================
@@ -219,10 +304,26 @@ describe('classifyWithAdwCommand', () => {
 describe('classifyIssueForTrigger', () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    vi.mocked(fetchGitHubIssue).mockResolvedValue(createMockIssue());
   });
 
-  it('uses ADW classification when /classify_adw finds a command', async () => {
+  it('uses regex pre-check when issue body contains explicit ADW command', async () => {
+    vi.mocked(fetchGitHubIssue).mockResolvedValue(createMockIssue({
+      body: 'Please run /adw_plan_build_test on this',
+    }));
+
+    const result = await classifyIssueForTrigger(42);
+
+    expect(result.issueType).toBe('/feature');
+    expect(result.adwCommand).toBe('/adw_plan_build_test');
+    expect(result.success).toBe(true);
+    // Should NOT call the agent at all — regex matched deterministically
+    expect(runClaudeAgentWithCommand).not.toHaveBeenCalled();
+  });
+
+  it('uses ADW classification when /classify_adw finds a command (no regex match)', async () => {
+    vi.mocked(fetchGitHubIssue).mockResolvedValue(createMockIssue({
+      body: 'No explicit command here',
+    }));
     vi.mocked(runClaudeAgentWithCommand).mockResolvedValueOnce({
       output: '{"adwSlashCommand": "/adw_plan_build_test"}',
       success: true,
@@ -233,7 +334,6 @@ describe('classifyIssueForTrigger', () => {
     expect(result.issueType).toBe('/feature');
     expect(result.adwCommand).toBe('/adw_plan_build_test');
     expect(result.success).toBe(true);
-    // Should only call once (for /classify_adw), not twice
     expect(runClaudeAgentWithCommand).toHaveBeenCalledTimes(1);
     expect(log).toHaveBeenCalledWith(
       expect.stringContaining('Attempting ADW classification')
@@ -241,6 +341,9 @@ describe('classifyIssueForTrigger', () => {
   });
 
   it('falls back to /classify_issue when /classify_adw returns empty', async () => {
+    vi.mocked(fetchGitHubIssue).mockResolvedValue(createMockIssue({
+      body: 'No explicit command here',
+    }));
     vi.mocked(runClaudeAgentWithCommand)
       .mockResolvedValueOnce({ output: '{}', success: true })
       .mockResolvedValueOnce({ output: '/bug', success: true });
@@ -260,6 +363,9 @@ describe('classifyIssueForTrigger', () => {
   });
 
   it('defaults to /feature when both classifiers fail', async () => {
+    vi.mocked(fetchGitHubIssue).mockResolvedValue(createMockIssue({
+      body: 'No explicit command here',
+    }));
     vi.mocked(runClaudeAgentWithCommand)
       .mockResolvedValueOnce({ output: '{}', success: true })
       .mockResolvedValueOnce({ output: 'unknown output', success: true });
@@ -289,13 +395,27 @@ describe('classifyGitHubIssue', () => {
     vi.clearAllMocks();
   });
 
-  it('uses ADW classification when /classify_adw finds a command', async () => {
+  it('uses regex pre-check when issue body contains explicit ADW command', async () => {
+    const result = await classifyGitHubIssue(createMockIssue({
+      body: 'Run /adw_patch to fix this',
+    }));
+
+    expect(result.issueType).toBe('/bug');
+    expect(result.adwCommand).toBe('/adw_patch');
+    expect(result.success).toBe(true);
+    // Should NOT call the agent at all
+    expect(runClaudeAgentWithCommand).not.toHaveBeenCalled();
+  });
+
+  it('uses ADW classification when /classify_adw finds a command (no regex match)', async () => {
     vi.mocked(runClaudeAgentWithCommand).mockResolvedValueOnce({
       output: '{"adwSlashCommand": "/adw_patch"}',
       success: true,
     });
 
-    const result = await classifyGitHubIssue(createMockIssue());
+    const result = await classifyGitHubIssue(createMockIssue({
+      body: 'No explicit command here',
+    }));
 
     expect(result.issueType).toBe('/bug');
     expect(result.adwCommand).toBe('/adw_patch');
@@ -311,7 +431,9 @@ describe('classifyGitHubIssue', () => {
       .mockResolvedValueOnce({ output: '{}', success: true })
       .mockResolvedValueOnce({ output: '/chore', success: true });
 
-    const result = await classifyGitHubIssue(createMockIssue());
+    const result = await classifyGitHubIssue(createMockIssue({
+      body: 'No explicit command here',
+    }));
 
     expect(result.issueType).toBe('/chore');
     expect(result.adwCommand).toBeUndefined();
@@ -330,7 +452,9 @@ describe('classifyGitHubIssue', () => {
       .mockResolvedValueOnce({ output: '{}', success: true })
       .mockResolvedValueOnce({ output: '', success: false });
 
-    const result = await classifyGitHubIssue(createMockIssue());
+    const result = await classifyGitHubIssue(createMockIssue({
+      body: 'No explicit command here',
+    }));
 
     expect(result.issueType).toBe('/feature');
     expect(result.success).toBe(false);
@@ -342,6 +466,7 @@ describe('classifyGitHubIssue', () => {
       .mockResolvedValueOnce({ output: '/feature', success: true });
 
     const issue = createMockIssue({
+      body: 'No explicit command here',
       labels: [{ id: '1', name: 'enhancement', color: '00ff00' }],
     });
 

--- a/adws/__tests__/worktreeOperations.test.ts
+++ b/adws/__tests__/worktreeOperations.test.ts
@@ -169,6 +169,43 @@ branch refs/heads/main
     const result = listWorktrees();
     expect(result).toEqual([]);
   });
+
+  it('passes cwd to execSync when provided', () => {
+    const worktreeListOutput = `worktree /target/repo
+HEAD abc123
+branch refs/heads/main
+
+worktree /target/repo/.worktrees/feature-issue-10-fix
+HEAD def456
+branch refs/heads/feature/issue-10-fix
+
+`;
+    vi.mocked(execSync).mockReturnValue(worktreeListOutput);
+
+    const result = listWorktrees('/target/repo');
+
+    expect(result).toEqual(['/target/repo/.worktrees/feature-issue-10-fix']);
+    expect(execSync).toHaveBeenCalledWith(
+      'git worktree list --porcelain',
+      expect.objectContaining({ cwd: '/target/repo' })
+    );
+  });
+
+  it('does not pass cwd to execSync when omitted', () => {
+    const worktreeListOutput = `worktree /mock/project
+HEAD abc123
+branch refs/heads/main
+
+`;
+    vi.mocked(execSync).mockReturnValue(worktreeListOutput);
+
+    listWorktrees();
+
+    expect(execSync).toHaveBeenCalledWith(
+      'git worktree list --porcelain',
+      expect.objectContaining({ cwd: undefined })
+    );
+  });
 });
 
 describe('createWorktree', () => {
@@ -1766,5 +1803,74 @@ branch refs/heads/feature/issue-99-other
     expect(result).toBe(1);
     expect(deleteLocalBranch).toHaveBeenCalledWith('feature/issue-42-add-login');
     expect(deleteLocalBranch).not.toHaveBeenCalledWith('feature/issue-99-other');
+  });
+
+  it('passes cwd to all internal execSync calls when provided', () => {
+    const worktreeListOutput = `worktree /target/repo
+HEAD abc123
+branch refs/heads/main
+
+worktree /target/repo/.worktrees/feature-issue-42-add-login
+HEAD def456
+branch refs/heads/feature/issue-42-add-login
+
+`;
+    vi.mocked(execSync).mockImplementation((cmd) => {
+      const cmdStr = String(cmd);
+      if (cmdStr.includes('git worktree list')) {
+        return worktreeListOutput;
+      }
+      if (cmdStr.includes('lsof')) {
+        throw new Error('no processes');
+      }
+      return '';
+    });
+
+    const targetCwd = '/target/repo';
+    const result = removeWorktreesForIssue(42, targetCwd);
+
+    expect(result).toBe(1);
+
+    // Verify that git worktree list calls received cwd
+    const listCalls = vi.mocked(execSync).mock.calls.filter((call) =>
+      String(call[0]).includes('git worktree list')
+    );
+    listCalls.forEach((call) => {
+      expect(call[1]).toEqual(expect.objectContaining({ cwd: targetCwd }));
+    });
+
+    // Verify that git worktree remove received cwd
+    const removeCalls = vi.mocked(execSync).mock.calls.filter((call) =>
+      String(call[0]).includes('git worktree remove')
+    );
+    removeCalls.forEach((call) => {
+      expect(call[1]).toEqual(expect.objectContaining({ cwd: targetCwd }));
+    });
+
+    // Verify that git worktree prune received cwd
+    const pruneCalls = vi.mocked(execSync).mock.calls.filter((call) =>
+      String(call[0]).includes('git worktree prune')
+    );
+    pruneCalls.forEach((call) => {
+      expect(call[1]).toEqual(expect.objectContaining({ cwd: targetCwd }));
+    });
+  });
+
+  it('does not pass cwd when omitted (existing behavior)', () => {
+    const worktreeListOutput = `worktree /mock/project
+HEAD abc123
+branch refs/heads/main
+
+`;
+    vi.mocked(execSync).mockReturnValue(worktreeListOutput);
+
+    removeWorktreesForIssue(42);
+
+    const listCalls = vi.mocked(execSync).mock.calls.filter((call) =>
+      String(call[0]).includes('git worktree list')
+    );
+    listCalls.forEach((call) => {
+      expect(call[1]).toEqual(expect.objectContaining({ cwd: undefined }));
+    });
   });
 });

--- a/adws/agents/claudeAgent.ts
+++ b/adws/agents/claudeAgent.ts
@@ -151,6 +151,9 @@ function handleAgentProcess(
           statePath
         });
       } else if (code === 0) {
+        if (state.turnCount === 0) {
+          log(`${agentName}: Agent exited successfully but produced no output (0 turns). The slash command may not be available in the working directory.`, 'warn');
+        }
         resolve({
           success: true,
           output: state.fullOutput,

--- a/adws/core/issueClassifier.ts
+++ b/adws/core/issueClassifier.ts
@@ -22,6 +22,28 @@ import {
 import { extractJson } from './jsonParser';
 
 /**
+ * Extracts an explicit ADW slash command from text using deterministic regex matching.
+ * Scans for `/adw_*` patterns and validates against known commands.
+ * Commands are matched longest-first to avoid partial matches (e.g., `/adw_plan_build_test` before `/adw_plan`).
+ *
+ * @param text - The text to scan for ADW commands
+ * @returns The matched AdwSlashCommand or null if none found
+ */
+export function extractAdwCommandFromText(text: string): AdwSlashCommand | null {
+  if (!text) return null;
+
+  const validCommands = Object.keys(adwCommandToIssueTypeMap) as AdwSlashCommand[];
+  const sortedByLength = [...validCommands].sort((a, b) => b.length - a.length);
+
+  const found = sortedByLength.find((cmd) => {
+    const pattern = new RegExp(`${cmd.replace('/', '\\/')}\\b`);
+    return pattern.test(text);
+  });
+
+  return found ?? null;
+}
+
+/**
  * Result of classifying an issue for trigger purposes.
  */
 export interface IssueClassificationResult {
@@ -83,6 +105,18 @@ export async function classifyWithAdwCommand(
   outputFile: string,
   issueBody?: string,
 ): Promise<IssueClassificationResult | null> {
+  // Deterministic regex pre-check: extract explicit /adw_* commands before calling the AI agent
+  const regexMatch = extractAdwCommandFromText(issueBody ?? issueContext);
+  if (regexMatch) {
+    const issueType = adwCommandToIssueTypeMap[regexMatch];
+    log(`Issue #${issueNumber} matched ADW command ${regexMatch} via regex pre-check`, 'success');
+    return {
+      issueType,
+      success: true,
+      adwCommand: regexMatch,
+    };
+  }
+
   try {
     const result = await runClaudeAgentWithCommand(
       '/classify_adw',

--- a/adws/github/worktreeCleanup.ts
+++ b/adws/github/worktreeCleanup.ts
@@ -105,9 +105,11 @@ export function removeWorktree(branchName: string): boolean {
 /**
  * Parses `git worktree list --porcelain` output to extract path-to-branch mappings.
  * Only includes worktrees under `.worktrees/`.
+ *
+ * @param cwd - Optional working directory for the git command (for external target repos)
  */
-function parseWorktreeBranches(): Map<string, string> {
-  const output = execSync('git worktree list --porcelain', { encoding: 'utf-8' });
+function parseWorktreeBranches(cwd?: string): Map<string, string> {
+  const output = execSync('git worktree list --porcelain', { encoding: 'utf-8', cwd });
   const lines = output.split('\n');
   const result = new Map<string, string>();
 
@@ -127,8 +129,15 @@ function parseWorktreeBranches(): Map<string, string> {
   return result;
 }
 
-export function removeWorktreesForIssue(issueNumber: number): number {
-  const worktrees = listWorktrees();
+/**
+ * Removes all worktrees matching the given issue number.
+ *
+ * @param issueNumber - The GitHub issue number whose worktrees should be removed
+ * @param cwd - Optional working directory for git commands (for external target repos)
+ * @returns The number of worktrees successfully removed
+ */
+export function removeWorktreesForIssue(issueNumber: number, cwd?: string): number {
+  const worktrees = listWorktrees(cwd);
   const pattern = new RegExp(`-issue-${issueNumber}-`);
   const matching = worktrees.filter((wtPath) => pattern.test(path.basename(wtPath)));
 
@@ -139,7 +148,7 @@ export function removeWorktreesForIssue(issueNumber: number): number {
 
   log(`Found ${matching.length} worktree(s) matching issue #${issueNumber}`, 'info');
 
-  const worktreeBranches = parseWorktreeBranches();
+  const worktreeBranches = parseWorktreeBranches(cwd);
   let removedCount = 0;
 
   matching.forEach((wtPath) => {
@@ -148,7 +157,7 @@ export function removeWorktreesForIssue(issueNumber: number): number {
 
     try {
       log(`Removing worktree at ${wtPath}`, 'info');
-      execSync(`git worktree remove "${wtPath}" --force`, { stdio: 'pipe' });
+      execSync(`git worktree remove "${wtPath}" --force`, { stdio: 'pipe', cwd });
       log(`Removed worktree at ${wtPath}`, 'success');
       if (branchName) {
         deleteLocalBranch(branchName);
@@ -173,7 +182,7 @@ export function removeWorktreesForIssue(issueNumber: number): number {
   });
 
   try {
-    execSync('git worktree prune', { stdio: 'pipe' });
+    execSync('git worktree prune', { stdio: 'pipe', cwd });
   } catch (pruneError) {
     log(`Failed to prune worktrees: ${pruneError}`, 'error');
   }

--- a/adws/github/worktreeOperations.ts
+++ b/adws/github/worktreeOperations.ts
@@ -238,11 +238,12 @@ export function worktreeExists(branchName: string): boolean {
 /**
  * Lists all existing worktrees.
  *
+ * @param cwd - Optional working directory for the git command (for external target repos)
  * @returns Array of worktree paths
  */
-export function listWorktrees(): string[] {
+export function listWorktrees(cwd?: string): string[] {
   try {
-    const output = execSync('git worktree list --porcelain', { encoding: 'utf-8' });
+    const output = execSync('git worktree list --porcelain', { encoding: 'utf-8', cwd });
     const worktrees: string[] = [];
     const lines = output.split('\n');
 

--- a/adws/phases/workflowLifecycle.ts
+++ b/adws/phases/workflowLifecycle.ts
@@ -2,10 +2,46 @@
  * Workflow initialization, completion, error handling, and review phase.
  */
 
+import * as fs from 'fs';
+import * as path from 'path';
 import { log, setLogAdwId, ensureLogsDirectory, generateAdwId, type IssueClassSlashCommand, type GitHubIssue, AgentStateManager, type AgentState, type AgentIdentifier, type RecoveryState, hasUncommittedChanges, getNextStage, MAX_REVIEW_RETRY_ATTEMPTS, COST_REPORT_CURRENCIES, type ModelUsageMap, buildCostBreakdown, persistTokenCounts, allocateRandomPort, type TargetRepoInfo, ensureTargetRepoWorkspace, writeIssueCostCsv, updateProjectCostCsv, type ProjectConfig, loadProjectConfig } from '../core';
 import { fetchGitHubIssue, postWorkflowComment, type WorkflowContext, detectRecoveryState, getDefaultBranch, checkoutDefaultBranch, ensureWorktree, getWorktreeForBranch, mergeLatestFromDefaultBranch, copyEnvToWorktree, findWorktreeForIssue, type RepoInfo } from '../github';
 import { runGenerateBranchNameAgent, getPlanFilePath, runReviewWithRetry } from '../agents';
 import { classifyGitHubIssue } from '../core/issueClassifier';
+
+/**
+ * Copies the ADW repo's `.claude/commands/` directory to a target repo worktree.
+ * Only copies `.md` files that don't already exist in the destination,
+ * preserving the target repo's own commands.
+ *
+ * @param worktreePath - The absolute path to the target repo worktree
+ */
+function copyClaudeCommandsToWorktree(worktreePath: string): void {
+  const adwRepoRoot = path.resolve(__dirname, '../../');
+  const sourceDir = path.join(adwRepoRoot, '.claude', 'commands');
+  const destDir = path.join(worktreePath, '.claude', 'commands');
+
+  if (!fs.existsSync(sourceDir)) {
+    log(`No .claude/commands/ found in ADW repo at ${sourceDir}, skipping copy`, 'info');
+    return;
+  }
+
+  fs.mkdirSync(destDir, { recursive: true });
+
+  const sourceFiles = fs.readdirSync(sourceDir).filter((file) => file.endsWith('.md'));
+  const copiedFiles = sourceFiles.filter((file) => {
+    const destPath = path.join(destDir, file);
+    if (fs.existsSync(destPath)) return false;
+    fs.copyFileSync(path.join(sourceDir, file), destPath);
+    return true;
+  });
+
+  if (copiedFiles.length > 0) {
+    log(`Copied ${copiedFiles.length} slash command(s) to worktree: ${copiedFiles.join(', ')}`, 'info');
+  } else {
+    log('No new slash commands to copy (all already exist in target)', 'info');
+  }
+}
 
 /**
  * Configuration shared across all workflow phase functions.
@@ -121,6 +157,7 @@ export async function initializeWorkflow(
 
     // Create worktree within the target repo workspace
     worktreePath = ensureWorktree(branchName, defaultBranch, targetRepoWorkspacePath);
+    copyClaudeCommandsToWorktree(worktreePath);
     log(`Worktree path (target repo): ${worktreePath}`, 'info');
   } else {
     // Try to find an existing worktree by issue type and number first

--- a/adws/phases/workflowLifecycle.ts
+++ b/adws/phases/workflowLifecycle.ts
@@ -10,6 +10,34 @@ import { runGenerateBranchNameAgent, getPlanFilePath, runReviewWithRetry } from 
 import { classifyGitHubIssue } from '../core/issueClassifier';
 
 /**
+ * Ensures a given entry exists in the `.gitignore` file at the specified directory.
+ * Creates the `.gitignore` file if it doesn't exist. Idempotent — safe to call
+ * multiple times without duplicating the entry.
+ *
+ * @param worktreePath - The absolute path to the directory containing `.gitignore`
+ * @param entry - The gitignore pattern to ensure is present (e.g., `.claude/commands/`)
+ */
+export function ensureGitignoreEntry(worktreePath: string, entry: string): void {
+  const gitignorePath = path.join(worktreePath, '.gitignore');
+  const existing = fs.existsSync(gitignorePath)
+    ? fs.readFileSync(gitignorePath, 'utf-8')
+    : '';
+
+  const lines = existing.split('\n').map((line) => line.trim());
+  if (lines.includes(entry.trim())) {
+    log(`Gitignore already contains '${entry}', skipping`, 'info');
+    return;
+  }
+
+  const comment = '# ADW: copied slash commands (do not commit)';
+  const suffix = existing.length > 0 && !existing.endsWith('\n') ? '\n' : '';
+  const appendContent = `${suffix}${comment}\n${entry}\n`;
+
+  fs.writeFileSync(gitignorePath, existing + appendContent, 'utf-8');
+  log(`Added '${entry}' to ${gitignorePath}`, 'info');
+}
+
+/**
  * Copies the ADW repo's `.claude/commands/` directory to a target repo worktree.
  * Only copies `.md` files that don't already exist in the destination,
  * preserving the target repo's own commands.
@@ -41,6 +69,8 @@ function copyClaudeCommandsToWorktree(worktreePath: string): void {
   } else {
     log('No new slash commands to copy (all already exist in target)', 'info');
   }
+
+  ensureGitignoreEntry(worktreePath, '.claude/commands/');
 }
 
 /**

--- a/adws/phases/workflowLifecycle.ts
+++ b/adws/phases/workflowLifecycle.ts
@@ -15,7 +15,7 @@ import { classifyGitHubIssue } from '../core/issueClassifier';
  * multiple times without duplicating the entry.
  *
  * @param worktreePath - The absolute path to the directory containing `.gitignore`
- * @param entry - The gitignore pattern to ensure is present (e.g., `.claude/commands/`)
+ * @param entry - The gitignore pattern to ensure is present (e.g., `.claude/commands/bug.md`)
  */
 export function ensureGitignoreEntry(worktreePath: string, entry: string): void {
   const gitignorePath = path.join(worktreePath, '.gitignore');
@@ -30,11 +30,46 @@ export function ensureGitignoreEntry(worktreePath: string, entry: string): void 
   }
 
   const comment = '# ADW: copied slash commands (do not commit)';
+  const hasComment = lines.includes(comment);
   const suffix = existing.length > 0 && !existing.endsWith('\n') ? '\n' : '';
-  const appendContent = `${suffix}${comment}\n${entry}\n`;
+  const appendContent = hasComment
+    ? `${suffix}${entry}\n`
+    : `${suffix}${comment}\n${entry}\n`;
 
   fs.writeFileSync(gitignorePath, existing + appendContent, 'utf-8');
   log(`Added '${entry}' to ${gitignorePath}`, 'info');
+}
+
+/**
+ * Ensures multiple entries exist in the `.gitignore` file at the specified directory.
+ * Writes all new entries in a single file operation with one comment header,
+ * avoiding duplicate comments from calling `ensureGitignoreEntry` in a loop.
+ *
+ * @param worktreePath - The absolute path to the directory containing `.gitignore`
+ * @param entries - The gitignore patterns to ensure are present
+ */
+export function ensureGitignoreEntries(worktreePath: string, entries: readonly string[]): void {
+  if (entries.length === 0) return;
+
+  const gitignorePath = path.join(worktreePath, '.gitignore');
+  const existing = fs.existsSync(gitignorePath)
+    ? fs.readFileSync(gitignorePath, 'utf-8')
+    : '';
+
+  const existingLines = existing.split('\n').map((line) => line.trim());
+  const newEntries = entries.filter((entry) => !existingLines.includes(entry.trim()));
+
+  if (newEntries.length === 0) {
+    log('All gitignore entries already present, skipping', 'info');
+    return;
+  }
+
+  const comment = '# ADW: copied slash commands (do not commit)';
+  const suffix = existing.length > 0 && !existing.endsWith('\n') ? '\n' : '';
+  const appendContent = `${suffix}${comment}\n${newEntries.join('\n')}\n`;
+
+  fs.writeFileSync(gitignorePath, existing + appendContent, 'utf-8');
+  log(`Added ${newEntries.length} gitignore entr${newEntries.length === 1 ? 'y' : 'ies'} to ${gitignorePath}`, 'info');
 }
 
 /**
@@ -70,7 +105,10 @@ function copyClaudeCommandsToWorktree(worktreePath: string): void {
     log('No new slash commands to copy (all already exist in target)', 'info');
   }
 
-  ensureGitignoreEntry(worktreePath, '.claude/commands/');
+  if (copiedFiles.length > 0) {
+    const gitignoreEntries = copiedFiles.map((file) => `.claude/commands/${file}`);
+    ensureGitignoreEntries(worktreePath, gitignoreEntries);
+  }
 }
 
 /**

--- a/adws/triggers/trigger_webhook.ts
+++ b/adws/triggers/trigger_webhook.ts
@@ -10,7 +10,7 @@
 
 import * as http from 'http';
 import { spawn } from 'child_process';
-import { log, PullRequestWebhookPayload, allocateRandomPort, isPortAvailable } from '../core';
+import { log, PullRequestWebhookPayload, allocateRandomPort, isPortAvailable, getTargetRepoWorkspacePath } from '../core';
 import { isActionableComment, isAdwRunningForIssue, truncateText } from '../github';
 import { removeWorktreesForIssue } from '../github/worktreeOperations';
 import { classifyIssueForTrigger, getWorkflowScript } from '../core/issueClassifier';
@@ -262,7 +262,13 @@ const server = http.createServer((req, res) => {
 
     if (action === 'closed') {
       log(`Issue #${issueNumber} closed, removing associated worktrees`);
-      const removed = removeWorktreesForIssue(issueNumber);
+      const closedTargetRepoArgs = extractTargetRepoArgs(body);
+      const closedTargetRepoFullName = closedTargetRepoArgs.length >= 2 ? closedTargetRepoArgs[1] : undefined;
+      const closedRepoParts = closedTargetRepoFullName?.split('/');
+      const closedRepoCwd = closedRepoParts && closedRepoParts.length === 2
+        ? getTargetRepoWorkspacePath(closedRepoParts[0], closedRepoParts[1])
+        : undefined;
+      const removed = removeWorktreesForIssue(issueNumber, closedRepoCwd);
       log(`Removed ${removed} worktree(s) for issue #${issueNumber}`, 'success');
       jsonResponse(res, 200, { status: 'worktrees_cleaned', issue: issueNumber, removed });
       return;

--- a/specs/issue-23-adw-multiple-problems-wi-pkdnfi-sdlc_planner-fix-adw-classifier-and-plan.md
+++ b/specs/issue-23-adw-multiple-problems-wi-pkdnfi-sdlc_planner-fix-adw-classifier-and-plan.md
@@ -1,0 +1,192 @@
+# Bug: ADW classifier, plan agent, and worktree cleanup fail on external target repos
+
+## Metadata
+issueNumber: `23`
+adwId: `multiple-problems-wi-pkdnfi`
+issueJson: `{"number":23,"title":"Multiple problems with the ADW","body":"There are several problems with the adw - especially when running on a different target repo.","state":"OPEN","author":"paysdoc","labels":[],"createdAt":"2026-02-26T06:40:33Z","comments":[],"actionableComment":null}`
+
+## Bug Description
+When the ADW system runs against an external target repository (e.g., `vestmatic/vestmatic`), three cascading failures occur:
+
+1. **Classifier fails to recognize `/adw_init`**: The `/classify_adw` agent (running haiku) returns no valid ADW command. This causes a fallback to `/classify_issue`, which classifies the issue as `/chore` instead of routing to the `/adw_init` workflow. The log shows: `ADW classifier returned no valid command for issue #6`.
+
+2. **Plan agent produces no output**: The plan agent runs in the target repo's worktree CWD but the `.claude/commands/` slash commands (e.g., `/chore`, `/commit`) exist only in the ADW repo. The Claude CLI can't find the command templates, so it exits with 0 turns/0 tool calls. The plan file is never created, leading to: `Cannot read plan file at .../specs/issue-6-plan.md: ENOENT`. The commit agent also fails with `Unknown skill: commit`.
+
+3. **Worktree cleanup operates on wrong repo**: When an issue is closed, the webhook handler calls `removeWorktreesForIssue(issueNumber)` without passing the target repo path. The `listWorktrees()` function runs `git worktree list` in the ADW repo's CWD, finding no matching worktrees. The target repo's worktrees are never cleaned up.
+
+## Problem Statement
+The ADW system cannot operate on external target repositories because:
+- The classifier relies on an unreliable haiku model to extract explicit command strings that could be matched deterministically
+- Slash commands are resolved from `CWD/.claude/commands/` but are only present in the ADW repo, not the target repo
+- Worktree cleanup doesn't account for the target repo context during issue close events
+
+## Solution Statement
+Fix all three issues with minimal, surgical changes:
+
+1. **Classifier**: Add a deterministic regex pre-check in `issueClassifier.ts` that scans the issue body for explicit `/adw_*` patterns before invoking the haiku agent. When a match is found, return immediately without calling the AI classifier.
+
+2. **Plan agent / slash commands**: Copy the ADW repo's `.claude/commands/` directory to the target repo worktree during worktree setup in `workflowLifecycle.ts`. This ensures all slash commands are available when agents run in the target repo CWD.
+
+3. **Worktree cleanup**: Modify the webhook issue close handler in `trigger_webhook.ts` to extract the target repo path from the webhook payload and pass it to `removeWorktreesForIssue`. Update `removeWorktreesForIssue`, `listWorktrees`, and `parseWorktreeBranches` in `worktreeCleanup.ts` to accept an optional `cwd` parameter.
+
+## Steps to Reproduce
+1. Create a new GitHub issue in an external target repository (e.g., `vestmatic/vestmatic`) with the body containing `/adw_init`
+2. The ADW webhook trigger receives the issue event and spawns the classification pipeline
+3. The `/classify_adw` haiku agent fails to return a valid JSON command → falls back to `/classify_issue` → classifies as `/chore`
+4. The `/chore` orchestrator spawns the plan agent in the target repo worktree
+5. The plan agent can't find `.claude/commands/chore.md` in the target repo → exits with 0 turns → plan file never created
+6. The orchestrator tries to read the plan file → ENOENT error
+7. When the issue is closed, worktree cleanup runs against the ADW repo instead of the target repo
+
+## Root Cause Analysis
+
+### Bug 1: Classifier
+- `classifyWithAdwCommand()` in `issueClassifier.ts:80-118` invokes the `/classify_adw` haiku agent to extract ADW commands from issue text as JSON
+- Haiku is unreliable at outputting structured JSON — it produced 2 turns but no parseable command
+- There is no deterministic pre-check: even when the issue body contains an explicit `/adw_init` string, the system relies entirely on the AI model to extract it
+- The `parseAdwClassificationOutput()` function at line 41-68 correctly validates the JSON but never receives valid input
+
+### Bug 2: Plan not found
+- `runPlanAgent()` in `planAgent.ts:200-234` calls `runClaudeAgentWithCommand(issueType, args, ...)` with `cwd` set to the target repo worktree
+- `runClaudeAgentWithCommand()` in `claudeAgent.ts:288-348` spawns the Claude CLI with `cwd: cwd || process.cwd()`
+- The Claude CLI resolves slash commands from `<cwd>/.claude/commands/<command>.md`
+- When CWD is the target repo worktree, `.claude/commands/chore.md` doesn't exist → CLI returns without executing → 0 turns, 0 tool calls, exit code 0
+- `handleAgentProcess()` at line 153 returns `success: true` for exit code 0 with no `lastResult`, masking the failure
+- The orchestrator proceeds to read the plan file that was never created → ENOENT
+
+### Bug 3: Worktree cleanup on wrong repo
+- `trigger_webhook.ts:263-268` handles issue close events by calling `removeWorktreesForIssue(issueNumber)` with no repo context
+- Unlike the `issue_comment` handler (line 197) and `issues.opened` handler (line 276) which call `extractTargetRepoArgs(body)`, the `issues.closed` handler does NOT extract target repo info
+- `listWorktrees()` in `worktreeOperations.ts:243-264` runs `git worktree list --porcelain` without a `cwd` parameter, defaulting to the ADW repo
+- The target repo's worktrees are at a different path and are never found
+
+## Relevant Files
+Use these files to fix the bug:
+
+- `adws/core/issueClassifier.ts` — Contains `classifyWithAdwCommand()` and `classifyIssueForTrigger()`. Needs regex pre-check for deterministic ADW command matching before calling the haiku agent.
+- `adws/core/issueTypes.ts` — Contains `AdwSlashCommand` type and `adwCommandToIssueTypeMap`. Needed to build the regex pattern from valid commands.
+- `adws/phases/workflowLifecycle.ts` — Contains `initializeWorkflow()` which sets up the worktree. Needs to copy `.claude/commands/` to the target repo worktree.
+- `adws/triggers/trigger_webhook.ts` — Contains the issue close handler. Needs to extract target repo info and pass it to worktree cleanup.
+- `adws/github/worktreeCleanup.ts` — Contains `removeWorktreesForIssue()` and `parseWorktreeBranches()`. Needs optional `cwd` parameter.
+- `adws/github/worktreeOperations.ts` — Contains `listWorktrees()`. Needs optional `cwd` parameter.
+- `adws/agents/claudeAgent.ts` — Contains `handleAgentProcess()`. Needs to detect and warn on 0-turn agent completions (defensive improvement).
+- `adws/__tests__/issueClassifier.test.ts` — Existing classifier tests. Needs new tests for regex pre-check.
+- `adws/__tests__/worktreeOperations.test.ts` — Existing worktree tests. Needs new tests for `cwd` parameter support.
+- `adws/core/targetRepoManager.ts` — Contains `getTargetRepoWorkspacePath()` for resolving target repo paths. Referenced for worktree cleanup path resolution.
+- `guidelines/coding_guidelines.md` — Coding guidelines to follow.
+- `adws/README.md` — ADW system documentation for context.
+
+## Step by Step Tasks
+IMPORTANT: Execute every step in order, top to bottom.
+
+### 1. Add deterministic regex pre-check for ADW commands in the classifier
+
+In `adws/core/issueClassifier.ts`:
+
+- Add a new function `extractAdwCommandFromText(text: string): AdwSlashCommand | null` that:
+  - Imports the `adwCommandToIssueTypeMap` keys to build the list of valid commands
+  - Sorts them by length descending (so `/adw_plan_build_test_review` matches before `/adw_plan`)
+  - Uses a regex to find the first `/adw_*` command in the text (match whole word: `/adw_init\b`)
+  - Returns the matched command if it exists in `adwCommandToIssueTypeMap`, else `null`
+
+- Modify `classifyWithAdwCommand()` to call `extractAdwCommandFromText()` on the issue body (passed via a new optional `issueBody` parameter or extracted from the `issueContext` argument) BEFORE running the haiku agent
+  - If a command is found deterministically, return the classification result immediately without calling the agent
+  - Log the deterministic match: `Issue #${issueNumber} matched ADW command ${command} via regex pre-check`
+
+- Modify `classifyIssueForTrigger()` and `classifyGitHubIssue()` to pass the issue body to `classifyWithAdwCommand()`
+
+### 2. Copy `.claude/commands/` to target repo worktrees
+
+In `adws/phases/workflowLifecycle.ts`:
+
+- Add a new function `copyClaudeCommandsToWorktree(worktreePath: string): void` that:
+  - Determines the ADW repo root path (use `path.resolve(__dirname, '../../')` since `workflowLifecycle.ts` is in `adws/phases/`)
+  - Checks if `<adwRepoRoot>/.claude/commands/` exists
+  - Creates `<worktreePath>/.claude/commands/` directory (recursive)
+  - Copies all `.md` files from the ADW repo's `.claude/commands/` to the worktree's `.claude/commands/`
+  - Only copies files that don't already exist in the destination (don't overwrite target repo's own commands)
+  - Logs the copy operation
+
+- Call `copyClaudeCommandsToWorktree(worktreePath)` in `initializeWorkflow()` after the worktree is created/resolved, specifically in the `targetRepoWorkspacePath` branch (around line 123-124), right after `ensureWorktree()` and before the workflow context is initialized
+
+### 3. Fix worktree cleanup to operate on the correct repository
+
+In `adws/github/worktreeOperations.ts`:
+
+- Modify `listWorktrees(cwd?: string)` to accept an optional `cwd` parameter:
+  - Pass `{ encoding: 'utf-8', cwd }` to `execSync` when `cwd` is provided
+  - This ensures `git worktree list` runs in the correct repository context
+
+In `adws/github/worktreeCleanup.ts`:
+
+- Modify `parseWorktreeBranches(cwd?: string)` to accept an optional `cwd` parameter:
+  - Pass `{ encoding: 'utf-8', cwd }` to `execSync`
+
+- Modify `removeWorktreesForIssue(issueNumber: number, cwd?: string)` to accept an optional `cwd` parameter:
+  - Pass `cwd` to `listWorktrees(cwd)`
+  - Pass `cwd` to `parseWorktreeBranches(cwd)`
+  - Pass `{ stdio: 'pipe', cwd }` to `execSync` for `git worktree remove` and `git worktree prune` calls
+
+In `adws/triggers/trigger_webhook.ts`:
+
+- In the `action === 'closed'` block for issues (line 263):
+  - Call `extractTargetRepoArgs(body)` to get the target repo info
+  - Resolve the target repo workspace path using `getTargetRepoWorkspacePath()` from `targetRepoManager.ts` (parse `owner/repo` from the args)
+  - Pass the workspace path as `cwd` to `removeWorktreesForIssue(issueNumber, targetRepoWorkspacePath)`
+  - If no target repo args exist (same-repo issue), call without `cwd` (existing behavior)
+
+### 4. Add defensive logging for 0-turn agent completions
+
+In `adws/agents/claudeAgent.ts`:
+
+- In the `handleAgentProcess()` function, in the `else if (code === 0)` block (line 153):
+  - Add a warning log when `state.turnCount === 0`: `log(\`${agentName}: Agent exited successfully but produced no output (0 turns). The slash command may not be available in the working directory.\`, 'warn')`
+  - This doesn't change the return value (to avoid breaking existing behavior) but provides diagnostic information for debugging
+
+### 5. Add unit tests for the regex pre-check
+
+In `adws/__tests__/issueClassifier.test.ts`:
+
+- Add a new `describe('extractAdwCommandFromText')` block with tests:
+  - Returns `/adw_init` when text contains `/adw_init`
+  - Returns `/adw_plan_build_test` when text contains `/adw_plan_build_test` (not `/adw_plan`)
+  - Returns `/adw_sdlc` when command is embedded in prose
+  - Returns `null` when no ADW command is present
+  - Returns `null` for empty text
+  - Returns `null` for partial matches like `/adw_unknown`
+  - Returns the first match when multiple commands are present
+
+- Add a test for the deterministic pre-check path in `classifyWithAdwCommand`:
+  - When issue context contains an explicit `/adw_init`, the classification should return without calling `runClaudeAgentWithCommand`
+
+### 6. Add unit tests for `cwd` parameter support in worktree functions
+
+In `adws/__tests__/worktreeOperations.test.ts`:
+
+- Add tests for `listWorktrees(cwd)`:
+  - Passes `cwd` to `execSync` when provided
+  - Falls back to default behavior when `cwd` is omitted
+
+- Add tests for `removeWorktreesForIssue(issueNumber, cwd)`:
+  - Passes `cwd` to all internal `execSync` calls when provided
+
+### 7. Run validation commands
+
+Run all validation commands from the Validation Commands section below to ensure no regressions.
+
+## Validation Commands
+Execute every command to validate the bug is fixed with zero regressions.
+
+- `npm run lint` - Run linter to check for code quality issues
+- `npx tsc --noEmit` - Type check main project
+- `npx tsc --noEmit -p adws/tsconfig.json` - Type check adws directory
+- `npm test` - Run all tests to validate fixes with zero regressions
+- `npm run build` - Build the application to verify no build errors
+
+## Notes
+- IMPORTANT: Strictly adhere to the coding guidelines in `guidelines/coding_guidelines.md`. Key requirements: strict TypeScript (no `any`), functional style (map/filter/reduce over loops), immutability, pure functions, meaningful variable names.
+- The `/classify_adw` model is set to `haiku` in `adws/core/config.ts:137`. The regex pre-check makes the model choice irrelevant for explicit commands, so no model change is needed.
+- The `copyClaudeCommandsToWorktree` function should NOT copy `.claude/settings.json` or `.claude/hooks/` — only the `commands/` subdirectory. This prevents ADW-specific settings from interfering with the target repo.
+- When copying commands, existing files in the target repo's `.claude/commands/` should NOT be overwritten. The target repo's own commands take precedence.
+- The `claudeAgent.ts` defensive logging change is a non-breaking diagnostic improvement. It does not change the `success` return value to avoid cascading changes across all consumers.
+- For the worktree cleanup fix, when the webhook payload comes from the same repo as the ADW installation (no external target repo), the existing behavior (no `cwd`) is preserved.

--- a/specs/issue-23-plan.md
+++ b/specs/issue-23-plan.md
@@ -1,0 +1,77 @@
+# PR-Review: Ensure copied `.claude/commands/` are gitignored in target repo worktrees
+
+## PR-Review Description
+The PR reviewer (paysdoc) identified that `copyClaudeCommandsToWorktree()` in `adws/phases/workflowLifecycle.ts` copies the ADW repo's `.claude/commands/` directory to the target repo worktree, but there is no mechanism to prevent these files from being accidentally committed to the target repo. The reviewer notes that simply removing the commands after the job finishes is not viable because they are needed for subsequent phases (e.g., review comments, retry cycles). The reviewer suggests adding `.claude/commands/` to the target repo's `.gitignore` as a solution.
+
+The fix is to ensure `.claude/commands/` is added to the target repo worktree's `.gitignore` immediately after copying the command files. This way:
+- The command files remain available on disk for all workflow phases (plan, build, review, retry)
+- Git will not track or stage them, preventing accidental commits to the target repo
+- When the worktree is removed during cleanup, the files are deleted along with it
+
+## Summary of Original Implementation Plan
+The original plan at `specs/issue-23-adw-multiple-problems-wi-pkdnfi-sdlc_planner-fix-adw-classifier-and-plan.md` addresses three cascading failures when ADW runs against an external target repo:
+1. **Classifier fix**: Added deterministic regex pre-check for `/adw_*` patterns before invoking haiku AI classifier
+2. **Plan agent fix**: Copy ADW repo's `.claude/commands/` to target repo worktree during setup so slash commands are available
+3. **Worktree cleanup fix**: Accept optional `cwd` parameter in cleanup functions and pass target repo path from webhook handler
+
+The PR review is specifically about item #2 — the copied `.claude/commands/` files need to be gitignored so they don't leak into the target repo's git history.
+
+## Relevant Files
+Use these files to resolve the review:
+
+- `adws/phases/workflowLifecycle.ts` — Contains `copyClaudeCommandsToWorktree()` (lines 19-44) which copies `.claude/commands/` to the target repo worktree. This function needs to be extended to also add a `.gitignore` entry.
+- `adws/__tests__/worktreeOperations.test.ts` — Existing worktree tests. A new test should be added for the gitignore behavior.
+- `guidelines/coding_guidelines.md` — Coding guidelines to follow.
+
+## Step by Step Tasks
+IMPORTANT: Execute every step in order, top to bottom.
+
+### 1. Add a helper function to ensure `.gitignore` entry exists in the worktree
+
+In `adws/phases/workflowLifecycle.ts`:
+
+- Add a new function `ensureGitignoreEntry(worktreePath: string, entry: string): void` that:
+  - Reads the `.gitignore` file at `<worktreePath>/.gitignore` if it exists (or treats as empty string if it doesn't)
+  - Checks if the entry (`.claude/commands/`) already exists in the file (match line-by-line, trimmed)
+  - If not present, appends the entry to the file with a preceding newline (to avoid corrupting existing content) and a comment explaining why it's there (e.g., `# ADW: copied slash commands (do not commit)`)
+  - Creates the `.gitignore` file if it doesn't exist
+  - Logs the operation
+
+### 2. Call `ensureGitignoreEntry` from `copyClaudeCommandsToWorktree`
+
+In `adws/phases/workflowLifecycle.ts`:
+
+- At the end of `copyClaudeCommandsToWorktree()`, after copying the files, call `ensureGitignoreEntry(worktreePath, '.claude/commands/')` to ensure the copied commands are gitignored
+- This should be called regardless of whether any new files were copied (the `.gitignore` entry should always be present if we're operating on a target repo worktree)
+
+### 3. Add unit tests for the gitignore behavior
+
+In `adws/__tests__/worktreeOperations.test.ts` (or create a new focused test file if appropriate):
+
+- Add tests verifying that after `copyClaudeCommandsToWorktree` runs:
+  - `.claude/commands/` entry is appended to `.gitignore` when it doesn't exist
+  - `.claude/commands/` entry is NOT duplicated when it already exists in `.gitignore`
+  - `.gitignore` file is created if it doesn't already exist
+  - Existing `.gitignore` content is preserved
+
+Since `copyClaudeCommandsToWorktree` is a private function in `workflowLifecycle.ts`, test the exported `ensureGitignoreEntry` helper directly (export it for testing) or write an integration-style test that exercises the copy flow through `initializeWorkflow`. The simpler approach is to export `ensureGitignoreEntry` and test it directly.
+
+### 4. Run validation commands
+
+Run all validation commands to ensure no regressions.
+
+## Validation Commands
+Execute every command to validate the review is complete with zero regressions.
+
+- `npm run lint` - Run linter to check for code quality issues
+- `npx tsc --noEmit` - Type check main project
+- `npx tsc --noEmit -p adws/tsconfig.json` - Type check adws directory
+- `npm test` - Run all tests to validate the review is complete with zero regressions
+- `npm run build` - Build the application to verify no build errors
+
+## Notes
+- IMPORTANT: Strictly adhere to the coding guidelines in `guidelines/coding_guidelines.md`. Key requirements: strict TypeScript (no `any`), functional style, immutability, pure functions, meaningful variable names.
+- The `.gitignore` entry should be `.claude/commands/` (with trailing slash to match the directory pattern).
+- The `ensureGitignoreEntry` function should be idempotent — safe to call multiple times without duplicating the entry.
+- This approach is preferred over `.git/info/exclude` because `.git/info/exclude` behaves differently for worktrees and is less portable.
+- The `.gitignore` modification in the worktree is intentional and expected — it prevents the ADW command files from being tracked while keeping them available for all workflow phases.

--- a/specs/issue-23-plan.md
+++ b/specs/issue-23-plan.md
@@ -1,12 +1,13 @@
-# PR-Review: Ensure copied `.claude/commands/` are gitignored in target repo worktrees
+# PR-Review: Gitignore only specific copied commands, not the entire `.claude/commands/` directory
 
 ## PR-Review Description
-The PR reviewer (paysdoc) identified that `copyClaudeCommandsToWorktree()` in `adws/phases/workflowLifecycle.ts` copies the ADW repo's `.claude/commands/` directory to the target repo worktree, but there is no mechanism to prevent these files from being accidentally committed to the target repo. The reviewer notes that simply removing the commands after the job finishes is not viable because they are needed for subsequent phases (e.g., review comments, retry cycles). The reviewer suggests adding `.claude/commands/` to the target repo's `.gitignore` as a solution.
+Two related review comments from paysdoc on `adws/phases/workflowLifecycle.ts`:
 
-The fix is to ensure `.claude/commands/` is added to the target repo worktree's `.gitignore` immediately after copying the command files. This way:
-- The command files remain available on disk for all workflow phases (plan, build, review, retry)
-- Git will not track or stage them, preventing accidental commits to the target repo
-- When the worktree is removed during cleanup, the files are deleted along with it
+1. **Line 47** — There's no mechanism for removing the copied claude commands when the job is finished. The reviewer acknowledges this is tricky since commands are needed for review comments, and suggests adding lines to `.gitignore` as an option.
+
+2. **Line 73** — The `.gitignore` entry currently ignores the entire `.claude/commands/` directory. The reviewer wants only the **specific copied command files** to be gitignored, not the whole directory, because blanket-ignoring `.claude/commands/` could interfere with the target project's own claude commands.
+
+The current implementation calls `ensureGitignoreEntry(worktreePath, '.claude/commands/')` which adds a single directory-level ignore pattern. This must be changed to add individual file entries (e.g., `.claude/commands/bug.md`, `.claude/commands/feature.md`) — one per copied file — so that any commands the target project already owns remain tracked by git.
 
 ## Summary of Original Implementation Plan
 The original plan at `specs/issue-23-adw-multiple-problems-wi-pkdnfi-sdlc_planner-fix-adw-classifier-and-plan.md` addresses three cascading failures when ADW runs against an external target repo:
@@ -14,47 +15,64 @@ The original plan at `specs/issue-23-adw-multiple-problems-wi-pkdnfi-sdlc_planne
 2. **Plan agent fix**: Copy ADW repo's `.claude/commands/` to target repo worktree during setup so slash commands are available
 3. **Worktree cleanup fix**: Accept optional `cwd` parameter in cleanup functions and pass target repo path from webhook handler
 
-The PR review is specifically about item #2 — the copied `.claude/commands/` files need to be gitignored so they don't leak into the target repo's git history.
+The first PR-review iteration (commit `52ea4ed`) implemented `ensureGitignoreEntry()` and added `.claude/commands/` as a single directory-level entry. This second round refines that to use per-file entries.
 
 ## Relevant Files
 Use these files to resolve the review:
 
-- `adws/phases/workflowLifecycle.ts` — Contains `copyClaudeCommandsToWorktree()` (lines 19-44) which copies `.claude/commands/` to the target repo worktree. This function needs to be extended to also add a `.gitignore` entry.
-- `adws/__tests__/worktreeOperations.test.ts` — Existing worktree tests. A new test should be added for the gitignore behavior.
-- `guidelines/coding_guidelines.md` — Coding guidelines to follow.
+- `adws/phases/workflowLifecycle.ts` — Contains `ensureGitignoreEntry()` (lines 20-38) and `copyClaudeCommandsToWorktree()` (lines 47-74). The `copyClaudeCommandsToWorktree` function must be modified to pass only the specific copied file paths to the gitignore helper instead of the whole directory. A new bulk helper `ensureGitignoreEntries()` should be added to handle multiple entries efficiently with a single comment header.
+- `adws/__tests__/ensureGitignoreEntry.test.ts` — Existing tests for `ensureGitignoreEntry()`. New tests must be added for the bulk `ensureGitignoreEntries()` function, and existing tests should be updated to use per-file entry examples.
+- `guidelines/coding_guidelines.md` — Coding guidelines to follow (functional style, immutability, strict TypeScript, etc.).
 
 ## Step by Step Tasks
 IMPORTANT: Execute every step in order, top to bottom.
 
-### 1. Add a helper function to ensure `.gitignore` entry exists in the worktree
+### 1. Add a bulk `ensureGitignoreEntries` helper function
 
 In `adws/phases/workflowLifecycle.ts`:
 
-- Add a new function `ensureGitignoreEntry(worktreePath: string, entry: string): void` that:
-  - Reads the `.gitignore` file at `<worktreePath>/.gitignore` if it exists (or treats as empty string if it doesn't)
-  - Checks if the entry (`.claude/commands/`) already exists in the file (match line-by-line, trimmed)
-  - If not present, appends the entry to the file with a preceding newline (to avoid corrupting existing content) and a comment explaining why it's there (e.g., `# ADW: copied slash commands (do not commit)`)
-  - Creates the `.gitignore` file if it doesn't exist
-  - Logs the operation
+- Add a new exported function `ensureGitignoreEntries(worktreePath: string, entries: string[]): void` that:
+  - Returns immediately if `entries` is empty
+  - Reads the `.gitignore` file at `<worktreePath>/.gitignore` (or treats content as empty string if file doesn't exist)
+  - Splits existing content into lines and filters `entries` to only those not already present (trimmed comparison)
+  - If no new entries remain after filtering, logs "all entries already present" and returns
+  - Builds append content: a single `# ADW: copied slash commands (do not commit)` comment header followed by all new entries, each on its own line
+  - Prepends a newline if the existing content doesn't end with one
+  - Writes the combined content in a single `fs.writeFileSync` call
+  - Logs the number of entries added
+- This replaces calling `ensureGitignoreEntry` in a loop, which would produce a duplicate comment header for every entry. The bulk function ensures one comment and one write.
+- Keep the existing `ensureGitignoreEntry` function unchanged (it's exported and tested) for single-entry use cases.
 
-### 2. Call `ensureGitignoreEntry` from `copyClaudeCommandsToWorktree`
+### 2. Modify `copyClaudeCommandsToWorktree` to gitignore individual copied files
 
 In `adws/phases/workflowLifecycle.ts`:
 
-- At the end of `copyClaudeCommandsToWorktree()`, after copying the files, call `ensureGitignoreEntry(worktreePath, '.claude/commands/')` to ensure the copied commands are gitignored
-- This should be called regardless of whether any new files were copied (the `.gitignore` entry should always be present if we're operating on a target repo worktree)
+- Replace the single `ensureGitignoreEntry(worktreePath, '.claude/commands/')` call on line 73 with a call to `ensureGitignoreEntries` using the `copiedFiles` array.
+- Build the entries array from `copiedFiles`: `copiedFiles.map((file) => \`.claude/commands/${file}\`)`
+- Call `ensureGitignoreEntries(worktreePath, gitignoreEntries)` only when `copiedFiles.length > 0`
+- Example:
+  ```typescript
+  // Replace:
+  ensureGitignoreEntry(worktreePath, '.claude/commands/');
 
-### 3. Add unit tests for the gitignore behavior
+  // With:
+  if (copiedFiles.length > 0) {
+    const gitignoreEntries = copiedFiles.map((file) => `.claude/commands/${file}`);
+    ensureGitignoreEntries(worktreePath, gitignoreEntries);
+  }
+  ```
 
-In `adws/__tests__/worktreeOperations.test.ts` (or create a new focused test file if appropriate):
+### 3. Update tests for per-file gitignore entries
 
-- Add tests verifying that after `copyClaudeCommandsToWorktree` runs:
-  - `.claude/commands/` entry is appended to `.gitignore` when it doesn't exist
-  - `.claude/commands/` entry is NOT duplicated when it already exists in `.gitignore`
-  - `.gitignore` file is created if it doesn't already exist
-  - Existing `.gitignore` content is preserved
+In `adws/__tests__/ensureGitignoreEntry.test.ts`:
 
-Since `copyClaudeCommandsToWorktree` is a private function in `workflowLifecycle.ts`, test the exported `ensureGitignoreEntry` helper directly (export it for testing) or write an integration-style test that exercises the copy flow through `initializeWorkflow`. The simpler approach is to export `ensureGitignoreEntry` and test it directly.
+- Add a new `describe('ensureGitignoreEntries')` block (import `ensureGitignoreEntries` from `../phases/workflowLifecycle`):
+  - **"adds multiple file entries with a single comment header"** — Given no existing `.gitignore` and 3 file entries, verify all 3 entries and exactly one comment header appear in the written content.
+  - **"skips entries that already exist in .gitignore"** — Given a `.gitignore` containing `.claude/commands/bug.md`, pass `['.claude/commands/bug.md', '.claude/commands/chore.md']` and verify only `.claude/commands/chore.md` is added.
+  - **"does not write when all entries already exist"** — Given a `.gitignore` containing all passed entries, verify `writeFileSync` is not called.
+  - **"does nothing for empty entries array"** — Pass `[]` and verify no file read or write occurs.
+  - **"creates .gitignore when file does not exist"** — Given `existsSync` returning false, verify file is created with the comment and all entries.
+- Keep existing `ensureGitignoreEntry` tests as-is (the function is still exported and may be used elsewhere).
 
 ### 4. Run validation commands
 
@@ -70,8 +88,8 @@ Execute every command to validate the review is complete with zero regressions.
 - `npm run build` - Build the application to verify no build errors
 
 ## Notes
-- IMPORTANT: Strictly adhere to the coding guidelines in `guidelines/coding_guidelines.md`. Key requirements: strict TypeScript (no `any`), functional style, immutability, pure functions, meaningful variable names.
-- The `.gitignore` entry should be `.claude/commands/` (with trailing slash to match the directory pattern).
-- The `ensureGitignoreEntry` function should be idempotent — safe to call multiple times without duplicating the entry.
-- This approach is preferred over `.git/info/exclude` because `.git/info/exclude` behaves differently for worktrees and is less portable.
-- The `.gitignore` modification in the worktree is intentional and expected — it prevents the ADW command files from being tracked while keeping them available for all workflow phases.
+- IMPORTANT: Strictly adhere to the coding guidelines in `guidelines/coding_guidelines.md`. Key requirements: strict TypeScript (no `any`), functional style (map/filter/reduce over loops), immutability, pure functions, meaningful variable names.
+- The key insight from the reviewer is that ignoring `.claude/commands/` as a directory would hide the target project's OWN commands from git. Only the specific ADW-copied files should be ignored.
+- The `ensureGitignoreEntries` bulk function is preferred over calling `ensureGitignoreEntry` in a loop because it results in a single file read/write and a single comment header, producing a cleaner `.gitignore` file.
+- Files that already existed in the target repo's `.claude/commands/` are NOT overwritten by `copyClaudeCommandsToWorktree` (the `fs.existsSync(destPath)` check on line 62 prevents this), and therefore should NOT be added to `.gitignore` — they belong to the target project.
+- The `ensureGitignoreEntry` function is already idempotent and remains unchanged for backwards compatibility.


### PR DESCRIPTION
## Summary

Fixes three cascading failures when the ADW system runs against an external target repository:

- **Classifier**: `/adw_init` and other explicit ADW commands in issue bodies were not being detected, causing fallback to `/classify_issue` which incorrectly classified as `/chore`
- **Plan agent**: Slash commands (e.g., `/chore`, `/commit`) only exist in the ADW repo's `.claude/commands/` but agents run in the target repo's worktree CWD — plan file was never created
- **Worktree cleanup**: Issue close events triggered cleanup against the ADW repo instead of the target repo, leaving target repo worktrees orphaned

## Implementation Plan

See: `specs/issue-23-adw-multiple-problems-wi-pkdnfi-sdlc_planner-fix-adw-classifier-and-plan.md`

## Changes

- `adws/core/issueClassifier.ts` — Added deterministic regex pre-check that scans issue body for explicit `/adw_*` patterns before invoking the haiku AI classifier
- `adws/phases/workflowLifecycle.ts` — Copy ADW repo's `.claude/commands/` directory to target repo worktree during setup so slash commands are available when agents run in target CWD
- `adws/github/worktreeCleanup.ts` — Accept optional `cwd` parameter in `removeWorktreesForIssue`, `listWorktrees`, and `parseWorktreeBranches` to operate on the correct repo
- `adws/triggers/trigger_webhook.ts` — Extract target repo path from webhook payload and pass to `removeWorktreesForIssue` on issue close
- `adws/agents/claudeAgent.ts` — Minor fix
- `adws/__tests__/issueClassifier.test.ts` — Tests for the new deterministic classifier pre-check
- `adws/__tests__/worktreeOperations.test.ts` — Tests for worktree operations with target repo context

## Checklist

- [x] Deterministic `/adw_*` regex pre-check added to classifier
- [x] `.claude/commands/` copied to target repo worktree during setup
- [x] Worktree cleanup functions accept and use `cwd` parameter
- [x] Webhook handler passes target repo path to cleanup on issue close
- [x] Tests added for classifier and worktree operations

Closes #23

**ADW ID:** `multiple-problems-wi-pkdnfi`