### PR TITLE
bug: #71 - prAgent passes args as string

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,7 +105,7 @@ npm run test:watch    # Run tests in watch mode
 │       └── constants.ts
 └── settings.json
 adws/                   # ADW workflow system
-├── __tests__/          # Unit tests (47 test files)
+├── __tests__/          # Unit tests (54 test files)
 ├── agents/             # Claude Code agent runners
 │   ├── buildAgent.ts
 │   ├── claudeAgent.ts
@@ -150,6 +150,7 @@ adws/                   # ADW workflow system
 │   ├── issueApi.ts
 │   ├── prApi.ts
 │   ├── prCommentDetector.ts
+│   ├── projectBoardApi.ts
 │   ├── pullRequestCreator.ts
 │   ├── workflowComments.ts
 │   ├── workflowCommentsBase.ts
@@ -170,7 +171,8 @@ adws/                   # ADW workflow system
 ├── triggers/           # Automation triggers
 │   ├── trigger_cron.ts
 │   ├── trigger_webhook.ts
-│   └── webhookHandlers.ts
+│   ├── webhookHandlers.ts
+│   └── webhookSignature.ts
 ├── adwBuild.tsx        # Orchestrators (individual & combined)
 ├── adwBuildHelpers.ts
 ├── adwClearComments.tsx

--- a/adws/__tests__/gitAgent.test.ts
+++ b/adws/__tests__/gitAgent.test.ts
@@ -45,18 +45,16 @@ function createMockIssue(overrides: Partial<GitHubIssue> = {}): GitHubIssue {
 }
 
 describe('formatBranchNameArgs', () => {
-  it('includes issueClass and issue JSON', () => {
+  it('returns array with issueClass and issue JSON', () => {
     const issue = createMockIssue();
     const result = formatBranchNameArgs('/feature', issue);
 
-    expect(result).toContain('issueClass: /feature');
-    expect(result).toContain('"number":123');
-    expect(result).toContain('"title":"Add user authentication"');
+    expect(result).toEqual(['/feature', JSON.stringify(issue)]);
   });
 
   it('does not include adwId', () => {
     const result = formatBranchNameArgs('/feature', createMockIssue());
-    expect(result).not.toContain('adwId');
+    expect(result.join(' ')).not.toContain('adwId');
   });
 
   it('handles different issue classes', () => {
@@ -64,7 +62,7 @@ describe('formatBranchNameArgs', () => {
 
     for (const issueClass of issueClasses) {
       const result = formatBranchNameArgs(issueClass, createMockIssue());
-      expect(result).toContain(`issueClass: ${issueClass}`);
+      expect(result[0]).toBe(issueClass);
     }
   });
 });
@@ -158,12 +156,10 @@ describe('validateBranchName', () => {
 });
 
 describe('formatCommitArgs', () => {
-  it('includes agentName, issueClass, and issue context', () => {
+  it('returns array with agentName, issueClass, and issue context', () => {
     const result = formatCommitArgs('plan-orchestrator', '/feature', '{"number":123}');
 
-    expect(result).toContain('agentName: plan-orchestrator');
-    expect(result).toContain('issueClass: /feature');
-    expect(result).toContain('issue: {"number":123}');
+    expect(result).toEqual(['plan-orchestrator', '/feature', '{"number":123}']);
   });
 
   it('handles different agent names', () => {
@@ -171,7 +167,7 @@ describe('formatCommitArgs', () => {
 
     for (const agent of agents) {
       const result = formatCommitArgs(agent, '/bug', '{}');
-      expect(result).toContain(`agentName: ${agent}`);
+      expect(result[0]).toBe(agent);
     }
   });
 });
@@ -215,7 +211,7 @@ describe('runGenerateBranchNameAgent', () => {
 
     expect(runClaudeAgentWithCommand).toHaveBeenCalledWith(
       '/generate_branch_name',
-      expect.stringContaining('issueClass: /feature'),
+      expect.arrayContaining(['/feature']),
       'Branch Name',
       expect.stringContaining('branchName-agent.jsonl'),
       'sonnet',
@@ -267,7 +263,7 @@ describe('runCommitAgent', () => {
 
     expect(runClaudeAgentWithCommand).toHaveBeenCalledWith(
       '/commit',
-      expect.stringContaining('agentName: plan-orchestrator'),
+      ['plan-orchestrator', '/feature', '{"number":123}'],
       'Commit',
       expect.stringContaining('commit-agent.jsonl'),
       'sonnet',

--- a/adws/__tests__/patchAgent.test.ts
+++ b/adws/__tests__/patchAgent.test.ts
@@ -36,31 +36,29 @@ describe('formatPatchArgs', () => {
     const issue = createReviewIssue();
     const result = formatPatchArgs('adw-123', issue, '/specs/plan.md', '/screenshots/issue.png');
 
-    expect(result).toContain('adw-123');
-    expect(result).toContain('Issue #1: Button color is wrong');
-    expect(result).toContain('Resolution: Change button color to blue');
-    expect(result).toContain('/specs/plan.md');
-    expect(result).toContain('/screenshots/issue.png');
+    expect(result[0]).toBe('adw-123');
+    expect(result[1]).toContain('Issue #1: Button color is wrong');
+    expect(result[1]).toContain('Resolution: Change button color to blue');
+    expect(result[2]).toBe('/specs/plan.md');
+    expect(result[3]).toBe('patchAgent');
+    expect(result[4]).toBe('/screenshots/issue.png');
   });
 
   it('handles optional parameters gracefully', () => {
     const issue = createReviewIssue();
     const result = formatPatchArgs('adw-456', issue);
 
-    expect(result).toContain('adw-456');
-    expect(result).toContain('Issue #1');
-    // Spec path and screenshots should be empty
-    const lines = result.split('\n');
-    // Line 0: adwId, Line 1: issue desc, Line 2: resolution, Line 3: spec_path, Line 4: agent_name, Line 5: screenshots
-    expect(lines[3]).toBe(''); // spec_path empty
-    expect(lines[5]).toBe(''); // screenshots empty
+    expect(result[0]).toBe('adw-456');
+    expect(result[1]).toContain('Issue #1');
+    expect(result[2]).toBe(''); // spec_path empty
+    expect(result[4]).toBe(''); // screenshots empty
   });
 
   it('formats with different issue numbers', () => {
     const issue = createReviewIssue({ reviewIssueNumber: 5 });
     const result = formatPatchArgs('adw-789', issue);
 
-    expect(result).toContain('Issue #5');
+    expect(result[1]).toContain('Issue #5');
   });
 });
 
@@ -75,7 +73,7 @@ describe('runPatchAgent', () => {
 
     expect(runClaudeAgentWithCommand).toHaveBeenCalledWith(
       '/patch',
-      expect.stringContaining('adw-123'),
+      expect.arrayContaining(['adw-123']),
       'Patch: 1',
       expect.stringContaining('patch-agent-issue-1.jsonl'),
       'opus',
@@ -91,7 +89,7 @@ describe('runPatchAgent', () => {
 
     expect(runClaudeAgentWithCommand).toHaveBeenCalledWith(
       '/patch',
-      expect.any(String),
+      expect.any(Array),
       'Patch: 1',
       expect.any(String),
       'opus',
@@ -105,15 +103,15 @@ describe('runPatchAgent', () => {
     const issue = createReviewIssue();
     await runPatchAgent('adw-123', issue, '/logs', '/specs/plan.md');
 
-    const args = vi.mocked(runClaudeAgentWithCommand).mock.calls[0][1];
-    expect(args).toContain('/specs/plan.md');
+    const args = vi.mocked(runClaudeAgentWithCommand).mock.calls[0][1] as string[];
+    expect(args[2]).toBe('/specs/plan.md');
   });
 
   it('uses issue screenshotPath as screenshots arg', async () => {
     const issue = createReviewIssue({ screenshotPath: '/img/blocker.png' });
     await runPatchAgent('adw-123', issue, '/logs');
 
-    const args = vi.mocked(runClaudeAgentWithCommand).mock.calls[0][1];
-    expect(args).toContain('/img/blocker.png');
+    const args = vi.mocked(runClaudeAgentWithCommand).mock.calls[0][1] as string[];
+    expect(args[4]).toBe('/img/blocker.png');
   });
 });

--- a/adws/__tests__/prAgent.test.ts
+++ b/adws/__tests__/prAgent.test.ts
@@ -25,7 +25,7 @@ import { runClaudeAgentWithCommand } from '../agents/claudeAgent';
 import { getDefaultBranch } from '../github/gitOperations';
 
 describe('formatPullRequestArgs', () => {
-  it('returns 5-value newline-separated string including defaultBranch', () => {
+  it('returns an array of 5 elements with correct values', () => {
     const result = formatPullRequestArgs(
       'feature/issue-62-fix-pr',
       '{"number":62}',
@@ -34,20 +34,18 @@ describe('formatPullRequestArgs', () => {
       'stage-3',
     );
 
-    const lines = result.split('\n');
-    expect(lines).toHaveLength(5);
-    expect(lines[0]).toBe('feature/issue-62-fix-pr');
-    expect(lines[1]).toBe('{"number":62}');
-    expect(lines[2]).toBe('/specs/plan.md');
-    expect(lines[3]).toBe('adw-123');
-    expect(lines[4]).toBe('stage-3');
+    expect(result).toHaveLength(5);
+    expect(result[0]).toBe('feature/issue-62-fix-pr');
+    expect(result[1]).toBe('{"number":62}');
+    expect(result[2]).toBe('/specs/plan.md');
+    expect(result[3]).toBe('adw-123');
+    expect(result[4]).toBe('stage-3');
   });
 
-  it('includes the default branch as the 5th value', () => {
+  it('includes the default branch as the 5th element', () => {
     const result = formatPullRequestArgs('branch', '{}', '/plan.md', 'id', 'main');
 
-    expect(result).toContain('main');
-    expect(result.split('\n')[4]).toBe('main');
+    expect(result[4]).toBe('main');
   });
 });
 
@@ -85,9 +83,8 @@ describe('runPullRequestAgent', () => {
       '/logs',
     );
 
-    const args = vi.mocked(runClaudeAgentWithCommand).mock.calls[0][1] as string;
-    const lines = args.split('\n');
-    expect(lines[4]).toBe('stage-3');
+    const args = vi.mocked(runClaudeAgentWithCommand).mock.calls[0][1] as string[];
+    expect(args[4]).toBe('stage-3');
   });
 
   it('calls getDefaultBranch with undefined when cwd is not provided', async () => {

--- a/adws/__tests__/reviewAgent.test.ts
+++ b/adws/__tests__/reviewAgent.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { runReviewAgent, ReviewIssue, ReviewResult } from '../agents/reviewAgent';
+import { runReviewAgent, formatReviewArgs, ReviewIssue, ReviewResult } from '../agents/reviewAgent';
 import { extractJson } from '../core/jsonParser';
 
 vi.mock('../agents/claudeAgent', () => ({
@@ -105,7 +105,7 @@ describe('runReviewAgent', () => {
 
     expect(runClaudeAgentWithCommand).toHaveBeenCalledWith(
       '/review',
-      'adw-123\nspecs/issue-1-plan.md\nreview_agent',
+      ['adw-123', 'specs/issue-1-plan.md', 'review_agent'],
       'Review',
       expect.stringContaining('review-agent.jsonl'),
       'opus',
@@ -183,7 +183,7 @@ describe('runReviewAgent', () => {
 
     expect(runClaudeAgentWithCommand).toHaveBeenCalledWith(
       '/review',
-      expect.any(String),
+      expect.any(Array),
       'Review',
       expect.any(String),
       'opus',
@@ -204,7 +204,7 @@ describe('runReviewAgent', () => {
 
     expect(runClaudeAgentWithCommand).toHaveBeenCalledWith(
       '/review',
-      'adw-123\nspecs/plan.md\nreview_agent\nhttp://localhost:45678',
+      ['adw-123', 'specs/plan.md', 'review_agent', 'http://localhost:45678'],
       'Review',
       expect.any(String),
       'opus',
@@ -225,7 +225,7 @@ describe('runReviewAgent', () => {
 
     expect(runClaudeAgentWithCommand).toHaveBeenCalledWith(
       '/review',
-      'adw-123\nspecs/plan.md\nreview_agent',
+      ['adw-123', 'specs/plan.md', 'review_agent'],
       'Review',
       expect.any(String),
       'opus',
@@ -233,5 +233,22 @@ describe('runReviewAgent', () => {
       undefined,
       undefined
     );
+  });
+});
+
+describe('formatReviewArgs', () => {
+  it('returns array with adwId, specFile, and agentName', () => {
+    const result = formatReviewArgs('adw-123', 'specs/plan.md', 'review_agent');
+    expect(result).toEqual(['adw-123', 'specs/plan.md', 'review_agent']);
+  });
+
+  it('includes applicationUrl as 4th element when provided', () => {
+    const result = formatReviewArgs('adw-123', 'specs/plan.md', 'review_agent', 'http://localhost:45678');
+    expect(result).toEqual(['adw-123', 'specs/plan.md', 'review_agent', 'http://localhost:45678']);
+  });
+
+  it('omits applicationUrl when not provided', () => {
+    const result = formatReviewArgs('adw-123', 'specs/plan.md', 'review_agent');
+    expect(result).toHaveLength(3);
   });
 });

--- a/adws/adwInit.tsx
+++ b/adws/adwInit.tsx
@@ -113,7 +113,7 @@ async function main(): Promise<void> {
 
     const result = await runClaudeAgentWithCommand(
       '/adw_init',
-      `${config.issueNumber} ${config.adwId} ${issueJson}`,
+      [String(config.issueNumber), config.adwId, issueJson],
       'adw-init',
       `${config.logsDir}/adw-init.jsonl`,
       'sonnet',

--- a/adws/agents/documentAgent.ts
+++ b/adws/agents/documentAgent.ts
@@ -14,8 +14,8 @@ export function formatDocumentArgs(
   adwId: string,
   specPath?: string,
   screenshotsDir?: string,
-): string {
-  return `${adwId}\n${specPath ?? ''}\n${screenshotsDir ?? ''}`;
+): string[] {
+  return [adwId, specPath ?? '', screenshotsDir ?? ''];
 }
 
 /**

--- a/adws/agents/gitAgent.ts
+++ b/adws/agents/gitAgent.ts
@@ -13,9 +13,8 @@ import { runClaudeAgentWithCommand, AgentResult } from './claudeAgent';
 export function formatBranchNameArgs(
   issueClass: IssueClassSlashCommand,
   issue: GitHubIssue
-): string {
-  return `issueClass: ${issueClass}
-issue: ${JSON.stringify(issue)}`;
+): string[] {
+  return [issueClass, JSON.stringify(issue)];
 }
 
 /**
@@ -99,10 +98,8 @@ export function formatCommitArgs(
   agentName: string,
   issueClass: string,
   issueContext: string
-): string {
-  return `agentName: ${agentName}
-issueClass: ${issueClass}
-issue: ${issueContext}`;
+): string[] {
+  return [agentName, issueClass, issueContext];
 }
 
 /**

--- a/adws/agents/patchAgent.ts
+++ b/adws/agents/patchAgent.ts
@@ -17,9 +17,9 @@ export function formatPatchArgs(
   reviewIssue: ReviewIssue,
   specPath?: string,
   screenshots?: string,
-): string {
+): string[] {
   const reviewChangeRequest = `Issue #${reviewIssue.reviewIssueNumber}: ${reviewIssue.issueDescription}\nResolution: ${reviewIssue.issueResolution}`;
-  return `${adwId}\n${reviewChangeRequest}\n${specPath ?? ''}\npatchAgent\n${screenshots ?? ''}`;
+  return [adwId, reviewChangeRequest, specPath ?? '', 'patchAgent', screenshots ?? ''];
 }
 
 /**

--- a/adws/agents/prAgent.ts
+++ b/adws/agents/prAgent.ts
@@ -17,8 +17,8 @@ export function formatPullRequestArgs(
   planFile: string,
   adwId: string,
   defaultBranch: string,
-): string {
-  return `${branchName}\n${issueJson}\n${planFile}\n${adwId}\n${defaultBranch}`;
+): string[] {
+  return [branchName, issueJson, planFile, adwId, defaultBranch];
 }
 
 /**

--- a/adws/agents/reviewAgent.ts
+++ b/adws/agents/reviewAgent.ts
@@ -44,6 +44,20 @@ export interface ReviewAgentResult extends AgentResult {
 }
 
 /**
+ * Formats structured args for the /review skill.
+ */
+export function formatReviewArgs(
+  adwId: string,
+  specFile: string,
+  agentName: string,
+  applicationUrl?: string,
+): string[] {
+  return applicationUrl
+    ? [adwId, specFile, agentName, applicationUrl]
+    : [adwId, specFile, agentName];
+}
+
+/**
  * Runs the /review command and returns parsed review results.
  * Uses 'opus' model for complex reasoning.
  *
@@ -66,10 +80,7 @@ export async function runReviewAgent(
   const agentName = 'review_agent';
   const outputFile = path.join(logsDir, 'review-agent.jsonl');
 
-  // Format args as: adwId\nspec_file\nagent_name[\napplicationUrl]
-  const args = applicationUrl
-    ? `${adwId}\n${specFile}\n${agentName}\n${applicationUrl}`
-    : `${adwId}\n${specFile}\n${agentName}`;
+  const args = formatReviewArgs(adwId, specFile, agentName, applicationUrl);
 
   const result = await runClaudeAgentWithCommand(
     '/review',

--- a/specs/issue-71-adw-pragent-passes-args-vrcjoy-sdlc_planner-fix-pr-agent-args-array.md
+++ b/specs/issue-71-adw-pragent-passes-args-vrcjoy-sdlc_planner-fix-pr-agent-args-array.md
@@ -1,0 +1,75 @@
+# Bug: prAgent passes args as string instead of array
+
+## Metadata
+issueNumber: `71`
+adwId: `pragent-passes-args-vrcjoy`
+issueJson: `{"number":71,"title":"prAgent passes args as string","body":"function formatPullRequestArgs formats the arguments as a string. This leads the ``/pull_request``` command to misinterpret the arguments. The args should be offered as an array.","state":"OPEN","author":"paysdoc","labels":[],"createdAt":"2026-03-05T12:21:55Z","comments":[],"actionableComment":null}`
+
+## Bug Description
+The `formatPullRequestArgs` function in `adws/agents/prAgent.ts` returns a single newline-separated string containing all 5 arguments (branchName, issueJson, planFile, adwId, defaultBranch). When this string is passed to `runClaudeAgentWithCommand`, it is treated as a single argument and wrapped in a single pair of quotes. This means the `/pull_request` slash command receives the entire string as `$ARGUMENTS` (or `$1`), and variables `$2` through `$5` are empty.
+
+**Expected behavior:** Each argument should be passed as a separate positional argument so the `/pull_request` command can access them as `$1`, `$2`, `$3`, `$4`, `$5`.
+
+**Actual behavior:** All arguments are concatenated into one newline-separated string and passed as a single argument.
+
+## Problem Statement
+`formatPullRequestArgs` returns a `string` instead of a `string[]`, causing `runClaudeAgentWithCommand` to treat all 5 values as one argument rather than 5 separate positional arguments.
+
+## Solution Statement
+Change `formatPullRequestArgs` to return a `string[]` (array of strings) instead of a single newline-separated `string`. This aligns with how `runClaudeAgentWithCommand` handles array args — each element becomes a separate single-quoted positional argument ($1, $2, $3, etc.). This pattern is already used by `planAgent.ts` (line 271).
+
+## Steps to Reproduce
+1. Run any ADW workflow that reaches the PR phase (e.g., `npx tsx adws/adwPlanBuild.tsx <issue>`)
+2. Observe that `formatPullRequestArgs` returns a newline-separated string
+3. `runClaudeAgentWithCommand` wraps the entire string in single quotes as one argument
+4. The `/pull_request` command receives `$1` = entire multi-line string, `$2`–`$5` = empty
+
+## Root Cause Analysis
+In `adws/agents/prAgent.ts`, `formatPullRequestArgs` (line 14–22) joins arguments with `\n` and returns a `string`. The `runClaudeAgentWithCommand` function (in `claudeAgent.ts`, line 302–306) handles strings by wrapping them in a single set of quotes, meaning the entire multi-line string becomes one CLI argument. When the slash command template tries to access `$1`, `$2`, etc., only `$1` contains data (the full concatenated string) and all other variables are empty.
+
+The fix is straightforward: return an array so each value maps to its own positional argument, matching the pattern used by other agents like `planAgent.ts`.
+
+## Relevant Files
+Use these files to fix the bug:
+
+- `adws/agents/prAgent.ts` — Contains `formatPullRequestArgs` which needs to return `string[]` instead of `string`. This is the primary file to fix.
+- `adws/__tests__/prAgent.test.ts` — Contains tests for `formatPullRequestArgs` and `runPullRequestAgent` that need to be updated to expect an array return type.
+- `adws/agents/claudeAgent.ts` — Contains `runClaudeAgentWithCommand` which already supports `string | readonly string[]` args. No changes needed, but useful for understanding the fix.
+- `guidelines/coding_guidelines.md` — Coding guidelines to follow.
+
+## Step by Step Tasks
+IMPORTANT: Execute every step in order, top to bottom.
+
+### 1. Update `formatPullRequestArgs` to return a `string[]`
+
+- In `adws/agents/prAgent.ts`, change the return type of `formatPullRequestArgs` from `string` to `string[]`
+- Replace the newline-concatenated return statement with an array literal:
+  ```ts
+  return [branchName, issueJson, planFile, adwId, defaultBranch];
+  ```
+
+### 2. Update tests in `adws/__tests__/prAgent.test.ts`
+
+- Update the `formatPullRequestArgs` test suite:
+  - Change the first test ("returns 5-value newline-separated string including defaultBranch") to verify the function returns an array of 5 elements with correct values at each index
+  - Change the second test ("includes the default branch as the 5th value") to verify the array's 5th element (index 4) is the default branch
+- Update the `runPullRequestAgent` test ("includes resolved default branch in args passed to agent"):
+  - Change the assertion to treat `args` as a `string[]` instead of splitting by newlines
+  - Verify `args[4]` equals `'stage-3'`
+
+### 3. Run validation commands
+
+- Run all validation commands listed below to confirm the fix works with zero regressions.
+
+## Validation Commands
+Execute every command to validate the bug is fixed with zero regressions.
+
+- `npx tsc --noEmit -p adws/tsconfig.json` — Type-check the adws project to verify the return type change compiles correctly
+- `npm test` — Run all tests to validate the fix and ensure zero regressions
+- `npm run lint` — Run linter to check for code quality issues
+- `npm run build` — Build the application to verify no build errors
+
+## Notes
+- The `guidelines/coding_guidelines.md` coding guidelines are followed: the fix uses immutability (returning a new array), type safety (changing the return type), and clarity (array literal is more explicit than string concatenation).
+- This fix follows the existing pattern in `planAgent.ts` (line 271) which already passes args as an array: `const args = [String(issue.number), adwId || 'adw-unknown', issueJson];`
+- No new libraries are required.

--- a/specs/issue-71-plan.md
+++ b/specs/issue-71-plan.md
@@ -1,0 +1,107 @@
+# PR-Review: Consistent argument formatting across all agents
+
+## PR-Review Description
+The PR review identified that fixing `prAgent` to return an array created an inconsistency across agents. Some agents format args as arrays (positional `$1`, `$2`, etc.) while others use newline-separated or markdown-formatted strings. The reviewer requests a consistent approach across all agents: adwInit, buildAgent, documentAgent, gitAgent, patchAgent, planAgent, prAgent, reviewAgent, testAgent, and issueClassifier.
+
+## Summary of Original Implementation Plan
+The original plan (`specs/issue-71-adw-pragent-passes-args-vrcjoy-sdlc_planner-fix-pr-agent-args-array.md`) fixed `formatPullRequestArgs` in `prAgent.ts` to return `string[]` instead of a newline-separated `string`. This ensured the `/pull_request` slash command received 5 separate positional arguments (`$1`–`$5`) instead of one concatenated string. Tests were updated accordingly.
+
+## Relevant Files
+Use these files to resolve the review:
+
+- `adws/agents/claudeAgent.ts` — Contains `runClaudeAgentWithCommand` which accepts `string | readonly string[]`. Understanding the escaping behavior is key: strings become a single quoted arg, arrays become multiple quoted args. No changes needed.
+- `adws/agents/prAgent.ts` — Already returns `string[]`. No changes needed (already consistent).
+- `adws/agents/planAgent.ts` — Already passes `string[]` inline at line 271. No changes needed.
+- `adws/agents/buildAgent.ts` — `formatImplementArgs` and `formatPrReviewImplementArgs` return `string`. The `/implement` command uses `$ARGUMENTS` (single blob), so string is correct. No changes needed.
+- `adws/agents/documentAgent.ts` — `formatDocumentArgs` returns newline-separated `string` but `/document` uses positional `$1`, `$2`, `$3`. Must convert to `string[]`.
+- `adws/agents/gitAgent.ts` — `formatBranchNameArgs` returns a multi-line string but `/generate_branch_name` uses `$1`, `$2`. Must convert to `string[]`. `formatCommitArgs` returns a multi-line string but `/commit` uses `$1`, `$2`, `$3`. Must convert to `string[]`.
+- `adws/agents/patchAgent.ts` — `formatPatchArgs` returns newline-separated `string` but `/patch` uses `$1`–`$5`. Must convert to `string[]`.
+- `adws/agents/reviewAgent.ts` — Args built inline as newline-separated `string` but `/review` uses `$1`–`$4`. Must convert to `string[]` via a new `formatReviewArgs` function.
+- `adws/agents/testAgent.ts` — `runTestAgent` passes empty string (no args needed). `runResolveTestAgent` and `runResolveE2ETestAgent` pass JSON strings for `/resolve_failed_test` and `/resolve_failed_e2e_test` which use `$ARGUMENTS`. String is correct. No changes needed.
+- `adws/core/issueClassifier.ts` — Passes a string to `/classify_issue` which uses `$ARGUMENTS`. String is correct. No changes needed.
+- `adws/adwInit.tsx` — Passes space-separated string to `/adw_init` which uses `$1`, `$2`, `$3`. Must convert to `string[]`.
+- `adws/__tests__/documentAgent.test.ts` — Tests for `formatDocumentArgs` must be updated for array format.
+- `adws/__tests__/gitAgent.test.ts` — Tests for `formatBranchNameArgs` and `formatCommitArgs` must be updated for array format.
+- `adws/__tests__/patchAgent.test.ts` — Tests for `formatPatchArgs` must be updated for array format.
+- `adws/__tests__/reviewAgent.test.ts` — Tests must be updated for array format args.
+- `adws/__tests__/adwInit.test.ts` — Tests for adwInit args must be updated for array format (if this file exists).
+- `guidelines/coding_guidelines.md` — Coding guidelines to follow.
+
+## Step by Step Tasks
+IMPORTANT: Execute every step in order, top to bottom.
+
+### 1. Update `formatDocumentArgs` in `adws/agents/documentAgent.ts` to return `string[]`
+
+- Change return type from `string` to `string[]`
+- Change the return statement from `return \`${adwId}\n${specPath ?? ''}\n${screenshotsDir ?? ''}\`` to `return [adwId, specPath ?? '', screenshotsDir ?? '']`
+
+### 2. Update `formatBranchNameArgs` in `adws/agents/gitAgent.ts` to return `string[]`
+
+- Change return type from `string` to `string[]`
+- Change the return statement from the multi-line template literal to `return [issueClass, JSON.stringify(issue)]`
+
+### 3. Update `formatCommitArgs` in `adws/agents/gitAgent.ts` to return `string[]`
+
+- Change return type from `string` to `string[]`
+- Change the return statement from the multi-line template literal to `return [agentName, issueClass, issueContext]`
+
+### 4. Update `formatPatchArgs` in `adws/agents/patchAgent.ts` to return `string[]`
+
+- Change return type from `string` to `string[]`
+- Keep the `reviewChangeRequest` variable construction as-is
+- Change the return statement from the newline-separated string to `return [adwId, reviewChangeRequest, specPath ?? '', 'patchAgent', screenshots ?? '']`
+
+### 5. Extract `formatReviewArgs` in `adws/agents/reviewAgent.ts` and return `string[]`
+
+- Create a new exported function `formatReviewArgs(adwId: string, specFile: string, agentName: string, applicationUrl?: string): string[]`
+- Return `applicationUrl ? [adwId, specFile, agentName, applicationUrl] : [adwId, specFile, agentName]`
+- Update `runReviewAgent` to call `formatReviewArgs(adwId, specFile, agentName, applicationUrl)` instead of building the string inline
+
+### 6. Update `adws/adwInit.tsx` to pass args as `string[]`
+
+- Change the inline string `\`${config.issueNumber} ${config.adwId} ${issueJson}\`` to `[String(config.issueNumber), config.adwId, issueJson]`
+
+### 7. Update tests in `adws/__tests__/documentAgent.test.ts`
+
+- Update `formatDocumentArgs` test assertions to expect arrays instead of newline-separated strings
+- For example, `expect(result).toEqual(['adw-123', 'specs/plan.md', 'screenshots/'])` instead of checking for newline-separated string
+
+### 8. Update tests in `adws/__tests__/gitAgent.test.ts`
+
+- Update `formatBranchNameArgs` test assertions to expect `[issueClass, JSON.stringify(issue)]` array
+- Update `formatCommitArgs` test assertions to expect `[agentName, issueClass, issueContext]` array
+
+### 9. Update tests in `adws/__tests__/patchAgent.test.ts`
+
+- Update `formatPatchArgs` test assertions to expect arrays
+- Update any `toContain` assertions on args to use array indexing instead (e.g., `expect(args[2]).toBe('/specs/plan.md')`)
+
+### 10. Update tests in `adws/__tests__/reviewAgent.test.ts`
+
+- Update assertions that check for newline-separated string args to expect arrays
+- For example, change `'adw-123\nspecs/issue-1-plan.md\nreview_agent'` to `['adw-123', 'specs/issue-1-plan.md', 'review_agent']`
+- Update the `applicationUrl` test to expect 4-element array
+- Add tests for the new `formatReviewArgs` function
+
+### 11. Update tests in `adws/__tests__/adwInit.test.ts` (if exists)
+
+- If this test file exists, update any assertions on args passed to `runClaudeAgentWithCommand` to expect arrays instead of space-separated strings
+
+### 12. Run validation commands
+
+- Run all validation commands listed below to validate the review is complete with zero regressions.
+
+## Validation Commands
+Execute every command to validate the review is complete with zero regressions.
+
+- `npx tsc --noEmit -p adws/tsconfig.json` — Type-check the adws project to verify all return type changes compile correctly
+- `npm test` — Run all tests to validate the changes and ensure zero regressions
+- `npm run lint` — Run linter to check for code quality issues
+- `npm run build` — Build the application to verify no build errors
+
+## Notes
+- The guiding principle is: **slash commands that use positional variables (`$1`, `$2`, etc.) should receive arrays; slash commands that use `$ARGUMENTS` (single blob) should receive strings.** This is inherent to how `runClaudeAgentWithCommand` works — strings become one quoted arg, arrays become multiple quoted args.
+- Agents that correctly use strings and need NO changes: `buildAgent` (`/implement` uses `$ARGUMENTS`), `testAgent` (`/test` has no args; `/resolve_failed_test` and `/resolve_failed_e2e_test` use `$ARGUMENTS`), `issueClassifier` (`/classify_issue` uses `$ARGUMENTS`).
+- Agents that already correctly use arrays and need NO changes: `prAgent` (fixed in original PR), `planAgent` (already uses arrays).
+- Agents that need conversion from string to array: `documentAgent`, `gitAgent` (both functions), `patchAgent`, `reviewAgent`, `adwInit`.
+- Follow the coding guidelines: use immutability (returning new arrays), type safety (explicit `string[]` return types), and clarity (array literals are more explicit than string concatenation).


### PR DESCRIPTION
## Summary

Fixes a bug where `formatPullRequestArgs` in `prAgent.ts` formatted arguments as a string instead of an array, causing the `/pull_request` command to misinterpret the arguments.

**Plan:** [specs/issue-71-adw-pragent-passes-args-vrcjoy-sdlc_planner-fix-pr-agent-args-array.md](specs/issue-71-adw-pragent-passes-args-vrcjoy-sdlc_planner-fix-pr-agent-args-array.md)

Closes #71

**ADW ID:** pragent-passes-args-vrcjoy

## Checklist

- [x] Updated `formatPullRequestArgs` in `adws/agents/prAgent.ts` to return args as an array
- [x] Updated tests in `adws/__tests__/prAgent.test.ts` to reflect correct array format
- [x] Added implementation plan spec file

## Key Changes

- **`adws/agents/prAgent.ts`**: Fixed `formatPullRequestArgs` to return arguments as an array instead of a concatenated string, ensuring the `/pull_request` command receives properly structured input
- **`adws/__tests__/prAgent.test.ts`**: Updated test expectations to assert array format for pull request arguments