### PR TITLE
feat: #54 - Initialization of adw should end with pr creation

### DIFF
--- a/adws/__tests__/adwInitPrPhase.test.ts
+++ b/adws/__tests__/adwInitPrPhase.test.ts
@@ -1,0 +1,38 @@
+import { describe, it, expect } from 'vitest';
+import * as fs from 'fs';
+import * as path from 'path';
+
+const adwInitSource = fs.readFileSync(
+  path.resolve(__dirname, '../adwInit.tsx'),
+  'utf-8',
+);
+
+describe('adwInit PR phase integration', () => {
+  it('imports executePRPhase from workflowPhases', () => {
+    expect(adwInitSource).toMatch(/import\s*\{[^}]*executePRPhase[^}]*\}\s*from\s*['"]\.\/workflowPhases['"]/s);
+  });
+
+  it('calls executePRPhase(config) after commitChanges', () => {
+    const commitIdx = adwInitSource.indexOf('commitChanges(');
+    const prCallIdx = adwInitSource.indexOf('executePRPhase(config)');
+    expect(commitIdx).toBeGreaterThan(-1);
+    expect(prCallIdx).toBeGreaterThan(-1);
+    expect(prCallIdx).toBeGreaterThan(commitIdx);
+  });
+
+  it('calls executePRPhase(config) before completeWorkflow', () => {
+    const prCallIdx = adwInitSource.indexOf('executePRPhase(config)');
+    const completeIdx = adwInitSource.indexOf('completeWorkflow(');
+    expect(prCallIdx).toBeGreaterThan(-1);
+    expect(completeIdx).toBeGreaterThan(-1);
+    expect(prCallIdx).toBeLessThan(completeIdx);
+  });
+
+  it('accumulates PR phase cost into totalCostUsd', () => {
+    expect(adwInitSource).toContain('totalCostUsd += prResult.costUsd');
+  });
+
+  it('merges PR phase model usage into totalModelUsage', () => {
+    expect(adwInitSource).toMatch(/mergeModelUsageMaps\(totalModelUsage,\s*prResult\.modelUsage\)/);
+  });
+});

--- a/adws/adwInit.tsx
+++ b/adws/adwInit.tsx
@@ -8,7 +8,8 @@
  * 1. Initialize: fetch issue, classify type, setup worktree, initialize state
  * 2. Run /adw_init slash command to generate .adw/ config files
  * 3. Commit the generated files
- * 4. Finalize: update state, post completion comment
+ * 4. PR Phase: create pull request
+ * 5. Finalize: update state, post completion comment
  *
  * Environment Requirements:
  * - ANTHROPIC_API_KEY: Anthropic API key
@@ -21,6 +22,7 @@ import { runClaudeAgentWithCommand } from './agents/claudeAgent';
 import { commitChanges } from './github';
 import {
   initializeWorkflow,
+  executePRPhase,
   completeWorkflow,
   handleWorkflowError,
 } from './workflowPhases';
@@ -136,6 +138,11 @@ async function main(): Promise<void> {
       'chore: initialize .adw/ project configuration',
       config.worktreePath,
     );
+
+    log('Phase: PR Creation', 'info');
+    const prResult = await executePRPhase(config);
+    totalCostUsd += prResult.costUsd;
+    totalModelUsage = mergeModelUsageMaps(totalModelUsage, prResult.modelUsage);
 
     persistTokenCounts(config.orchestratorStatePath, totalCostUsd, totalModelUsage);
     await completeWorkflow(config, totalCostUsd, undefined, totalModelUsage);

--- a/projects/AI_Dev_Workflow/0-bug-52-issue-classifier-running-on-incorrect-repo.csv
+++ b/projects/AI_Dev_Workflow/0-bug-52-issue-classifier-running-on-incorrect-repo.csv
@@ -1,0 +1,6 @@
+Model,Input Tokens,Output Tokens,Cache Read,Cache Write,Cost (USD)
+claude-opus-4-6,88,42078,7045523,210319,5.8896
+claude-haiku-4-5-20251001,257,18842,1548504,165010,0.4556
+
+Total Cost (USD):,6.3452
+Total Cost (EUR):,5.3742

--- a/projects/AI_Dev_Workflow/46-add-logging-to-classifier.csv
+++ b/projects/AI_Dev_Workflow/46-add-logging-to-classifier.csv
@@ -1,0 +1,7 @@
+Model,Input Tokens,Output Tokens,Cache Read,Cache Write,Cost (USD)
+claude-opus-4-6,111,31183,2472507,143209,2.9114
+claude-haiku-4-5-20251001,110,5148,421507,75270,0.1621
+claude-sonnet-4-6,19,4912,394123,20633,0.4489
+
+Total Cost (USD):,3.5224
+Total Cost (EUR):,2.9834

--- a/projects/AI_Dev_Workflow/48-clearing-issue-comments-triggers-additional-classi.csv
+++ b/projects/AI_Dev_Workflow/48-clearing-issue-comments-triggers-additional-classi.csv
@@ -1,0 +1,7 @@
+Model,Input Tokens,Output Tokens,Cache Read,Cache Write,Cost (USD)
+claude-opus-4-6,34,10901,1391329,86514,1.5091
+claude-haiku-4-5-20251001,75,2211,256903,25267,0.0684
+claude-sonnet-4-6,7,926,127187,9531,0.1463
+
+Total Cost (USD):,1.7238
+Total Cost (EUR):,1.4600

--- a/projects/AI_Dev_Workflow/49-issue-48-identified-as-adw-init.csv
+++ b/projects/AI_Dev_Workflow/49-issue-48-identified-as-adw-init.csv
@@ -1,0 +1,7 @@
+Model,Input Tokens,Output Tokens,Cache Read,Cache Write,Cost (USD)
+claude-opus-4-6,69,14160,1378348,77763,1.5295
+claude-haiku-4-5-20251001,61,1693,187809,24783,0.0583
+claude-sonnet-4-6,6,904,83330,3847,0.0883
+
+Total Cost (USD):,1.6762
+Total Cost (EUR):,1.4197

--- a/projects/AI_Dev_Workflow/52-issue-classifier-running-on-incorrect-repo.csv
+++ b/projects/AI_Dev_Workflow/52-issue-classifier-running-on-incorrect-repo.csv
@@ -1,0 +1,7 @@
+Model,Input Tokens,Output Tokens,Cache Read,Cache Write,Cost (USD)
+claude-opus-4-6,41,16283,1929947,122727,2.1393
+claude-haiku-4-5-20251001,103,4192,327179,24248,0.0841
+claude-sonnet-4-6,7,1055,112553,6030,0.1204
+
+Total Cost (USD):,2.3438
+Total Cost (EUR):,1.9851

--- a/projects/AI_Dev_Workflow/total-cost.csv
+++ b/projects/AI_Dev_Workflow/total-cost.csv
@@ -15,6 +15,12 @@ Issue number,Issue description,Cost (USD),Markup (10%)
 42,Huge problems with classification,4.9941,0.4994
 44,Remove /classify_adw command,3.7199,0.3720
 0,chore: #44 - Remove /classify_adw command,0.6440,0.0644
+46,Add logging to classifier,3.5224,0.3522
+48,Clearing issue comments triggers additional classification,0.3513,0.0351
+49,Issue #48 identified as adw init,1.6762,0.1676
+48,Clearing issue comments triggers additional classification,1.7238,0.1724
+52,Issue classifier running on incorrect repo,2.3438,0.2344
+0,bug: #52 - Issue classifier running on incorrect repo,6.3452,0.6345
 
-Total Cost (USD):,73.5125
-Total Cost (EUR):,62.2625
+Total Cost (USD):,91.0714
+Total Cost (EUR):,77.1343

--- a/projects/Millennium/35-set-up-adw-environment.csv
+++ b/projects/Millennium/35-set-up-adw-environment.csv
@@ -1,0 +1,5 @@
+Model,Input Tokens,Output Tokens,Cache Read,Cache Write,Cost (USD)
+claude-sonnet-4-6,12,4340,353881,20437,0.4132
+
+Total Cost (USD):,0.4132
+Total Cost (EUR):,0.3500

--- a/projects/Millennium/total-cost.csv
+++ b/projects/Millennium/total-cost.csv
@@ -1,0 +1,6 @@
+Issue number,Issue description,Cost (USD),Markup (10%)
+35,set up adw environment,0.3487,0.0349
+35,set up adw environment,0.4132,0.0413
+
+Total Cost (USD):,0.8382
+Total Cost (EUR):,0.7099

--- a/specs/issue-54-adw-initialization-of-ad-hu9frs-sdlc_planner-adw-init-create-pr.md
+++ b/specs/issue-54-adw-initialization-of-ad-hu9frs-sdlc_planner-adw-init-create-pr.md
@@ -1,0 +1,116 @@
+# Feature: Add PR Creation Phase to adwInit Orchestrator
+
+## Metadata
+issueNumber: `54`
+adwId: `initialization-of-ad-hu9frs`
+issueJson: `{"number":54,"title":"Initialization of adw should end with pr creation","body":"``` adw_init ``` creates a branch in a worktree, but does not add a pull request. \n\nAdd the PR phase before completing the issue. ","state":"OPEN","author":"paysdoc","labels":[],"createdAt":"2026-03-01T18:21:56Z","comments":[],"actionableComment":null}`
+
+## Feature Description
+The `adwInit.tsx` orchestrator currently initializes `.adw/` project configuration files, commits them, and completes the workflow — but it never creates a pull request. Every other orchestrator that modifies code (e.g., `adwPlanBuild.tsx`, `adwSdlc.tsx`) includes a PR phase so that changes are reviewable. This feature adds the existing `executePRPhase()` call to `adwInit.tsx` so the generated `.adw/` configuration is submitted as a pull request, consistent with all other ADW orchestrators.
+
+## User Story
+As a developer using ADW to initialize a target repository
+I want the `adwInit` workflow to automatically create a pull request with the generated `.adw/` configuration
+So that the configuration changes go through the standard code review process instead of only existing on an unmerged branch
+
+## Problem Statement
+When `adwInit.tsx` runs, it creates a worktree with a feature branch, generates `.adw/` configuration files, and commits them. However, it never pushes the branch or creates a pull request. This means the generated configuration sits on a local branch with no visibility to the team and no review process. Other orchestrators like `adwPlanBuild.tsx` include a PR phase — `adwInit.tsx` should follow the same pattern.
+
+## Solution Statement
+Add the `executePRPhase(config)` call to `adwInit.tsx` after the commit step and before `completeWorkflow()`. This reuses the existing PR phase infrastructure (`adws/phases/prPhase.ts`) which handles pushing the branch, creating the PR via the `/pull_request` skill, and posting workflow status comments. The change also requires importing `executePRPhase` from `./workflowPhases` and accumulating the PR phase's cost and model usage into the workflow totals.
+
+## Relevant Files
+Use these files to implement the feature:
+
+- `adws/adwInit.tsx` — The main orchestrator file that needs modification. Currently missing the PR phase call between commit and `completeWorkflow()`.
+- `adws/workflowPhases.ts` — Re-exports all phase functions including `executePRPhase`. The import source for the PR phase.
+- `adws/phases/prPhase.ts` — The existing PR phase implementation. Already handles uncommitted changes, PR creation, and workflow comments. No changes needed here — read for reference only.
+- `adws/adwPlanBuild.tsx` — Reference orchestrator that already includes the PR phase. Use as a pattern for how to integrate `executePRPhase()`.
+- `adws/phases/workflowLifecycle.ts` — Contains `WorkflowConfig`, `initializeWorkflow`, `completeWorkflow`, and `handleWorkflowError`. Read for reference only.
+- `guidelines/coding_guidelines.md` — Coding guidelines that must be followed.
+
+### New Files
+- `adws/__tests__/adwInitPrPhase.test.ts` — Unit test verifying that `adwInit.tsx` calls the PR phase after committing `.adw/` files.
+
+## Implementation Plan
+### Phase 1: Foundation
+No foundational work is needed. The `executePRPhase()` function already exists in `adws/phases/prPhase.ts` and is exported through `adws/workflowPhases.ts`. The `WorkflowConfig` interface already contains all the fields the PR phase needs (`branchName`, `worktreePath`, `issue`, etc.).
+
+### Phase 2: Core Implementation
+Modify `adwInit.tsx` to:
+1. Import `executePRPhase` from `./workflowPhases`
+2. After the `commitChanges()` call, invoke `executePRPhase(config)` to create the pull request
+3. Accumulate the PR phase's `costUsd` and `modelUsage` into the existing `totalCostUsd` and `totalModelUsage` variables
+4. Call `persistTokenCounts()` after the PR phase (following the pattern in `adwPlanBuild.tsx`)
+
+### Phase 3: Integration
+The change integrates naturally because:
+- `initializeWorkflow()` already sets up the worktree, branch, and all config needed by `executePRPhase()`
+- `executePRPhase()` handles pushing the branch and creating the PR via the `/pull_request` slash command
+- `completeWorkflow()` already logs the PR URL if `ctx.prUrl` is set (which `executePRPhase` sets)
+- No changes to the workflow lifecycle, slash commands, or agent infrastructure are needed
+
+## Step by Step Tasks
+IMPORTANT: Execute every step in order, top to bottom.
+
+### Step 1: Update adwInit.tsx imports
+- In `adws/adwInit.tsx`, add `executePRPhase` to the import from `./workflowPhases`
+- The current import is: `import { initializeWorkflow, completeWorkflow, handleWorkflowError } from './workflowPhases';`
+- Add `executePRPhase` to this import statement
+
+### Step 2: Add PR phase call after commit
+- In the `main()` function of `adws/adwInit.tsx`, after the `commitChanges()` call (line ~138) and before `persistTokenCounts()` / `completeWorkflow()`, add:
+  - A log line: `log('Phase: PR Creation', 'info');`
+  - The PR phase call: `const prResult = await executePRPhase(config);`
+  - Accumulate cost: `totalCostUsd += prResult.costUsd;`
+  - Merge model usage: `totalModelUsage = mergeModelUsageMaps(totalModelUsage, prResult.modelUsage);`
+- Keep the existing `persistTokenCounts()` call after the PR phase (it already exists before `completeWorkflow`)
+
+### Step 3: Update the orchestrator JSDoc header
+- Update the JSDoc comment at the top of `adws/adwInit.tsx` to reflect the new workflow step:
+  - Change step 3 from "Commit the generated files" to "Commit the generated files"
+  - Add step 4: "PR Phase: create pull request"
+  - Renumber step 4 (Finalize) to step 5
+
+### Step 4: Write unit test
+- Create `adws/__tests__/adwInitPrPhase.test.ts`
+- Test that the `adwInit.tsx` module imports `executePRPhase` from `./workflowPhases` by reading the source file and verifying the import statement contains `executePRPhase`
+- Test that the source code calls `executePRPhase(config)` after `commitChanges()`
+- Follow existing test patterns in the `adws/__tests__/` directory (use `describe`/`it` blocks, `fs.readFileSync` to read source)
+
+### Step 5: Run validation commands
+- Run all validation commands listed below to ensure zero regressions
+
+## Testing Strategy
+### Unit Tests
+- Verify `adwInit.tsx` imports `executePRPhase` from `./workflowPhases`
+- Verify the source code of `adwInit.tsx` calls `executePRPhase(config)` after `commitChanges` and before `completeWorkflow`
+- Verify cost accumulation from PR phase is present in the source
+
+### Edge Cases
+- If `executePRPhase` fails, the error should be caught by the existing `try/catch` block and handled by `handleWorkflowError()`
+- If there are no uncommitted changes at PR time (already committed), `executePRPhase` handles this gracefully (it checks `hasUncommittedChanges` internally)
+- Recovery mode: `shouldExecuteStage('pr_created', recoveryState)` inside `executePRPhase` handles skipping if already done
+
+## Acceptance Criteria
+- `adws/adwInit.tsx` imports and calls `executePRPhase(config)` after committing `.adw/` files
+- PR phase cost and model usage are accumulated into workflow totals
+- The orchestrator JSDoc header documents the PR phase step
+- A unit test verifies the PR phase integration in the source code
+- All existing tests pass with zero regressions
+- Lint, type check, and build all pass cleanly
+
+## Validation Commands
+Execute every command to validate the feature works correctly with zero regressions.
+
+- `npm run lint` — Run linter to check for code quality issues
+- `npx tsc --noEmit` — Type check the Next.js project
+- `npx tsc --noEmit -p adws/tsconfig.json` — Type check the ADW scripts
+- `npm test` — Run all tests to validate zero regressions
+- `npm run build` — Build the application to verify no build errors
+
+## Notes
+- IMPORTANT: Strictly adhere to the coding guidelines in `guidelines/coding_guidelines.md`.
+- The change follows the exact same pattern used in `adwPlanBuild.tsx` (lines 113-116) for integrating the PR phase.
+- No new dependencies or libraries are needed.
+- The `executePRPhase` function already handles all PR creation complexity (pushing, creating PR, posting comments). We only need to call it and accumulate costs.


### PR DESCRIPTION
## Summary

This PR implements the PR creation phase for `adw_init`, ensuring that when initializing an ADW project, the workflow completes with a pull request being created automatically.

**Issue context:** `adw_init` creates a branch in a worktree but did not previously add a pull request. This adds the PR phase before completing the issue.

**Plan:** [specs/issue-54-adw-initialization-of-ad-hu9frs-sdlc_planner-adw-init-create-pr.md](specs/issue-54-adw-initialization-of-ad-hu9frs-sdlc_planner-adw-init-create-pr.md)

Closes #54

**ADW tracking ID:** initialization-of-ad-hu9frs

## Checklist

- [x] Added PR creation phase to `adw_init` workflow
- [x] Updated `adwInit.tsx` to include PR phase logic
- [x] Added tests for the new PR phase (`adwInitPrPhase.test.ts`)
- [x] Added implementation spec/plan file

## Key Changes

- **`adws/adwInit.tsx`**: Extended the `adw_init` workflow to include a PR creation phase after branch setup in the worktree
- **`adws/__tests__/adwInitPrPhase.test.ts`**: New test file validating the PR creation phase behavior
- **`specs/issue-54-adw-initialization-of-ad-hu9frs-sdlc_planner-adw-init-create-pr.md`**: Implementation plan for this feature