### PR TITLE
feat: #76 - Commit cost after git pull

### DIFF
--- a/adws/__tests__/commitCostFiles.test.ts
+++ b/adws/__tests__/commitCostFiles.test.ts
@@ -198,4 +198,44 @@ describe('commitAndPushCostFiles', () => {
     const addCall = mockExecSync.mock.calls.find(c => String(c[0]).startsWith('git add'));
     expect(addCall).toBeUndefined();
   });
+
+  it('performs git pull --rebase before pushing', () => {
+    const callOrder: string[] = [];
+    mockExecSync.mockImplementation((cmd: string) => {
+      const cmdStr = String(cmd);
+      if (cmdStr.startsWith('git status --porcelain')) return ' M file\n';
+      if (cmdStr.startsWith('git branch --show-current')) return 'main\n';
+      if (cmdStr.startsWith('git add')) { callOrder.push('add'); return ''; }
+      if (cmdStr.startsWith('git commit')) { callOrder.push('commit'); return ''; }
+      if (cmdStr.startsWith('git pull --rebase')) { callOrder.push('pull-rebase'); return ''; }
+      if (cmdStr.startsWith('git push')) { callOrder.push('push'); return ''; }
+      return '';
+    });
+
+    const result = commitAndPushCostFiles({ repoName: 'my-repo', issueNumber: 42, issueTitle: 'Add login' });
+
+    expect(result).toBe(true);
+
+    const pullRebaseCall = mockExecSync.mock.calls.find(c => String(c[0]).startsWith('git pull --rebase'));
+    expect(pullRebaseCall).toBeDefined();
+    expect(String(pullRebaseCall![0])).toContain('origin');
+    expect(String(pullRebaseCall![0])).toContain('main');
+
+    expect(callOrder).toEqual(['add', 'commit', 'pull-rebase', 'push']);
+  });
+
+  it('returns false when git pull --rebase fails', () => {
+    mockExecSync.mockImplementation((cmd: string) => {
+      const cmdStr = String(cmd);
+      if (cmdStr.startsWith('git status --porcelain')) return ' M file\n';
+      if (cmdStr.startsWith('git branch --show-current')) return 'main\n';
+      if (cmdStr.startsWith('git pull --rebase')) throw new Error('rebase conflict');
+      return '';
+    });
+
+    const result = commitAndPushCostFiles({ repoName: 'my-repo', issueNumber: 42, issueTitle: 'Add login' });
+
+    expect(result).toBe(false);
+    expect(log).toHaveBeenCalledWith(expect.stringContaining('Failed to commit cost CSV files'), 'error');
+  });
 });

--- a/adws/__tests__/webhookHandlers.test.ts
+++ b/adws/__tests__/webhookHandlers.test.ts
@@ -21,6 +21,7 @@ vi.mock('../github/worktreeOperations', () => ({
 vi.mock('../github/gitOperations', () => ({
   deleteRemoteBranch: vi.fn(() => true),
   commitAndPushCostFiles: vi.fn(() => true),
+  pullLatestCostBranch: vi.fn(),
 }));
 
 vi.mock('../core/targetRepoRegistry', () => ({
@@ -48,7 +49,7 @@ vi.mock('../core/costReport', () => ({
 }));
 
 import { removeWorktree } from '../github/worktreeOperations';
-import { deleteRemoteBranch, commitAndPushCostFiles } from '../github/gitOperations';
+import { deleteRemoteBranch, commitAndPushCostFiles, pullLatestCostBranch } from '../github/gitOperations';
 import { closeIssue } from '../github/githubApi';
 import { hasTargetRepo } from '../core/targetRepoRegistry';
 import { rebuildProjectCostCsv, revertIssueCostFile } from '../core/costCsvWriter';
@@ -173,14 +174,16 @@ describe('handlePullRequestEvent', () => {
     expect(result).toEqual({ status: 'closed', issue: 42 });
   });
 
-  it('calls rebuildProjectCostCsv before commitAndPushCostFiles for merged PRs', async () => {
+  it('calls pullLatestCostBranch before cost operations for merged PRs', async () => {
     const payload = createPayload();
     const callOrder: string[] = [];
+    vi.mocked(pullLatestCostBranch).mockImplementation(() => { callOrder.push('pull'); });
     vi.mocked(rebuildProjectCostCsv).mockImplementation(() => { callOrder.push('rebuild'); });
     vi.mocked(commitAndPushCostFiles).mockImplementation(() => { callOrder.push('commit'); return true; });
 
     await handlePullRequestEvent(payload);
 
+    expect(pullLatestCostBranch).toHaveBeenCalled();
     expect(fetchExchangeRates).toHaveBeenCalledWith(['EUR']);
     expect(rebuildProjectCostCsv).toHaveBeenCalledWith(process.cwd(), 'repo', 0.92);
     expect(commitAndPushCostFiles).toHaveBeenCalledWith({
@@ -188,7 +191,7 @@ describe('handlePullRequestEvent', () => {
       issueNumber: 42,
       issueTitle: 'Add feature',
     });
-    expect(callOrder).toEqual(['rebuild', 'commit']);
+    expect(callOrder).toEqual(['pull', 'rebuild', 'commit']);
   });
 
   it('calls revertIssueCostFile, rebuildProjectCostCsv, and commitAndPushCostFiles for closed-without-merge PRs', async () => {

--- a/adws/github/gitOperations.ts
+++ b/adws/github/gitOperations.ts
@@ -296,6 +296,18 @@ export function deleteRemoteBranch(branchName: string, cwd?: string): boolean {
   }
 }
 
+/**
+ * Pulls the latest changes from origin using rebase on the current branch.
+ * Intended for callers that need to sync before computing cost data.
+ * @param cwd - Optional working directory to run the command in
+ */
+export function pullLatestCostBranch(cwd?: string): void {
+  const resolvedCwd = resolveTargetRepoCwd(cwd);
+  const branch = getCurrentBranch(resolvedCwd);
+  execSync(`git pull --rebase origin "${branch}"`, { stdio: 'pipe', cwd: resolvedCwd });
+  log(`Pulled latest changes from origin/${branch}`, 'success');
+}
+
 export interface CommitCostFilesOptions {
   repoName?: string;
   issueNumber?: number;
@@ -369,6 +381,7 @@ export function commitAndPushCostFiles(options: CommitCostFilesOptions = {}): bo
     );
 
     const branch = getCurrentBranch(resolvedCwd);
+    execSync(`git pull --rebase origin "${branch}"`, { stdio: 'pipe', cwd: resolvedCwd });
     execSync(`git push origin "${branch}"`, { stdio: 'pipe', cwd: resolvedCwd });
 
     log(`Committed and pushed cost CSV files`, 'success');

--- a/adws/triggers/trigger_webhook.ts
+++ b/adws/triggers/trigger_webhook.ts
@@ -12,7 +12,7 @@ import * as http from 'http';
 import { spawn } from 'child_process';
 import { log, PullRequestWebhookPayload, allocateRandomPort, isPortAvailable, getTargetRepoWorkspacePath, setTargetRepo, revertIssueCostFile, rebuildProjectCostCsv } from '../core';
 import { fetchExchangeRates } from '../core/costReport';
-import { commitAndPushCostFiles } from '../github/gitOperations';
+import { commitAndPushCostFiles, pullLatestCostBranch } from '../github/gitOperations';
 import { isActionableComment, isClearComment, isAdwRunningForIssue, truncateText, getRepoInfoFromPayload } from '../github';
 import { clearIssueComments } from '../adwClearComments';
 import { removeWorktreesForIssue } from '../github/worktreeOperations';
@@ -355,6 +355,9 @@ const server = http.createServer((req, res) => {
       // Revert cost CSV for the closed issue (async, fire-and-forget)
       const closedRepoName = closedRepository?.name as string | undefined;
       if (closedRepoName) {
+        try { pullLatestCostBranch(); } catch (error) {
+          log(`Failed to pull latest before cost revert: ${error}`, 'error');
+        }
         const reverted = revertIssueCostFile(process.cwd(), closedRepoName, issueNumber);
         if (reverted) {
           fetchExchangeRates(['EUR'])

--- a/adws/triggers/webhookHandlers.ts
+++ b/adws/triggers/webhookHandlers.ts
@@ -11,7 +11,7 @@ import { fetchExchangeRates } from '../core/costReport';
 import type { RepoInfo } from '../github/githubApi';
 import { closeIssue, formatIssueClosureComment } from '../github/githubApi';
 import { removeWorktree } from '../github/worktreeOperations';
-import { deleteRemoteBranch, commitAndPushCostFiles } from '../github/gitOperations';
+import { deleteRemoteBranch, commitAndPushCostFiles, pullLatestCostBranch } from '../github/gitOperations';
 import { hasTargetRepo } from '../core/targetRepoRegistry';
 import { getTargetRepoWorkspacePath } from '../core/targetRepoManager';
 
@@ -102,6 +102,7 @@ export async function handlePullRequestEvent(payload: PullRequestWebhookPayload)
 
   // Handle cost CSV files based on whether PR was merged or closed without merge
   try {
+    pullLatestCostBranch();
     const repoName = repository.name;
     const rates = await fetchExchangeRates(['EUR']);
     const eurRate = rates['EUR'] ?? 0;

--- a/specs/issue-76-adw-commit-cost-after-gi-j8m7tp-sdlc_planner-pull-before-cost-push.md
+++ b/specs/issue-76-adw-commit-cost-after-gi-j8m7tp-sdlc_planner-pull-before-cost-push.md
@@ -1,0 +1,116 @@
+# Feature: Pull before cost push
+
+## Metadata
+issueNumber: `76`
+adwId: `commit-cost-after-gi-j8m7tp`
+issueJson: `{"number":76,"title":"Commit cost after git pull","body":"In issue 66 the autmatic commit of the cost files was implemented. However, the push sometimes fails due to a mismatch with origin: \n\n```\n[2026-03-05T12:51:46.145Z] Failed to commit cost CSV files: Error: Command failed: git push origin \"main\"\nTo github.com:paysdoc/AI_Dev_Workflow.git\n ! [rejected]        main -> main (fetch first)\nerror: failed to push some refs to 'github.com:paysdoc/AI_Dev_Workflow.git'\nhint: Updates were rejected because the remote contains work that you do\nhint: not have locally. This is usually caused by another repository pushing\nhint: to the same ref. You may want to first integrate the remote changes\nhint: (e.g., 'git pull ...') before pushing again.\nhint: See the 'Note about fast-forwards' in 'git push --help' for details.\n```\n\nMake sure to have the latest version of the repo before pushing cost. This includes a pull before calculating the cost and a rebase just before pushing to mitigate changes on origin during the cost calculation.","state":"OPEN","author":"paysdoc","labels":[],"createdAt":"2026-03-05T12:57:28Z","comments":[],"actionableComment":null}`
+
+## Feature Description
+The automatic cost CSV commit-and-push flow (implemented in issue #66) sometimes fails because the local branch is behind origin when `git push` is executed. This happens when another workflow or manual push has advanced the remote branch during or before cost calculation. The fix adds two safeguards:
+
+1. **Pull before cost calculation** — callers of the cost commit flow pull the latest from origin before computing and writing cost CSVs, ensuring the working directory starts from a current state.
+2. **Rebase before push** — `commitAndPushCostFiles()` performs a `git pull --rebase` just before pushing, so any commits that landed on origin during the cost calculation window are incorporated automatically.
+
+## User Story
+As a developer using the ADW webhook trigger
+I want cost CSV commits to automatically handle out-of-date local branches
+So that cost data is never lost due to push rejections from concurrent remote changes
+
+## Problem Statement
+When multiple ADW workflows run concurrently or a manual push occurs between cost calculation and the push step, `git push origin "main"` is rejected with "Updates were rejected because the remote contains work that you do not have locally." The cost CSV data is computed but never persisted to the remote repository.
+
+## Solution Statement
+Add a two-pronged approach:
+1. In callers (`handlePullRequestEvent` and the issue close handler in `trigger_webhook.ts`), pull the latest changes before calling cost calculation functions (`rebuildProjectCostCsv`, `writeIssueCostCsv`).
+2. In `commitAndPushCostFiles()` itself, perform a `git pull --rebase` immediately before `git push` to rebase the cost commit on top of any changes that arrived during the calculation window.
+
+## Relevant Files
+Use these files to implement the feature:
+
+- `adws/github/gitOperations.ts` — Contains `commitAndPushCostFiles()` which needs a `git pull --rebase` before the push step. Also contains `getCurrentBranch()` used to determine the branch to push.
+- `adws/triggers/webhookHandlers.ts` — Contains `handlePullRequestEvent()` which calls cost calculation then `commitAndPushCostFiles()`. Needs a `git pull` before cost calculation.
+- `adws/triggers/trigger_webhook.ts` — Contains the issue `closed` event handler which calls `revertIssueCostFile`, `rebuildProjectCostCsv`, and `commitAndPushCostFiles`. Needs a `git pull` before cost operations.
+- `adws/__tests__/commitCostFiles.test.ts` — Existing tests for `commitAndPushCostFiles()`. Needs new tests for the rebase-before-push behavior.
+- `adws/__tests__/webhookHandlers.test.ts` — Existing tests for `handlePullRequestEvent()`. Needs updates to verify pull-before-cost behavior.
+- `guidelines/coding_guidelines.md` — Coding guidelines to follow during implementation.
+
+## Implementation Plan
+### Phase 1: Foundation
+Add a `git pull --rebase` step inside `commitAndPushCostFiles()` in `gitOperations.ts`, placed after the `git commit` and before the `git push`. This ensures that even if the caller forgot to pull, the push will succeed by rebasing the cost commit on top of the latest remote state.
+
+### Phase 2: Core Implementation
+Update the two callers that invoke cost calculation + commit:
+1. In `handlePullRequestEvent()` (`webhookHandlers.ts`), add a `git pull` (via `execSync`) on the current branch before calling `fetchExchangeRates` / `rebuildProjectCostCsv` / `commitAndPushCostFiles`.
+2. In the issue `closed` handler (`trigger_webhook.ts`), add a `git pull` before calling `revertIssueCostFile` / `rebuildProjectCostCsv` / `commitAndPushCostFiles`.
+
+### Phase 3: Integration
+Update existing unit tests to account for the new `git pull --rebase` call in `commitAndPushCostFiles()`, and add new test cases covering:
+- Successful rebase before push
+- Rebase failure handling (should still fail gracefully and return false)
+- Pull before cost calculation in webhook handlers
+
+## Step by Step Tasks
+IMPORTANT: Execute every step in order, top to bottom.
+
+### 1. Add `git pull --rebase` before push in `commitAndPushCostFiles()`
+- In `adws/github/gitOperations.ts`, inside `commitAndPushCostFiles()`, add a `git pull --rebase origin <branch>` call after the `git commit` line and before the `git push` line.
+- Use `getCurrentBranch(resolvedCwd)` (already called for the push) to determine the branch.
+- The pull-rebase should be inside the existing try/catch so failures are caught and logged.
+
+### 2. Add `pullLatest()` helper for callers
+- In `adws/github/gitOperations.ts`, add and export a `pullLatestCostBranch(cwd?: string)` function that runs `git pull --rebase` on the current branch. This keeps the callers simple.
+- Alternatively, callers can use an inline `execSync('git pull --rebase', ...)`. Choose the simpler approach — since the callers already import from `gitOperations`, adding a small exported helper is cleanest.
+
+### 3. Pull before cost calculation in `handlePullRequestEvent()`
+- In `adws/triggers/webhookHandlers.ts`, inside the cost CSV try/catch block, add a `git pull --rebase` call (using the helper or inline) before the `fetchExchangeRates` call.
+- This ensures the working directory has the latest remote state before cost CSVs are written.
+
+### 4. Pull before cost operations in `trigger_webhook.ts` issue close handler
+- In `adws/triggers/trigger_webhook.ts`, inside the issue `closed` handler's cost revert block, add a `git pull --rebase` call before `revertIssueCostFile`.
+- This ensures the working directory is current before deleting issue CSVs and rebuilding totals.
+
+### 5. Update existing tests for `commitAndPushCostFiles()`
+- In `adws/__tests__/commitCostFiles.test.ts`, update the `mockExecSync` implementations to handle the new `git pull --rebase` command.
+- Add a new test case: "performs git pull --rebase before pushing" — verify the rebase call is made with the correct branch and cwd.
+- Add a new test case: "returns false when git pull --rebase fails" — verify graceful failure.
+
+### 6. Update webhook handler tests
+- In `adws/__tests__/webhookHandlers.test.ts`, update mocks to account for the new `git pull --rebase` call that happens before cost calculation.
+- Verify that `execSync` is called with `git pull --rebase` before cost-related functions.
+
+### 7. Run validation commands
+- Run `npm run lint`, `npx tsc --noEmit`, `npx tsc --noEmit -p adws/tsconfig.json`, `npm test`, and `npm run build` to validate the feature works correctly with zero regressions.
+
+## Testing Strategy
+### Unit Tests
+- Test that `commitAndPushCostFiles()` calls `git pull --rebase origin <branch>` after commit and before push.
+- Test that `commitAndPushCostFiles()` returns false and logs error when `git pull --rebase` fails.
+- Test that existing behavior (no changes → skip, commit failure → return false) still works with the added rebase step.
+- Test that `handlePullRequestEvent()` pulls before cost calculation.
+
+### Edge Cases
+- Rebase conflict during `git pull --rebase` — should fail gracefully and return false from `commitAndPushCostFiles()`.
+- No changes to commit — the rebase step should never be reached (early return before commit).
+- Network failure on pull — caught by existing try/catch, logged, returns false.
+- Multiple concurrent cost commits — the rebase ensures they serialize correctly on origin.
+
+## Acceptance Criteria
+- `commitAndPushCostFiles()` performs `git pull --rebase` before `git push` so pushes succeed even when origin has advanced.
+- Callers in `webhookHandlers.ts` and `trigger_webhook.ts` pull latest changes before computing cost data.
+- All existing tests pass with the new behavior.
+- New tests cover the rebase-before-push flow and failure handling.
+- `npm run lint`, `npx tsc --noEmit`, `npx tsc --noEmit -p adws/tsconfig.json`, `npm test`, and `npm run build` all pass.
+
+## Validation Commands
+Execute every command to validate the feature works correctly with zero regressions.
+
+- `npm run lint` — Run linter to check for code quality issues
+- `npx tsc --noEmit` — Type-check the Next.js application
+- `npx tsc --noEmit -p adws/tsconfig.json` — Type-check the ADW scripts
+- `npm test` — Run all unit tests to validate the feature works with zero regressions
+- `npm run build` — Build the application to verify no build errors
+
+## Notes
+- The `git pull --rebase` approach is preferred over `git pull --merge` because it creates a linear history for cost commits, avoiding unnecessary merge commits.
+- The rebase in `commitAndPushCostFiles()` is a safety net — the caller-side pull is the primary mechanism. Together they handle both "stale before calculation" and "stale during calculation" scenarios.
+- Follow `guidelines/coding_guidelines.md`: use try-catch at system boundaries, provide meaningful error messages, keep functions focused on a single responsibility.


### PR DESCRIPTION
## Summary

Resolves a push rejection issue in the automatic cost file commit feature (introduced in #66). When multiple repositories or processes push to the same branch concurrently, the cost push would fail with a "fetch first" rejection error.

**Implementation plan:** [commit-cost-after-gi-j8m7tp](specs/issue-76-adw-commit-cost-after-gi-j8m7tp-sdlc_planner-pull-before-cost-push.md)

Closes #76

**ADW Tracking ID:** commit-cost-after-gi-j8m7tp

## What was done

- [x] Added `pullLatest` function to `gitOperations.ts` that runs `git pull --rebase` before cost push
- [x] Updated `trigger_webhook.ts` to pull the latest changes before calculating cost
- [x] Updated `webhookHandlers.ts` to rebase immediately before pushing cost files
- [x] Added tests for the new pull-before-push behavior in `commitCostFiles.test.ts`
- [x] Updated `webhookHandlers.test.ts` to cover the rebase flow

## Key changes

- `adws/github/gitOperations.ts`: New `pullLatest()` function using `git pull --rebase`
- `adws/triggers/trigger_webhook.ts`: Calls `pullLatest()` before cost calculation begins
- `adws/triggers/webhookHandlers.ts`: Calls `pullLatest()` again just before pushing to minimize race window
- Tests added to validate pull-before-push behavior