### PR TITLE
bug: #60 - Fix total cost contains unlinked item lines

### DIFF
--- a/adws/__tests__/costCsvWriter.test.ts
+++ b/adws/__tests__/costCsvWriter.test.ts
@@ -9,7 +9,8 @@ import {
   formatProjectCostCsv,
   parseProjectCostCsv,
   writeIssueCostCsv,
-  updateProjectCostCsv,
+  parseIssueCostTotal,
+  rebuildProjectCostCsv,
 } from '../core/costCsvWriter';
 import type { CostBreakdown } from '../core/costTypes';
 import type { ProjectCostRow } from '../core/costCsvWriter';
@@ -211,7 +212,31 @@ describe('costCsvWriter', () => {
     });
   });
 
-  describe('updateProjectCostCsv', () => {
+  describe('parseIssueCostTotal', () => {
+    it('parses valid issue CSV content and returns the correct total', () => {
+      const csv = [
+        'Model,Input Tokens,Output Tokens,Cache Read,Cache Write,Cost (USD)',
+        'claude-opus-4-6,45,11896,1190928,26536,1.0589',
+        'claude-haiku-4-5-20251001,21308,1156,0,0,0.0271',
+        '',
+        'Total Cost (USD):,1.5378',
+        'Total Cost (EUR):,1.3030',
+      ].join('\n');
+
+      expect(parseIssueCostTotal(csv)).toBe(1.5378);
+    });
+
+    it('returns 0 for content without a Total Cost (USD) line', () => {
+      const csv = 'Model,Input Tokens\nsonnet,100';
+      expect(parseIssueCostTotal(csv)).toBe(0);
+    });
+
+    it('returns 0 for empty content', () => {
+      expect(parseIssueCostTotal('')).toBe(0);
+    });
+  });
+
+  describe('rebuildProjectCostCsv', () => {
     let tmpDir: string;
 
     beforeEach(() => {
@@ -222,50 +247,106 @@ describe('costCsvWriter', () => {
       fs.rmSync(tmpDir, { recursive: true, force: true });
     });
 
-    it('creates new CSV when none exists', () => {
-      updateProjectCostCsv(tmpDir, 'test-repo', 1, 'First Issue', 2.0, 0.92);
+    const writeIssueCsv = (dir: string, filename: string, totalCostUsd: number): void => {
+      const projectDir = path.join(dir, 'projects', 'test-repo');
+      fs.mkdirSync(projectDir, { recursive: true });
+      const content = [
+        'Model,Input Tokens,Output Tokens,Cache Read,Cache Write,Cost (USD)',
+        `sonnet,100,50,0,0,${totalCostUsd.toFixed(4)}`,
+        '',
+        `Total Cost (USD):,${totalCostUsd.toFixed(4)}`,
+        `Total Cost (EUR):,N/A`,
+      ].join('\n') + '\n';
+      fs.writeFileSync(path.join(projectDir, filename), content, 'utf-8');
+    };
 
-      const csvPath = path.join(tmpDir, 'projects', 'test-repo', 'total-cost.csv');
-      expect(fs.existsSync(csvPath)).toBe(true);
+    it('rebuilds correctly from multiple issue CSV files', () => {
+      writeIssueCsv(tmpDir, '1-add-login.csv', 2.0);
+      writeIssueCsv(tmpDir, '2-fix-bug.csv', 1.0);
 
-      const content = fs.readFileSync(csvPath, 'utf-8');
-      expect(content).toContain('Issue number,Issue description,Cost (USD),Markup (10%)');
-      expect(content).toContain('1,First Issue,2.0000,0.2000');
-      // Total: 2.0 + 0.2 = 2.2; EUR: 2.2 * 0.92 = 2.024
-      expect(content).toContain('Total Cost (USD):,2.2000');
-      expect(content).toContain('Total Cost (EUR):,2.0240');
-    });
-
-    it('appends to existing CSV and updates totals', () => {
-      updateProjectCostCsv(tmpDir, 'test-repo', 1, 'First Issue', 2.0, 0.92);
-      updateProjectCostCsv(tmpDir, 'test-repo', 2, 'Second Issue', 1.0, 0.92);
-
-      const csvPath = path.join(tmpDir, 'projects', 'test-repo', 'total-cost.csv');
-      const content = fs.readFileSync(csvPath, 'utf-8');
-
-      expect(content).toContain('1,First Issue,2.0000,0.2000');
-      expect(content).toContain('2,Second Issue,1.0000,0.1000');
-      // Total: (2.0 + 0.2) + (1.0 + 0.1) = 3.3; EUR: 3.3 * 0.92 = 3.036
-      expect(content).toContain('Total Cost (USD):,3.3000');
-      expect(content).toContain('Total Cost (EUR):,3.0360');
-    });
-
-    it('handles multiple sequential updates correctly', () => {
-      updateProjectCostCsv(tmpDir, 'test-repo', 1, 'Issue A', 1.0, 0.92);
-      updateProjectCostCsv(tmpDir, 'test-repo', 2, 'Issue B', 2.0, 0.92);
-      updateProjectCostCsv(tmpDir, 'test-repo', 3, 'Issue C', 3.0, 0.92);
+      rebuildProjectCostCsv(tmpDir, 'test-repo', 0.92);
 
       const csvPath = path.join(tmpDir, 'projects', 'test-repo', 'total-cost.csv');
       const content = fs.readFileSync(csvPath, 'utf-8');
       const rows = parseProjectCostCsv(content);
 
-      expect(rows).toHaveLength(3);
-      expect(rows[0].issueNumber).toBe(1);
-      expect(rows[1].issueNumber).toBe(2);
-      expect(rows[2].issueNumber).toBe(3);
+      expect(rows).toHaveLength(2);
+      expect(rows[0]).toEqual({ issueNumber: 1, issueDescription: 'add login', costUsd: 2.0, markupUsd: 0.2 });
+      expect(rows[1]).toEqual({ issueNumber: 2, issueDescription: 'fix bug', costUsd: 1.0, markupUsd: 0.1 });
+      // Total: (2.0+0.2) + (1.0+0.1) = 3.3; EUR: 3.3 * 0.92 = 3.036
+      expect(content).toContain('Total Cost (USD):,3.3000');
+      expect(content).toContain('Total Cost (EUR):,3.0360');
+    });
 
-      // Total: (1+0.1) + (2+0.2) + (3+0.3) = 6.6
-      expect(content).toContain('Total Cost (USD):,6.6000');
+    it('creates empty CSV when project directory has no issue files', () => {
+      rebuildProjectCostCsv(tmpDir, 'test-repo', 0.92);
+
+      const csvPath = path.join(tmpDir, 'projects', 'test-repo', 'total-cost.csv');
+      const content = fs.readFileSync(csvPath, 'utf-8');
+      const rows = parseProjectCostCsv(content);
+
+      expect(rows).toHaveLength(0);
+      expect(content).toContain('Total Cost (USD):,0.0000');
+    });
+
+    it('skips total-cost.csv when scanning files', () => {
+      writeIssueCsv(tmpDir, '1-some-issue.csv', 1.5);
+      // Write a total-cost.csv with stale data
+      const projectDir = path.join(tmpDir, 'projects', 'test-repo');
+      fs.writeFileSync(path.join(projectDir, 'total-cost.csv'), 'stale data', 'utf-8');
+
+      rebuildProjectCostCsv(tmpDir, 'test-repo', 0.92);
+
+      const content = fs.readFileSync(path.join(projectDir, 'total-cost.csv'), 'utf-8');
+      const rows = parseProjectCostCsv(content);
+
+      expect(rows).toHaveLength(1);
+      expect(rows[0].issueNumber).toBe(1);
+    });
+
+    it('skips files that do not follow the {number}-{slug}.csv naming pattern', () => {
+      writeIssueCsv(tmpDir, '1-valid-issue.csv', 1.0);
+      // Write files with invalid naming patterns
+      const projectDir = path.join(tmpDir, 'projects', 'test-repo');
+      fs.writeFileSync(path.join(projectDir, 'notes.csv'), 'some notes', 'utf-8');
+      fs.writeFileSync(path.join(projectDir, 'abc-not-a-number.csv'), 'invalid', 'utf-8');
+
+      rebuildProjectCostCsv(tmpDir, 'test-repo', 0.92);
+
+      const content = fs.readFileSync(path.join(projectDir, 'total-cost.csv'), 'utf-8');
+      const rows = parseProjectCostCsv(content);
+
+      expect(rows).toHaveLength(1);
+      expect(rows[0].issueNumber).toBe(1);
+    });
+
+    it('sorts rows by issue number ascending', () => {
+      writeIssueCsv(tmpDir, '10-later-issue.csv', 3.0);
+      writeIssueCsv(tmpDir, '2-middle-issue.csv', 2.0);
+      writeIssueCsv(tmpDir, '1-first-issue.csv', 1.0);
+
+      rebuildProjectCostCsv(tmpDir, 'test-repo', 0.92);
+
+      const csvPath = path.join(tmpDir, 'projects', 'test-repo', 'total-cost.csv');
+      const rows = parseProjectCostCsv(fs.readFileSync(csvPath, 'utf-8'));
+
+      expect(rows.map(r => r.issueNumber)).toEqual([1, 2, 10]);
+    });
+
+    it('reflects latest cost with no duplicates on re-run', () => {
+      writeIssueCsv(tmpDir, '6-set-up-adw-environment.csv', 1.1719);
+      rebuildProjectCostCsv(tmpDir, 'test-repo', 0.92);
+
+      // Overwrite with updated cost (simulating a re-run)
+      writeIssueCsv(tmpDir, '6-set-up-adw-environment.csv', 1.5378);
+      rebuildProjectCostCsv(tmpDir, 'test-repo', 0.92);
+
+      const csvPath = path.join(tmpDir, 'projects', 'test-repo', 'total-cost.csv');
+      const rows = parseProjectCostCsv(fs.readFileSync(csvPath, 'utf-8'));
+
+      expect(rows).toHaveLength(1);
+      expect(rows[0].issueNumber).toBe(6);
+      expect(rows[0].costUsd).toBe(1.5378);
     });
   });
 });

--- a/adws/__tests__/prReviewCostTracking.test.ts
+++ b/adws/__tests__/prReviewCostTracking.test.ts
@@ -37,7 +37,7 @@ vi.mock('../core', async (importOriginal) => {
       currencies: [{ currency: 'EUR', amount: 1.35, symbol: '€' }],
     }),
     writeIssueCostCsv: vi.fn(),
-    updateProjectCostCsv: vi.fn(),
+    rebuildProjectCostCsv: vi.fn(),
     mergeModelUsageMaps: actual.mergeModelUsageMaps,
     emptyModelUsageMap: actual.emptyModelUsageMap,
     persistTokenCounts: vi.fn(),
@@ -97,7 +97,7 @@ vi.mock('../agents', () => ({
   runE2ETestsWithRetry: vi.fn(),
 }));
 
-import { AgentStateManager, writeIssueCostCsv, updateProjectCostCsv, persistTokenCounts, buildCostBreakdown } from '../core';
+import { AgentStateManager, writeIssueCostCsv, rebuildProjectCostCsv, persistTokenCounts, buildCostBreakdown } from '../core';
 import { postPRWorkflowComment, getRepoInfo } from '../github';
 import { runPrReviewPlanAgent, runPrReviewBuildAgent, runUnitTestsWithRetry, runE2ETestsWithRetry } from '../agents';
 
@@ -280,12 +280,9 @@ describe('PR Review Cost Tracking', () => {
         'Test PR',
         expect.objectContaining({ totalCostUsd: 1.5 }),
       );
-      expect(updateProjectCostCsv).toHaveBeenCalledWith(
+      expect(rebuildProjectCostCsv).toHaveBeenCalledWith(
         process.cwd(),
         'repo',
-        10,
-        'Test PR',
-        1.5,
         expect.any(Number),
       );
     });
@@ -316,7 +313,7 @@ describe('PR Review Cost Tracking', () => {
       await completePRReviewWorkflow(config);
 
       expect(writeIssueCostCsv).not.toHaveBeenCalled();
-      expect(updateProjectCostCsv).not.toHaveBeenCalled();
+      expect(rebuildProjectCostCsv).not.toHaveBeenCalled();
     });
 
     it('does not write CSVs when modelUsage is an empty object', async () => {
@@ -325,7 +322,7 @@ describe('PR Review Cost Tracking', () => {
       await completePRReviewWorkflow(config, {});
 
       expect(writeIssueCostCsv).not.toHaveBeenCalled();
-      expect(updateProjectCostCsv).not.toHaveBeenCalled();
+      expect(rebuildProjectCostCsv).not.toHaveBeenCalled();
     });
 
     it('catches and logs CSV write failures without throwing', async () => {

--- a/adws/__tests__/workflowPhases.test.ts
+++ b/adws/__tests__/workflowPhases.test.ts
@@ -59,7 +59,7 @@ vi.mock('../core', async (importOriginal) => {
       currencies: [{ currency: 'EUR', amount: 1.35, symbol: '€' }],
     }),
     writeIssueCostCsv: vi.fn(),
-    updateProjectCostCsv: vi.fn(),
+    rebuildProjectCostCsv: vi.fn(),
     mergeModelUsageMaps: actual.mergeModelUsageMaps,
     emptyModelUsageMap: actual.emptyModelUsageMap,
     persistTokenCounts: vi.fn(),
@@ -175,7 +175,7 @@ vi.mock('../core/issueClassifier', () => ({
 }));
 
 // Import mocked modules for assertions
-import { shouldExecuteStage, hasUncommittedChanges, getNextStage, AgentStateManager, generateAdwId, writeIssueCostCsv, updateProjectCostCsv } from '../core';
+import { shouldExecuteStage, hasUncommittedChanges, getNextStage, AgentStateManager, generateAdwId, writeIssueCostCsv, rebuildProjectCostCsv } from '../core';
 import {
   fetchPRDetails,
   getUnaddressedComments,
@@ -770,12 +770,9 @@ describe('completeWorkflow', () => {
       config.issue.title,
       expect.any(Object),
     );
-    expect(updateProjectCostCsv).toHaveBeenCalledWith(
+    expect(rebuildProjectCostCsv).toHaveBeenCalledWith(
       '/mock/worktree',
       expect.any(String),
-      config.issueNumber,
-      config.issue.title,
-      expect.any(Number),
       expect.any(Number),
     );
   });
@@ -796,12 +793,9 @@ describe('completeWorkflow', () => {
       config.issue.title,
       expect.any(Object),
     );
-    expect(updateProjectCostCsv).toHaveBeenCalledWith(
+    expect(rebuildProjectCostCsv).toHaveBeenCalledWith(
       process.cwd(),
       expect.any(String),
-      config.issueNumber,
-      config.issue.title,
-      expect.any(Number),
       expect.any(Number),
     );
   });

--- a/adws/core/costCsvWriter.ts
+++ b/adws/core/costCsvWriter.ts
@@ -100,6 +100,14 @@ export function formatProjectCostCsv(rows: ProjectCostRow[], eurRate: number): s
   return lines.join('\n') + '\n';
 }
 
+/** Parses an issue CSV file's content and extracts the Total Cost (USD) value. */
+export function parseIssueCostTotal(csvContent: string): number {
+  const line = csvContent.split('\n').find(l => l.startsWith('Total Cost (USD):,'));
+  if (!line) return 0;
+  const value = parseFloat(line.split(',')[1]);
+  return isNaN(value) ? 0 : value;
+}
+
 /** Writes a per-issue cost CSV file. */
 export function writeIssueCostCsv(
   repoRoot: string,
@@ -117,34 +125,39 @@ export function writeIssueCostCsv(
   log(`Issue cost CSV written: ${relativePath}`, 'success');
 }
 
-/** Updates the project total cost CSV, appending a new row and recalculating totals. */
-export function updateProjectCostCsv(
+/** Rebuilds the project total cost CSV from scratch by scanning all individual issue CSV files. */
+export function rebuildProjectCostCsv(
   repoRoot: string,
   repoName: string,
-  issueNumber: number,
-  issueTitle: string,
-  costUsd: number,
   eurRate: number,
 ): void {
+  const projectDir = path.join(repoRoot, 'projects', repoName);
+  fs.mkdirSync(projectDir, { recursive: true });
+
+  const csvFiles = fs.existsSync(projectDir)
+    ? fs.readdirSync(projectDir).filter(f => f.endsWith('.csv') && f !== 'total-cost.csv')
+    : [];
+
+  const rows: ProjectCostRow[] = csvFiles
+    .map(filename => {
+      const dashIndex = filename.indexOf('-');
+      if (dashIndex === -1) return null;
+
+      const issueNumber = parseInt(filename.substring(0, dashIndex), 10);
+      if (isNaN(issueNumber)) return null;
+
+      const issueDescription = filename.substring(dashIndex + 1).replace(/\.csv$/, '').replace(/-/g, ' ');
+      const content = fs.readFileSync(path.join(projectDir, filename), 'utf-8');
+      const costUsd = parseIssueCostTotal(content);
+
+      return { issueNumber, issueDescription, costUsd, markupUsd: costUsd * 0.1 };
+    })
+    .filter((row): row is ProjectCostRow => row !== null)
+    .sort((a, b) => a.issueNumber - b.issueNumber);
+
   const relativePath = getProjectCsvPath(repoName);
   const fullPath = path.join(repoRoot, relativePath);
+  fs.writeFileSync(fullPath, formatProjectCostCsv(rows, eurRate), 'utf-8');
 
-  fs.mkdirSync(path.dirname(fullPath), { recursive: true });
-
-  let existingRows: ProjectCostRow[] = [];
-  if (fs.existsSync(fullPath)) {
-    const content = fs.readFileSync(fullPath, 'utf-8');
-    existingRows = parseProjectCostCsv(content);
-  }
-
-  existingRows.push({
-    issueNumber,
-    issueDescription: issueTitle,
-    costUsd,
-    markupUsd: costUsd * 0.1,
-  });
-
-  fs.writeFileSync(fullPath, formatProjectCostCsv(existingRows, eurRate), 'utf-8');
-
-  log(`Project cost CSV updated: ${relativePath}`, 'success');
+  log(`Project cost CSV rebuilt: ${relativePath}`, 'success');
 }

--- a/adws/core/index.ts
+++ b/adws/core/index.ts
@@ -99,7 +99,8 @@ export {
   formatProjectCostCsv,
   parseProjectCostCsv,
   writeIssueCostCsv,
-  updateProjectCostCsv,
+  parseIssueCostTotal,
+  rebuildProjectCostCsv,
 } from './costCsvWriter';
 
 // Project configuration

--- a/adws/phases/prReviewPhase.ts
+++ b/adws/phases/prReviewPhase.ts
@@ -4,7 +4,7 @@
 
 import * as fs from 'fs';
 import * as path from 'path';
-import { log, setLogAdwId, ensureLogsDirectory, generateAdwId, type PRDetails, type PRReviewComment, AgentStateManager, type AgentState, MAX_TEST_RETRY_ATTEMPTS, COST_REPORT_CURRENCIES, type ModelUsageMap, buildCostBreakdown, allocateRandomPort, mergeModelUsageMaps, emptyModelUsageMap, persistTokenCounts, writeIssueCostCsv, updateProjectCostCsv } from '../core';
+import { log, setLogAdwId, ensureLogsDirectory, generateAdwId, type PRDetails, type PRReviewComment, AgentStateManager, type AgentState, MAX_TEST_RETRY_ATTEMPTS, COST_REPORT_CURRENCIES, type ModelUsageMap, buildCostBreakdown, allocateRandomPort, mergeModelUsageMaps, emptyModelUsageMap, persistTokenCounts, writeIssueCostCsv, rebuildProjectCostCsv } from '../core';
 import { fetchPRDetails, getUnaddressedComments, pushBranch, postPRWorkflowComment, type PRReviewWorkflowContext, ensureWorktree, inferIssueTypeFromBranch, type RepoInfo } from '../github';
 import { setTargetRepo, getTargetRepo } from '../core/targetRepoRegistry';
 import { getPlanFilePath, runPrReviewPlanAgent, runPrReviewBuildAgent, runCommitAgent, type ProgressCallback, type ProgressInfo, runUnitTestsWithRetry, runE2ETestsWithRetry } from '../agents';
@@ -315,7 +315,7 @@ export async function completePRReviewWorkflow(config: PRReviewWorkflowConfig, m
       const eurRate = eurEntry ? eurEntry.amount / costBreakdown.totalCostUsd : 0;
 
       writeIssueCostCsv(adwRepoRoot, repoName, config.issueNumber, config.prDetails.title, costBreakdown);
-      updateProjectCostCsv(adwRepoRoot, repoName, config.issueNumber, config.prDetails.title, costBreakdown.totalCostUsd, eurRate);
+      rebuildProjectCostCsv(adwRepoRoot, repoName, eurRate);
     } catch (csvError) {
       log(`Failed to write cost CSV files: ${csvError}`, 'error');
     }

--- a/adws/phases/workflowLifecycle.ts
+++ b/adws/phases/workflowLifecycle.ts
@@ -5,7 +5,7 @@
 import * as fs from 'fs';
 import * as path from 'path';
 import { fileURLToPath } from 'node:url';
-import { log, setLogAdwId, ensureLogsDirectory, generateAdwId, type IssueClassSlashCommand, type GitHubIssue, AgentStateManager, type AgentState, type AgentIdentifier, type RecoveryState, hasUncommittedChanges, getNextStage, MAX_REVIEW_RETRY_ATTEMPTS, COST_REPORT_CURRENCIES, type ModelUsageMap, buildCostBreakdown, persistTokenCounts, allocateRandomPort, type TargetRepoInfo, ensureTargetRepoWorkspace, writeIssueCostCsv, updateProjectCostCsv, type ProjectConfig, loadProjectConfig, setTargetRepo } from '../core';
+import { log, setLogAdwId, ensureLogsDirectory, generateAdwId, type IssueClassSlashCommand, type GitHubIssue, AgentStateManager, type AgentState, type AgentIdentifier, type RecoveryState, hasUncommittedChanges, getNextStage, MAX_REVIEW_RETRY_ATTEMPTS, COST_REPORT_CURRENCIES, type ModelUsageMap, buildCostBreakdown, persistTokenCounts, allocateRandomPort, type TargetRepoInfo, ensureTargetRepoWorkspace, writeIssueCostCsv, rebuildProjectCostCsv, type ProjectConfig, loadProjectConfig, setTargetRepo } from '../core';
 import { fetchGitHubIssue, postWorkflowComment, type WorkflowContext, detectRecoveryState, getDefaultBranch, checkoutDefaultBranch, ensureWorktree, getWorktreeForBranch, mergeLatestFromDefaultBranch, copyEnvToWorktree, findWorktreeForIssue, type RepoInfo } from '../github';
 import { runGenerateBranchNameAgent, getPlanFilePath, runReviewWithRetry } from '../agents';
 import { classifyGitHubIssue } from '../core/issueClassifier';
@@ -370,7 +370,7 @@ export async function completeWorkflow(
       const eurRate = eurEntry ? eurEntry.amount / costBreakdown.totalCostUsd : 0;
 
       writeIssueCostCsv(adwRepoRoot, repoName, config.issueNumber, config.issue.title, costBreakdown);
-      updateProjectCostCsv(adwRepoRoot, repoName, config.issueNumber, config.issue.title, costBreakdown.totalCostUsd, eurRate);
+      rebuildProjectCostCsv(adwRepoRoot, repoName, eurRate);
     } catch (csvError) {
       log(`Failed to write cost CSV files: ${csvError}`, 'error');
     }

--- a/specs/issue-60-adw-total-cost-contains-ojlavn-sdlc_planner-fix-total-cost-duplicates.md
+++ b/specs/issue-60-adw-total-cost-contains-ojlavn-sdlc_planner-fix-total-cost-duplicates.md
@@ -1,0 +1,130 @@
+# Bug: Total cost CSV contains duplicate/orphaned rows
+
+## Metadata
+issueNumber: `60`
+adwId: `total-cost-contains-ojlavn`
+issueJson: `{"number":60,"title":"Total cost contains unlinked item lines","body":"The total cost sometimes contains lines that do not correspond with lines in the issue csv. \n\nTo prevent this error from occurring, the total-cost.csv should be deleted and recalculated based on all the issue csv's in the project directory.\n\nSee the following example. \n### 6-set-up-adw-environment.csv\n```\nModel,Input Tokens,Output Tokens,Cache Read,Cache Write,Cost (USD)\nclaude-opus-4-6,45,11896,1190928,26536,1.0589\nclaude-haiku-4-5-20251001,21308,1156,0,0,0.0271\nclaude-sonnet-4-6,22,3906,530753,14183,0.4518\n\nTotal Cost (USD):,1.5378\nTotal Cost (EUR):,1.3030\n```\n\n### total-cost.csv\n```\nIssue number,Issue description,Cost (USD),Markup (10%)\n6,Set up adw environment,1.1719,0.1172\n6,Set up adw environment,1.5378,0.1538\n\nTotal Cost (USD):,2.9807\nTotal Cost (EUR):,2.5255\n```","state":"OPEN","author":"paysdoc","labels":[],"createdAt":"2026-03-03T10:20:21Z","comments":[],"actionableComment":null}`
+
+## Bug Description
+The `total-cost.csv` file accumulates duplicate and orphaned rows over time. When the same issue goes through multiple workflow runs (e.g., build then PR review, or a re-run after failure), `updateProjectCostCsv()` blindly appends a new row each time without checking whether an entry for that issue already exists. This results in multiple rows for the same issue number with different costs, and the totals become inflated.
+
+**Expected behavior:** Each issue should have exactly one row in `total-cost.csv`, reflecting the latest cost from its individual issue CSV file. The total should be the sum of all individual issue CSVs in the project directory.
+
+**Actual behavior:** The same issue number appears multiple times with different cost values (e.g., issue 6 appears twice with costs 1.1719 and 1.5378), and the total is the sum of all duplicate rows.
+
+## Problem Statement
+`updateProjectCostCsv()` in `adws/core/costCsvWriter.ts` reads the existing `total-cost.csv`, appends a new row unconditionally, and writes back. It never checks for existing rows with the same issue number, and it never cross-references the actual issue CSV files on disk. This causes duplicates when an issue goes through multiple workflow phases or re-runs.
+
+## Solution Statement
+Replace the append-based `updateProjectCostCsv()` with a new `rebuildProjectCostCsv()` function that deletes the existing `total-cost.csv` and rebuilds it from scratch by scanning all individual issue CSV files in the project directory. Each issue CSV file is parsed to extract its total cost, and the issue number and description are derived from the filename. This ensures `total-cost.csv` is always an accurate reflection of the issue CSVs on disk, with no duplicates or orphaned entries.
+
+## Steps to Reproduce
+1. Run an ADW workflow on an issue (e.g., issue #6 via `adwPlanBuild.tsx 6`). This writes `6-set-up-adw-environment.csv` and appends a row to `total-cost.csv`.
+2. Run another ADW workflow on the same issue (e.g., PR review via `adwPrReview.tsx`). This overwrites the issue CSV with updated costs but appends a second row to `total-cost.csv`.
+3. Observe `total-cost.csv` now has two rows for issue 6 with different costs.
+
+## Root Cause Analysis
+In `adws/core/costCsvWriter.ts`, the `updateProjectCostCsv()` function (lines 121-150):
+1. Reads the existing `total-cost.csv` and parses its rows via `parseProjectCostCsv()`
+2. **Always pushes** a new `ProjectCostRow` to the array (line 140-145) without checking if a row for the same `issueNumber` already exists
+3. Writes the full array back to disk
+
+Meanwhile, `writeIssueCostCsv()` (lines 104-118) **overwrites** the issue CSV file each time it runs, so the individual issue CSV always has the correct latest cost. But `total-cost.csv` accumulates stale rows.
+
+The callers in `workflowLifecycle.ts:373` and `prReviewPhase.ts:318` both call `updateProjectCostCsv()` after `writeIssueCostCsv()`, so every workflow completion adds another row.
+
+## Relevant Files
+Use these files to fix the bug:
+
+- `adws/core/costCsvWriter.ts` — Contains `updateProjectCostCsv()` (the buggy function), `writeIssueCostCsv()`, `parseProjectCostCsv()`, `formatProjectCostCsv()`, `getProjectCsvPath()`, and `getIssueCsvPath()`. This is the primary file to modify.
+- `adws/phases/workflowLifecycle.ts` — Calls `updateProjectCostCsv()` at line 373 inside `completeWorkflow()`. Must be updated to call the new `rebuildProjectCostCsv()`.
+- `adws/phases/prReviewPhase.ts` — Calls `updateProjectCostCsv()` at line 318 inside `completePRReviewWorkflow()`. Must be updated to call the new `rebuildProjectCostCsv()`.
+- `adws/core/index.ts` — Barrel exports for core module. Must export the new function and remove the old export.
+- `adws/__tests__/costCsvWriter.test.ts` — Unit tests for `costCsvWriter.ts`. Must add tests for the new function and update/remove tests for the old function.
+- `adws/__tests__/workflowPhases.test.ts` — Tests for `completeWorkflow()`. Must update mocks and assertions to use the new function.
+- `adws/__tests__/prReviewCostTracking.test.ts` — Tests for `completePRReviewWorkflow()`. Must update mocks and assertions to use the new function.
+- `adws/core/utils.ts` — Contains `slugify()`. Read-only reference to understand how issue CSV filenames are generated.
+- `guidelines/coding_guidelines.md` — Coding guidelines to follow strictly.
+
+## Step by Step Tasks
+IMPORTANT: Execute every step in order, top to bottom.
+
+### 1. Add `parseIssueCostTotal()` helper to `costCsvWriter.ts`
+- Add a new exported function `parseIssueCostTotal(csvContent: string): number` that parses an issue CSV file's content and extracts the `Total Cost (USD)` value
+- Find the line starting with `Total Cost (USD):,` and parse the number after the comma
+- Return `0` if the line is not found or the value cannot be parsed
+
+### 2. Add `rebuildProjectCostCsv()` function to `costCsvWriter.ts`
+- Add a new exported function `rebuildProjectCostCsv(repoRoot: string, repoName: string, eurRate: number): void`
+- Compute the project directory path: `path.join(repoRoot, 'projects', repoName)`
+- List all `.csv` files in the project directory using `fs.readdirSync()`
+- Filter out `total-cost.csv` from the list
+- For each remaining CSV file:
+  - Extract the issue number from the filename: parse the digits before the first `-` character (e.g., `6` from `6-set-up-adw-environment.csv`). Skip files where the prefix is not a valid number (e.g., files that don't follow the `{number}-{slug}.csv` pattern)
+  - Extract the issue description: take the part after the first `-` and before `.csv`, replace all `-` with spaces (e.g., `set up adw environment`)
+  - Read the file content and call `parseIssueCostTotal()` to get the cost
+  - Create a `ProjectCostRow` with the extracted data and `markupUsd: costUsd * 0.1`
+- Sort the rows by `issueNumber` ascending for consistent output
+- Write the file using `formatProjectCostCsv(rows, eurRate)` to the `total-cost.csv` path
+- Log a success message
+
+### 3. Remove `updateProjectCostCsv()` from `costCsvWriter.ts`
+- Delete the entire `updateProjectCostCsv()` function (lines 121-150)
+- It is no longer needed since `rebuildProjectCostCsv()` replaces its functionality
+
+### 4. Update barrel exports in `core/index.ts`
+- Replace the export of `updateProjectCostCsv` with `rebuildProjectCostCsv` and `parseIssueCostTotal`
+- Remove `updateProjectCostCsv` from the export list
+
+### 5. Update caller in `workflowLifecycle.ts`
+- Update the import to use `rebuildProjectCostCsv` instead of `updateProjectCostCsv`
+- Replace line 373: `updateProjectCostCsv(adwRepoRoot, repoName, config.issueNumber, config.issue.title, costBreakdown.totalCostUsd, eurRate)` with `rebuildProjectCostCsv(adwRepoRoot, repoName, eurRate)`
+
+### 6. Update caller in `prReviewPhase.ts`
+- Update the import to use `rebuildProjectCostCsv` instead of `updateProjectCostCsv`
+- Replace line 318: `updateProjectCostCsv(adwRepoRoot, repoName, config.issueNumber, config.prDetails.title, costBreakdown.totalCostUsd, eurRate)` with `rebuildProjectCostCsv(adwRepoRoot, repoName, eurRate)`
+
+### 7. Update unit tests in `costCsvWriter.test.ts`
+- Add tests for `parseIssueCostTotal()`:
+  - Parses valid issue CSV content and returns the correct total
+  - Returns `0` for content without a `Total Cost (USD)` line
+  - Returns `0` for empty content
+- Add tests for `rebuildProjectCostCsv()`:
+  - Rebuilds correctly from multiple issue CSV files, producing one row per file with correct totals
+  - Handles the case where the project directory does not exist (should create it and produce an empty CSV or handle gracefully)
+  - Skips `total-cost.csv` when scanning files
+  - Skips files that don't follow the `{number}-{slug}.csv` naming pattern
+  - Sorts rows by issue number ascending
+  - Correctly handles re-running: write issue CSVs, rebuild, overwrite an issue CSV with new cost, rebuild again — verify the row reflects the latest cost with no duplicates
+- Remove or update the existing `updateProjectCostCsv` tests:
+  - Remove the three existing tests (`creates new CSV when none exists`, `appends to existing CSV and updates totals`, `handles multiple sequential updates correctly`) since the function is being deleted
+
+### 8. Update test mocks in `workflowPhases.test.ts`
+- Replace `updateProjectCostCsv: vi.fn()` with `rebuildProjectCostCsv: vi.fn()` in the mock setup
+- Update the import to use `rebuildProjectCostCsv` instead of `updateProjectCostCsv`
+- Update assertions that check `updateProjectCostCsv` was called: change to verify `rebuildProjectCostCsv` is called with `(adwRepoRoot, repoName, eurRate)` — note the simplified signature (no issueNumber, issueTitle, or costUsd params)
+
+### 9. Update test mocks in `prReviewCostTracking.test.ts`
+- Replace `updateProjectCostCsv: vi.fn()` with `rebuildProjectCostCsv: vi.fn()` in the mock setup
+- Update the import to use `rebuildProjectCostCsv` instead of `updateProjectCostCsv`
+- Update assertions that check `updateProjectCostCsv` was called: change to verify `rebuildProjectCostCsv` is called with `(adwRepoRoot, repoName, eurRate)`
+- Update negative assertions (where `updateProjectCostCsv` should not have been called) to check `rebuildProjectCostCsv` instead
+
+### 10. Run validation commands
+- Execute all validation commands listed below to confirm the fix works with zero regressions.
+
+## Validation Commands
+Execute every command to validate the bug is fixed with zero regressions.
+
+- `npm test` — Run all unit tests to validate the new `rebuildProjectCostCsv()` function works correctly and all existing tests pass
+- `npm run lint` — Run linter to check for code quality issues
+- `npx tsc --noEmit` — Type check the Next.js project
+- `npx tsc --noEmit -p adws/tsconfig.json` — Type check the ADW scripts project
+- `npm run build` — Build the application to verify no build errors
+
+## Notes
+- The `guidelines/coding_guidelines.md` must be strictly followed: pure functions, immutability, strict TypeScript, functional programming patterns (map/filter/reduce over for loops).
+- The issue description derived from the filename is lossy (lowercase, truncated at 50 chars by `slugify()`), but this is acceptable since the description is only used for display in the total-cost CSV.
+- Files prefixed with `0-` (e.g., `0-bug-52-issue-classifier-running-on-incorrect-repo.csv`) should be handled correctly — the issue number `0` is valid.
+- The `eurRate` is still needed by the callers and passed through to `rebuildProjectCostCsv()`. The rate comes from the exchange rate API at workflow completion time.
+- No new libraries are needed for this fix.


### PR DESCRIPTION
## Summary

Fixes an issue where `total-cost.csv` contained duplicate or unlinked lines that did not correspond to entries in the individual issue CSV files. The root cause was that cost entries were being appended to `total-cost.csv` without first checking for existing entries for the same issue, causing duplicates on repeated runs.

### Solution

Rebuild `total-cost.csv` from scratch on every write by reading all individual issue CSV files from the project directory and recalculating totals. This ensures the total cost file always reflects the actual state of the issue CSV files.

## Plan

See implementation spec: `specs/issue-60-adw-total-cost-contains-ojlavn-sdlc_planner-fix-total-cost-duplicates.md`

## Changes

- **`adws/core/costCsvWriter.ts`**: Refactored to rebuild `total-cost.csv` from all issue CSV files instead of appending entries; added logic to scan project directory for issue CSVs and aggregate costs
- **`adws/core/index.ts`**: Updated exports to expose new utility functions
- **`adws/phases/prReviewPhase.ts`**: Updated to use revised cost writer API
- **`adws/phases/workflowLifecycle.ts`**: Updated to use revised cost writer API
- **`adws/__tests__/costCsvWriter.test.ts`**: Added comprehensive tests for duplicate prevention, rebuild logic, and multi-issue aggregation
- **`adws/__tests__/prReviewCostTracking.test.ts`**: Updated tests to match new API
- **`adws/__tests__/workflowPhases.test.ts`**: Updated tests to match new API
- **`specs/issue-60-adw-total-cost-contains-ojlavn-sdlc_planner-fix-total-cost-duplicates.md`**: Implementation specification

## Checklist

- [x] Root cause identified: appending without deduplication
- [x] `total-cost.csv` now rebuilt from all issue CSV files on each update
- [x] Unit tests updated and passing
- [x] No duplicate entries possible after fix

Closes #60

ADW ID: total-cost-contains-ojlavn