### PR TITLE
bug: #29 - CLEAR_COMMENT_PATTERN should trigger adw

### DIFF
--- a/adws/__tests__/triggerCommentHandling.test.ts
+++ b/adws/__tests__/triggerCommentHandling.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { isActionableComment, ADW_SIGNATURE } from '../github/workflowCommentsBase';
+import { isActionableComment, isClearComment, ADW_SIGNATURE } from '../github/workflowCommentsBase';
 
 /**
  * Tests for the qualifying-issue logic used by the cron trigger.
@@ -18,7 +18,7 @@ function isQualifyingIssue(issue: RawIssue): boolean {
   if (issue.comments.length === 0) return true;
 
   const latestComment = issue.comments[issue.comments.length - 1];
-  return isActionableComment(latestComment.body);
+  return isActionableComment(latestComment.body) || isClearComment(latestComment.body);
 }
 
 describe('isQualifyingIssue (cron trigger logic)', () => {
@@ -92,6 +92,36 @@ describe('isQualifyingIssue (cron trigger logic)', () => {
     const issue: RawIssue = {
       number: 8,
       comments: [{ body: 'Some context here\n\n## Take action\n\nPlease re-run the workflow' }],
+      createdAt: '2025-01-01T00:00:00Z',
+    };
+    expect(isQualifyingIssue(issue)).toBe(true);
+  });
+
+  it('qualifies issue where latest comment is ## Clear', () => {
+    const issue: RawIssue = {
+      number: 9,
+      comments: [
+        { body: '## :tada: ADW Workflow Completed\n\n**ADW ID:** `adw-123-abc`' },
+        { body: '## Clear' },
+      ],
+      createdAt: '2025-01-01T00:00:00Z',
+    };
+    expect(isQualifyingIssue(issue)).toBe(true);
+  });
+
+  it('qualifies issue where latest comment is ## clear (lowercase)', () => {
+    const issue: RawIssue = {
+      number: 10,
+      comments: [{ body: '## clear' }],
+      createdAt: '2025-01-01T00:00:00Z',
+    };
+    expect(isQualifyingIssue(issue)).toBe(true);
+  });
+
+  it('qualifies issue where latest comment contains ## Clear with surrounding text', () => {
+    const issue: RawIssue = {
+      number: 11,
+      comments: [{ body: 'Some context\n\n## Clear\n\nPlease reset' }],
       createdAt: '2025-01-01T00:00:00Z',
     };
     expect(isQualifyingIssue(issue)).toBe(true);

--- a/adws/__tests__/webhookClearComment.test.ts
+++ b/adws/__tests__/webhookClearComment.test.ts
@@ -41,7 +41,7 @@ function makeRawComment(overrides: Record<string, unknown> = {}) {
 function handleIssueComment(commentBody: string, issueNumber: number): { status: string; issue?: number; deleted?: number } | null {
   if (isClearComment(commentBody)) {
     const result = clearIssueComments(issueNumber);
-    return { status: 'cleared', issue: issueNumber, deleted: result.deleted };
+    return { status: 'cleared_and_processing', issue: issueNumber, deleted: result.deleted };
   }
   return null;
 }
@@ -51,25 +51,25 @@ describe('webhook clear-comment handler', () => {
     vi.clearAllMocks();
   });
 
-  it('triggers clearIssueComments for ## Clear comment', () => {
+  it('triggers clearIssueComments and returns cleared_and_processing for ## Clear comment', () => {
     mockRepoInfo();
     vi.mocked(execSync).mockReturnValueOnce(JSON.stringify([]));
 
     const result = handleIssueComment('## Clear', 42);
 
-    expect(result).toEqual({ status: 'cleared', issue: 42, deleted: 0 });
+    expect(result).toEqual({ status: 'cleared_and_processing', issue: 42, deleted: 0 });
   });
 
-  it('triggers clearIssueComments for lowercase ## clear comment', () => {
+  it('triggers clearIssueComments and returns cleared_and_processing for lowercase ## clear comment', () => {
     mockRepoInfo();
     vi.mocked(execSync).mockReturnValueOnce(JSON.stringify([]));
 
     const result = handleIssueComment('## clear', 42);
 
-    expect(result).toEqual({ status: 'cleared', issue: 42, deleted: 0 });
+    expect(result).toEqual({ status: 'cleared_and_processing', issue: 42, deleted: 0 });
   });
 
-  it('returns deleted count from clearIssueComments', () => {
+  it('returns deleted count from clearIssueComments with cleared_and_processing status', () => {
     // getRepoInfo for fetchIssueCommentsRest
     mockRepoInfo();
     // fetch comments
@@ -88,7 +88,17 @@ describe('webhook clear-comment handler', () => {
 
     const result = handleIssueComment('## Clear', 10);
 
-    expect(result).toEqual({ status: 'cleared', issue: 10, deleted: 3 });
+    expect(result).toEqual({ status: 'cleared_and_processing', issue: 10, deleted: 3 });
+  });
+
+  it('calls clearIssueComments for ## Clear comments', () => {
+    mockRepoInfo();
+    vi.mocked(execSync).mockReturnValueOnce(JSON.stringify([]));
+
+    const result = handleIssueComment('## Clear', 7);
+
+    expect(result).not.toBeNull();
+    expect(result!.deleted).toBe(0);
   });
 
   it('does not trigger clear logic for ## Take action comment', () => {

--- a/adws/triggers/trigger_cron.ts
+++ b/adws/triggers/trigger_cron.ts
@@ -7,8 +7,9 @@
 
 import { execSync, spawn } from 'child_process';
 import { log } from '../core';
-import { getRepoInfo, fetchPRList, hasUnaddressedComments, isActionableComment, isAdwRunningForIssue, truncateText } from '../github';
+import { getRepoInfo, fetchPRList, hasUnaddressedComments, isActionableComment, isClearComment, isAdwRunningForIssue, truncateText } from '../github';
 import { classifyIssueForTrigger, getWorkflowScript } from '../core/issueClassifier';
+import { clearIssueComments } from '../adwClearComments';
 
 const POLL_INTERVAL_MS = 20_000;
 const PR_POLL_INTERVAL_MS = 60_000;
@@ -66,6 +67,11 @@ function isQualifyingIssue(issue: RawIssue): boolean {
     return true;
   }
 
+  if (isClearComment(latestComment.body)) {
+    log(`Issue #${issue.number}: latest comment contains "## Clear" directive, qualifies`);
+    return true;
+  }
+
   log(`Issue #${issue.number}: latest comment does not contain "## Take action" directive (${truncateText(latestComment.body, 100)}), does not qualify`);
   return false;
 }
@@ -88,6 +94,15 @@ async function checkAndTrigger(): Promise<void> {
     }
 
     processedIssues.add(issue.number);
+
+    const latestComment = issue.comments.length > 0
+      ? issue.comments[issue.comments.length - 1]
+      : null;
+    if (latestComment && isClearComment(latestComment.body)) {
+      log(`Clear directive on issue #${issue.number}, clearing all comments before spawning workflow`);
+      const clearResult = clearIssueComments(issue.number);
+      log(`Cleared ${clearResult.deleted}/${clearResult.total} comments on issue #${issue.number}`);
+    }
 
     const classification = await classifyIssueForTrigger(issue.number);
     const workflowScript = getWorkflowScript(classification.issueType, classification.adwCommand);

--- a/adws/triggers/trigger_webhook.ts
+++ b/adws/triggers/trigger_webhook.ts
@@ -219,21 +219,19 @@ const server = http.createServer((req, res) => {
 
       log(`Checking comment on issue #${issueNumber}: "${truncateText(commentBody, 100)}"`);
 
+      let clearResult: { deleted: number; total: number; failed: number } | null = null;
+
       if (isClearComment(commentBody)) {
         log(`Clear directive on issue #${issueNumber}, clearing all comments`);
-        const result = clearIssueComments(issueNumber);
-        log(`Cleared ${result.deleted}/${result.total} comments on issue #${issueNumber}`);
-        jsonResponse(res, 200, { status: 'cleared', issue: issueNumber, deleted: result.deleted });
-        return;
-      }
-
-      if (!isActionableComment(commentBody)) {
+        clearResult = clearIssueComments(issueNumber);
+        log(`Cleared ${clearResult.deleted}/${clearResult.total} comments on issue #${issueNumber}`);
+      } else if (!isActionableComment(commentBody)) {
         log(`Ignored comment on issue #${issueNumber}: missing "## Take action" directive`);
         jsonResponse(res, 200, { status: 'ignored' });
         return;
+      } else {
+        log(`Actionable comment on issue #${issueNumber}: contains "## Take action" directive`);
       }
-
-      log(`Actionable comment on issue #${issueNumber}: contains "## Take action" directive`);
 
       // Check if workflow is already running — respond quickly, handle async
       const commentTargetRepoArgs = extractTargetRepoArgs(body);
@@ -260,7 +258,10 @@ const server = http.createServer((req, res) => {
           spawnDetached('npx', ['tsx', 'adws/adwPlanBuildTest.tsx', String(issueNumber), ...commentTargetRepoArgs]);
         });
 
-      jsonResponse(res, 200, { status: 'processing', issue: issueNumber });
+      const responseBody = clearResult
+        ? { status: 'cleared_and_processing', issue: issueNumber, deleted: clearResult.deleted }
+        : { status: 'processing', issue: issueNumber };
+      jsonResponse(res, 200, responseBody);
       return;
     }
 

--- a/specs/issue-29-adw-clear-comment-patter-my7g9p-sdlc_planner-fix-clear-comment-triggers-adw.md
+++ b/specs/issue-29-adw-clear-comment-patter-my7g9p-sdlc_planner-fix-clear-comment-triggers-adw.md
@@ -1,0 +1,116 @@
+# Bug: CLEAR_COMMENT_PATTERN should trigger ADW
+
+## Metadata
+issueNumber: `29`
+adwId: `clear-comment-patter-my7g9p`
+issueJson: `{"number":29,"title":"CLEAR_COMMENT_PATTERN should trigger adw","body":"CLEAR_COMMENT_PATTERN is a subset of ACTIONABLE_COMMENT_PATTERN and should trigger the adw. Currently, it is being ignored","state":"OPEN","author":"paysdoc","labels":[],"createdAt":"2026-02-26T11:58:22Z","comments":[{"author":"paysdoc","createdAt":"2026-02-26T12:10:35Z","body":"## Take action"}],"actionableComment":null}`
+
+## Bug Description
+When a user posts a `## Clear` comment on a GitHub issue, the system correctly clears all existing comments but does **not** trigger an ADW workflow afterward. The `## Clear` directive is conceptually a subset of `## Take action` — both are human directives that should result in an ADW workflow being spawned. Currently, `## Clear` only performs comment cleanup and then returns early, leaving the issue without a re-triggered ADW run.
+
+**Expected behavior:** A `## Clear` comment should (1) clear all existing comments on the issue, then (2) trigger an ADW workflow (classify + spawn), just like `## Take action` does.
+
+**Actual behavior:** A `## Clear` comment clears comments and returns `{ status: 'cleared' }` without triggering any ADW workflow. In the cron trigger, `## Clear` is not recognized as qualifying, so the issue is also skipped.
+
+## Problem Statement
+Both the webhook trigger (`trigger_webhook.ts`) and the cron trigger (`trigger_cron.ts`) fail to spawn an ADW workflow when a `## Clear` comment is detected. The webhook handler returns early after clearing comments (line 227), and the cron trigger's `isQualifyingIssue` function only checks `isActionableComment` (which matches `## Take action`), not `isClearComment` (which matches `## Clear`).
+
+## Solution Statement
+1. **Webhook trigger (`trigger_webhook.ts`):** After clearing comments, instead of returning early, continue to the ADW workflow classification and spawning logic. The response status should reflect both the clear action and the workflow trigger.
+2. **Cron trigger (`trigger_cron.ts`):** In `isQualifyingIssue`, add a check for `isClearComment` on the latest comment so that issues with a `## Clear` directive also qualify for ADW processing.
+3. **Tests:** Update `webhookClearComment.test.ts` and `triggerCommentHandling.test.ts` to validate that `## Clear` comments trigger ADW workflows.
+
+## Steps to Reproduce
+1. Create a GitHub issue.
+2. Let ADW run and post workflow comments on the issue.
+3. Post a `## Clear` comment on the issue.
+4. **Expected:** Comments are cleared AND a new ADW workflow is triggered.
+5. **Actual:** Comments are cleared but no ADW workflow is triggered. The webhook returns `{ status: 'cleared' }` and stops.
+
+## Root Cause Analysis
+There are two trigger entry points, both with the same deficiency:
+
+**Webhook trigger (`trigger_webhook.ts`, lines 222-228):**
+```typescript
+if (isClearComment(commentBody)) {
+  log(`Clear directive on issue #${issueNumber}, clearing all comments`);
+  const result = clearIssueComments(issueNumber);
+  log(`Cleared ${result.deleted}/${result.total} comments on issue #${issueNumber}`);
+  jsonResponse(res, 200, { status: 'cleared', issue: issueNumber, deleted: result.deleted });
+  return;  // ← EARLY RETURN prevents ADW workflow from being spawned
+}
+```
+The `return` statement on line 227 exits the handler before the classification + spawn logic (lines 236-261) is reached.
+
+**Cron trigger (`trigger_cron.ts`, lines 56-71, `isQualifyingIssue`):**
+```typescript
+function isQualifyingIssue(issue: RawIssue): boolean {
+  if (issue.comments.length === 0) return true;
+  const latestComment = issue.comments[issue.comments.length - 1];
+  if (isActionableComment(latestComment.body)) return true;  // Only checks ## Take action
+  return false;  // ← ## Clear falls through here and is ignored
+}
+```
+The function only checks `isActionableComment`, which matches `## Take action` but not `## Clear`. There is no `isClearComment` check.
+
+## Relevant Files
+Use these files to fix the bug:
+
+- `adws/triggers/trigger_webhook.ts` — Contains the webhook handler for `issue_comment` events. The clear comment branch (lines 222-228) returns early without spawning an ADW workflow. Needs to be modified to continue to classification/spawn logic after clearing comments.
+- `adws/triggers/trigger_cron.ts` — Contains `isQualifyingIssue` (lines 56-71) which only checks `isActionableComment`. Needs to also check `isClearComment` and clear comments before qualifying.
+- `adws/__tests__/webhookClearComment.test.ts` — Tests for the webhook clear-comment handler. Needs new tests to validate that `## Clear` triggers ADW workflow after clearing comments.
+- `adws/__tests__/triggerCommentHandling.test.ts` — Tests for the cron trigger's qualifying-issue logic. Needs new tests to validate that `## Clear` qualifies an issue.
+- `adws/github/workflowCommentsBase.ts` — Defines `isClearComment` and `isActionableComment`. Read-only reference for understanding the patterns.
+- `adws/adwClearComments.tsx` — Defines `clearIssueComments`. Read-only reference for understanding the clearing logic.
+- `adws/core/issueClassifier.ts` — Defines `classifyIssueForTrigger` and `getWorkflowScript`. Read-only reference for understanding the classification flow.
+- `guidelines/coding_guidelines.md` — Coding guidelines to follow.
+
+## Step by Step Tasks
+IMPORTANT: Execute every step in order, top to bottom.
+
+### Step 1: Modify the webhook trigger to spawn ADW after clearing comments
+- Read `adws/triggers/trigger_webhook.ts`.
+- In the `issue_comment` handler (around lines 222-228), modify the `isClearComment` branch:
+  - Keep the existing clear logic: call `clearIssueComments(issueNumber)` and log the result.
+  - **Remove the early return** (`jsonResponse` + `return`).
+  - After clearing, fall through to the existing classification and spawn logic (lines 236-261).
+  - The response should still be sent immediately (like the actionable comment path on line 263), but the status should indicate both clearing and processing, e.g., `{ status: 'cleared_and_processing', issue: issueNumber, deleted: result.deleted }`.
+- Ensure the `isAdwRunningForIssue` check and `classifyIssueForTrigger` flow are reused (not duplicated) — the clear branch should fall through to the same code path that the actionable comment branch uses.
+
+### Step 2: Modify the cron trigger to qualify issues with `## Clear` comments
+- Read `adws/triggers/trigger_cron.ts`.
+- Import `isClearComment` from `../github`.
+- In `isQualifyingIssue` (lines 56-71), add a check: if the latest comment matches `isClearComment`, log a message and return `true`.
+- In `checkAndTrigger` (lines 74-112), before spawning the workflow for a qualifying issue, check if the latest comment is a clear comment. If so, call `clearIssueComments(issueNumber)` before spawning the workflow. Import `clearIssueComments` from `../adwClearComments`.
+
+### Step 3: Update webhook clear-comment tests
+- Read `adws/__tests__/webhookClearComment.test.ts`.
+- The existing `handleIssueComment` helper function (lines 41-47) only replicates the clear-and-return logic. Update it to also replicate the new behavior: after clearing, proceed to return a status indicating ADW was triggered (e.g., `{ status: 'cleared_and_processing', ... }`).
+- Add tests:
+  - `## Clear` comment clears comments AND returns a status indicating ADW processing was triggered.
+  - Verify `clearIssueComments` is still called for `## Clear` comments.
+
+### Step 4: Update cron trigger comment handling tests
+- Read `adws/__tests__/triggerCommentHandling.test.ts`.
+- The existing `isQualifyingIssue` helper (lines 17-22) replicates the cron logic. Update it to also check `isClearComment`.
+- Add tests:
+  - An issue whose latest comment is `## Clear` qualifies.
+  - An issue whose latest comment is `## clear` (lowercase) qualifies.
+  - An issue whose latest comment is `## Clear` with surrounding text qualifies.
+
+### Step 5: Run validation commands
+- Run all validation commands listed below to ensure the bug is fixed with zero regressions.
+
+## Validation Commands
+Execute every command to validate the bug is fixed with zero regressions.
+
+- `npm run lint` — Run linter to check for code quality issues
+- `npx tsc --noEmit` — TypeScript type check for main project
+- `npx tsc --noEmit -p adws/tsconfig.json` — TypeScript type check for adws
+- `npm test` — Run all tests to validate the bug is fixed with zero regressions
+
+## Notes
+- IMPORTANT: Strictly adhere to `guidelines/coding_guidelines.md` coding guidelines.
+- The `clearIssueComments` function is synchronous (uses `execSync` internally). This is important in the webhook handler since the response needs to be sent quickly — the clear operation should complete before the async classification/spawn begins.
+- The cron trigger's `isQualifyingIssue` is a module-private function. Tests replicate its logic via a local helper. When updating the real function, also update the test helper to match.
+- No new libraries are needed for this fix.


### PR DESCRIPTION
## Summary

Fixes a bug where `CLEAR_COMMENT_PATTERN` was not triggering the ADW (AI Dev Workflow). Since `CLEAR_COMMENT_PATTERN` is a subset of `ACTIONABLE_COMMENT_PATTERN`, it should trigger the ADW just like other actionable comments do.

**Issue:** CLEAR_COMMENT_PATTERN is a subset of ACTIONABLE_COMMENT_PATTERN and should trigger the adw. Currently, it is being ignored.

**Plan:** [specs/issue-29-adw-clear-comment-patter-my7g9p-sdlc_planner-fix-clear-comment-triggers-adw.md](specs/issue-29-adw-clear-comment-patter-my7g9p-sdlc_planner-fix-clear-comment-triggers-adw.md)

Closes #29

**ADW Tracking ID:** clear-comment-patter-my7g9p

## Checklist

- [x] Fixed `CLEAR_COMMENT_PATTERN` detection in webhook trigger to properly match and dispatch ADW
- [x] Updated `trigger_webhook.ts` to handle clear comment pattern as an actionable comment
- [x] Updated `trigger_cron.ts` to correctly handle clear comment triggers
- [x] Added/updated tests in `triggerCommentHandling.test.ts` for clear comment pattern handling
- [x] Added/updated tests in `webhookClearComment.test.ts` for webhook clear comment scenarios

## Key Changes

- **`adws/triggers/trigger_webhook.ts`**: Updated comment handling logic to ensure `CLEAR_COMMENT_PATTERN` is recognized as an actionable comment trigger, preventing it from being silently ignored
- **`adws/triggers/trigger_cron.ts`**: Aligned cron trigger logic to handle clear comment patterns consistently
- **`adws/__tests__/triggerCommentHandling.test.ts`**: Extended tests to cover clear comment pattern triggering scenarios
- **`adws/__tests__/webhookClearComment.test.ts`**: Updated webhook tests to validate clear comment events properly trigger the ADW