### PR TITLE
bug: #99 - Fix currency conversion

### DIFF
--- a/adws/core/__tests__/costReport.test.ts
+++ b/adws/core/__tests__/costReport.test.ts
@@ -6,6 +6,7 @@ import {
   buildCostBreakdown,
   formatCostBreakdownMarkdown,
   computeEurRate,
+  resetLastKnownRates,
 } from '../costReport';
 import type { ModelUsageMap, CostBreakdown } from '../../types/costTypes';
 
@@ -76,6 +77,7 @@ describe('costReport', () => {
   describe('fetchExchangeRates', () => {
     beforeEach(() => {
       vi.restoreAllMocks();
+      resetLastKnownRates();
     });
 
     it('returns fallback EUR rate after all retries are exhausted', async () => {
@@ -140,6 +142,21 @@ describe('costReport', () => {
       vi.stubGlobal('fetch', vi.fn().mockRejectedValue(new Error('Network error')));
       const rates = await fetchExchangeRates(['GBP']);
       expect(rates).toEqual({});
+    });
+
+    it('updates fallback rate with latest fetched rate for subsequent failures', async () => {
+      vi.stubGlobal('fetch', vi.fn().mockResolvedValue({
+        ok: true,
+        json: () => Promise.resolve({ rates: { EUR: 0.95 } }),
+      }));
+
+      const firstRates = await fetchExchangeRates(['EUR']);
+      expect(firstRates).toEqual({ EUR: 0.95 });
+
+      vi.stubGlobal('fetch', vi.fn().mockRejectedValue(new Error('Network error')));
+
+      const fallbackRates = await fetchExchangeRates(['EUR']);
+      expect(fallbackRates).toEqual({ EUR: 0.95 });
     });
   });
 

--- a/adws/core/__tests__/costReport.test.ts
+++ b/adws/core/__tests__/costReport.test.ts
@@ -5,6 +5,7 @@ import {
   fetchExchangeRates,
   buildCostBreakdown,
   formatCostBreakdownMarkdown,
+  computeEurRate,
 } from '../costReport';
 import type { ModelUsageMap, CostBreakdown } from '../../types/costTypes';
 
@@ -77,10 +78,10 @@ describe('costReport', () => {
       vi.restoreAllMocks();
     });
 
-    it('handles network errors gracefully', async () => {
+    it('returns fallback EUR rate after all retries are exhausted', async () => {
       vi.stubGlobal('fetch', vi.fn().mockRejectedValue(new Error('Network error')));
       const rates = await fetchExchangeRates(['EUR']);
-      expect(rates).toEqual({});
+      expect(rates).toEqual({ EUR: 0.92 });
     });
 
     it('returns empty map for empty currencies', async () => {
@@ -99,14 +100,75 @@ describe('costReport', () => {
       expect(rates['GBP']).toBe(0.79);
     });
 
-    it('handles non-ok response', async () => {
+    it('returns fallback EUR rate on non-ok response after retries', async () => {
       vi.stubGlobal('fetch', vi.fn().mockResolvedValue({
         ok: false,
         status: 500,
       }));
 
       const rates = await fetchExchangeRates(['EUR']);
+      expect(rates).toEqual({ EUR: 0.92 });
+    });
+
+    it('retries on transient failure then returns rates on success', async () => {
+      const mockFetch = vi.fn()
+        .mockRejectedValueOnce(new Error('Network error'))
+        .mockResolvedValueOnce({
+          ok: true,
+          json: () => Promise.resolve({ rates: { EUR: 0.91 } }),
+        });
+      vi.stubGlobal('fetch', mockFetch);
+
+      const rates = await fetchExchangeRates(['EUR']);
+      expect(rates).toEqual({ EUR: 0.91 });
+      expect(mockFetch).toHaveBeenCalledTimes(2);
+    });
+
+    it('passes timeout signal to fetch', async () => {
+      const mockFetch = vi.fn().mockResolvedValue({
+        ok: true,
+        json: () => Promise.resolve({ rates: { EUR: 0.92 } }),
+      });
+      vi.stubGlobal('fetch', mockFetch);
+
+      await fetchExchangeRates(['EUR']);
+      const callArgs = mockFetch.mock.calls[0];
+      expect(callArgs[1]).toHaveProperty('signal');
+    });
+
+    it('returns empty for currencies without a known fallback after retries', async () => {
+      vi.stubGlobal('fetch', vi.fn().mockRejectedValue(new Error('Network error')));
+      const rates = await fetchExchangeRates(['GBP']);
       expect(rates).toEqual({});
+    });
+  });
+
+  describe('computeEurRate', () => {
+    it('returns correct rate with valid EUR entry and non-zero totalCostUsd', () => {
+      const breakdown: CostBreakdown = {
+        totalCostUsd: 2.0,
+        modelUsage: {},
+        currencies: [{ currency: 'EUR', amount: 1.84, symbol: '€' }],
+      };
+      expect(computeEurRate(breakdown)).toBeCloseTo(0.92);
+    });
+
+    it('returns 0 when totalCostUsd is zero', () => {
+      const breakdown: CostBreakdown = {
+        totalCostUsd: 0,
+        modelUsage: {},
+        currencies: [{ currency: 'EUR', amount: 0, symbol: '€' }],
+      };
+      expect(computeEurRate(breakdown)).toBe(0);
+    });
+
+    it('returns 0 when no EUR entry exists', () => {
+      const breakdown: CostBreakdown = {
+        totalCostUsd: 2.0,
+        modelUsage: {},
+        currencies: [{ currency: 'GBP', amount: 1.58, symbol: '£' }],
+      };
+      expect(computeEurRate(breakdown)).toBe(0);
     });
   });
 

--- a/adws/core/costReport.ts
+++ b/adws/core/costReport.ts
@@ -56,6 +56,14 @@ export function computeTotalCostUsd(usageMap: ModelUsageMap): number {
 /** Known fallback rates keyed by currency code. */
 const FALLBACK_RATES: Readonly<Record<string, number>> = { EUR: FALLBACK_EUR_RATE };
 
+/** Mutable cache of the most recently fetched live rates, seeded from FALLBACK_RATES. */
+let lastKnownRates: Record<string, number> = { ...FALLBACK_RATES };
+
+/** @internal Resets cached rates — for testing only. */
+export function resetLastKnownRates(): void {
+  lastKnownRates = { ...FALLBACK_RATES };
+}
+
 /**
  * Fetches exchange rates from the free ExchangeRate-API with retry,
  * timeout, and fallback. Retries up to {@link MAX_EXCHANGE_RATE_RETRIES}
@@ -86,6 +94,7 @@ export async function fetchExchangeRates(targetCurrencies: string[]): Promise<Re
         const rate = data.rates[currency];
         if (typeof rate === 'number') {
           rates[currency] = rate;
+          lastKnownRates[currency] = rate;
         }
       }
       return rates;
@@ -104,7 +113,7 @@ export async function fetchExchangeRates(targetCurrencies: string[]): Promise<Re
   log('All exchange rate fetch attempts failed, using fallback rates', 'error');
   const fallbackRates: Record<string, number> = {};
   for (const currency of targetCurrencies) {
-    const fallback = FALLBACK_RATES[currency];
+    const fallback = lastKnownRates[currency];
     if (typeof fallback === 'number') {
       fallbackRates[currency] = fallback;
     }

--- a/adws/core/costReport.ts
+++ b/adws/core/costReport.ts
@@ -8,6 +8,15 @@ import { emptyModelUsage } from '../types/costTypes';
 import { log } from './utils';
 import { AgentStateManager } from './agentState';
 
+/** Last-resort fallback EUR/USD rate used when the exchange rate API is unreachable after all retries. */
+const FALLBACK_EUR_RATE = 0.92;
+
+/** Maximum number of retry attempts after the initial fetch (3 total attempts). */
+const MAX_EXCHANGE_RATE_RETRIES = 2;
+
+/** Timeout in milliseconds for each exchange rate fetch request. */
+const EXCHANGE_RATE_TIMEOUT_MS = 5000;
+
 /** Maps common currency codes to their symbols. */
 export const CURRENCY_SYMBOLS: Readonly<Record<string, string>> = {
   USD: '$',
@@ -44,36 +53,63 @@ export function computeTotalCostUsd(usageMap: ModelUsageMap): number {
   return Object.values(usageMap).reduce((sum, usage) => sum + usage.costUSD, 0);
 }
 
+/** Known fallback rates keyed by currency code. */
+const FALLBACK_RATES: Readonly<Record<string, number>> = { EUR: FALLBACK_EUR_RATE };
+
 /**
- * Fetches exchange rates from the free ExchangeRate-API.
- * Returns a map of currency code to conversion rate from USD.
- * Handles network errors gracefully by returning an empty map.
+ * Fetches exchange rates from the free ExchangeRate-API with retry,
+ * timeout, and fallback. Retries up to {@link MAX_EXCHANGE_RATE_RETRIES}
+ * additional times with exponential backoff. Falls back to approximate
+ * hardcoded rates when all attempts are exhausted.
  */
 export async function fetchExchangeRates(targetCurrencies: string[]): Promise<Record<string, number>> {
   if (targetCurrencies.length === 0) return {};
 
-  try {
-    const response = await fetch('https://open.er-api.com/v6/latest/USD');
-    if (!response.ok) {
-      log(`Exchange rate API returned status ${response.status}`, 'error');
-      return {};
-    }
+  const totalAttempts = MAX_EXCHANGE_RATE_RETRIES + 1;
 
-    const data = await response.json() as { rates?: Record<string, number> };
-    if (!data.rates) return {};
+  for (let attempt = 0; attempt < totalAttempts; attempt++) {
+    try {
+      const response = await fetch('https://open.er-api.com/v6/latest/USD', {
+        signal: AbortSignal.timeout(EXCHANGE_RATE_TIMEOUT_MS),
+      });
 
-    const rates: Record<string, number> = {};
-    for (const currency of targetCurrencies) {
-      const rate = data.rates[currency];
-      if (typeof rate === 'number') {
-        rates[currency] = rate;
+      if (!response.ok) {
+        log(`Exchange rate API returned status ${response.status}`, 'error');
+        throw new Error(`HTTP ${response.status}`);
+      }
+
+      const data = await response.json() as { rates?: Record<string, number> };
+      if (!data.rates) return {};
+
+      const rates: Record<string, number> = {};
+      for (const currency of targetCurrencies) {
+        const rate = data.rates[currency];
+        if (typeof rate === 'number') {
+          rates[currency] = rate;
+        }
+      }
+      return rates;
+    } catch (error) {
+      log(`Failed to fetch exchange rates: ${error}`, 'error');
+
+      if (attempt < totalAttempts - 1) {
+        const delay = 500 * Math.pow(2, attempt);
+        log(`Retrying exchange rate fetch (attempt ${attempt + 2}/${totalAttempts})...`, 'info');
+        await new Promise(resolve => setTimeout(resolve, delay));
       }
     }
-    return rates;
-  } catch (error) {
-    log(`Failed to fetch exchange rates: ${error}`, 'error');
-    return {};
   }
+
+  // All retries exhausted — return fallback rates for known currencies
+  log('All exchange rate fetch attempts failed, using fallback rates', 'error');
+  const fallbackRates: Record<string, number> = {};
+  for (const currency of targetCurrencies) {
+    const fallback = FALLBACK_RATES[currency];
+    if (typeof fallback === 'number') {
+      fallbackRates[currency] = fallback;
+    }
+  }
+  return fallbackRates;
 }
 
 /** Builds a complete CostBreakdown by fetching exchange rates and computing totals. */
@@ -97,6 +133,15 @@ export async function buildCostBreakdown(
     modelUsage: usageMap,
     currencies: currencyAmounts,
   };
+}
+
+/** Computes the EUR exchange rate from a cost breakdown, guarding against division by zero. */
+export function computeEurRate(costBreakdown: CostBreakdown): number {
+  const eurEntry = costBreakdown.currencies.find(c => c.currency === 'EUR');
+  if (eurEntry && costBreakdown.totalCostUsd > 0) {
+    return eurEntry.amount / costBreakdown.totalCostUsd;
+  }
+  return 0;
 }
 
 /** Formats a number with commas as thousands separator. */

--- a/adws/core/index.ts
+++ b/adws/core/index.ts
@@ -93,6 +93,7 @@ export {
   buildCostBreakdown,
   formatCostBreakdownMarkdown,
   persistTokenCounts,
+  computeEurRate,
 } from './costReport';
 
 // Cost CSV writer

--- a/adws/phases/prReviewCompletion.ts
+++ b/adws/phases/prReviewCompletion.ts
@@ -5,7 +5,7 @@
  * pushing branches, posting completion comments, and error handling.
  */
 
-import { log, AgentStateManager, COST_REPORT_CURRENCIES, type ModelUsageMap, buildCostBreakdown, mergeModelUsageMaps, emptyModelUsageMap, persistTokenCounts, writeIssueCostCsv, rebuildProjectCostCsv, OrchestratorId } from '../core';
+import { log, AgentStateManager, COST_REPORT_CURRENCIES, type ModelUsageMap, buildCostBreakdown, mergeModelUsageMaps, emptyModelUsageMap, persistTokenCounts, writeIssueCostCsv, rebuildProjectCostCsv, OrchestratorId, computeEurRate } from '../core';
 import { pushBranch, postPRWorkflowComment, inferIssueTypeFromBranch, moveIssueToStatus } from '../github';
 import { getTargetRepo } from '../core/targetRepoRegistry';
 import { runCommitAgent, runUnitTestsWithRetry, runE2ETestsWithRetry } from '../agents';
@@ -103,8 +103,7 @@ export async function completePRReviewWorkflow(config: PRReviewWorkflowConfig, m
     try {
       const repoName = config.repoInfo?.repo ?? getTargetRepo().repo;
       const adwRepoRoot = process.cwd();
-      const eurEntry = costBreakdown.currencies.find(c => c.currency === 'EUR');
-      const eurRate = eurEntry ? eurEntry.amount / costBreakdown.totalCostUsd : 0;
+      const eurRate = computeEurRate(costBreakdown);
 
       writeIssueCostCsv(adwRepoRoot, repoName, config.issueNumber, config.prDetails.title, costBreakdown);
       rebuildProjectCostCsv(adwRepoRoot, repoName, eurRate);

--- a/adws/phases/workflowCompletion.ts
+++ b/adws/phases/workflowCompletion.ts
@@ -12,6 +12,7 @@ import {
   persistTokenCounts,
   writeIssueCostCsv,
   rebuildProjectCostCsv,
+  computeEurRate,
 } from '../core';
 import {
   postWorkflowComment,
@@ -40,8 +41,7 @@ export async function completeWorkflow(
     try {
       const repoName = config.targetRepo?.repo ?? config.repoInfo?.repo ?? 'unknown';
       const adwRepoRoot = config.targetRepo ? process.cwd() : config.worktreePath;
-      const eurEntry = costBreakdown.currencies.find(c => c.currency === 'EUR');
-      const eurRate = eurEntry ? eurEntry.amount / costBreakdown.totalCostUsd : 0;
+      const eurRate = computeEurRate(costBreakdown);
 
       writeIssueCostCsv(adwRepoRoot, repoName, config.issueNumber, config.issue.title, costBreakdown);
       rebuildProjectCostCsv(adwRepoRoot, repoName, eurRate);

--- a/specs/issue-99-adw-bug-in-currency-conv-kcbcrp-sdlc_planner-fix-currency-conversion.md
+++ b/specs/issue-99-adw-bug-in-currency-conv-kcbcrp-sdlc_planner-fix-currency-conversion.md
@@ -1,0 +1,106 @@
+# Bug: Currency conversion fails when exchange rate API is unreachable
+
+## Metadata
+issueNumber: `99`
+adwId: `bug-in-currency-conv-kcbcrp`
+issueJson: `{"number":99,"title":"Bug in currency conversion","body":"📋 [2026-03-09T10:33:25.414Z] Ignored comment on issue #97: missing \"## Take action\" directive\n❌ [2026-03-09T10:33:34.584Z] [refactor-the-code-fuyzg6] Failed to fetch exchange rates: TypeError: fetch failed\n✅ [2026-03-09T10:33:34.585Z] [refactor-the-code-fuyzg6] Issue cost CSV written: projects/AI_Dev_Workflow/97-refactor-the-code.csv\n✅ [2026-03-09T10:33:34.590Z] [refactor-the-code-fuyzg6] Project cost CSV rebuilt: projects/AI_Dev_Workflow/total-cost.csv\n","state":"OPEN","author":"paysdoc","labels":[],"createdAt":"2026-03-09T11:29:16Z","comments":[{"author":"paysdoc","createdAt":"2026-03-09T11:32:10Z","body":"## Take action"}],"actionableComment":null}`
+
+## Bug Description
+When the exchange rate API (`https://open.er-api.com/v6/latest/USD`) is unreachable, the `fetchExchangeRates()` function fails with `TypeError: fetch failed`. This causes:
+- **Actual behavior**: EUR conversion is silently lost — issue cost CSVs and total-cost CSV show `Total Cost (EUR):,N/A`. The error is logged but no retry is attempted.
+- **Expected behavior**: The system should retry transient failures before giving up, apply a timeout to prevent hanging, use a fallback rate when the API is completely unavailable, and guard against division-by-zero when computing the EUR rate.
+
+## Problem Statement
+The `fetchExchangeRates()` function in `adws/core/costReport.ts` makes a single HTTP request with no retry logic, no timeout, and no fallback mechanism. When the request fails, every downstream consumer (workflow completion, PR review completion, webhook handlers) silently produces `N/A` for EUR values in cost CSVs. Additionally, the EUR rate calculation in `completeWorkflow` and `completePRReviewWorkflow` divides by `totalCostUsd`, which risks `NaN`/`Infinity` when the cost is zero.
+
+## Solution Statement
+1. **Add retry with exponential backoff** to `fetchExchangeRates()` — retry up to 2 additional times (3 total attempts) with exponential backoff on transient failures.
+2. **Add a fetch timeout** — abort requests that take longer than 5 seconds using `AbortSignal.timeout()`.
+3. **Add a fallback EUR rate** — when all retries are exhausted, fall back to a hardcoded approximate EUR rate so cost reports always include EUR conversion.
+4. **Fix division-by-zero** — guard `eurEntry.amount / costBreakdown.totalCostUsd` against zero `totalCostUsd` in both `completeWorkflow` and `completePRReviewWorkflow`.
+
+## Steps to Reproduce
+1. Run any ADW workflow (e.g., `bunx tsx adws/adwPlanBuild.tsx 97`) when the network is unavailable or the exchange rate API is down.
+2. Observe the error log: `❌ Failed to fetch exchange rates: TypeError: fetch failed`
+3. Check the generated CSV files — `Total Cost (EUR):,N/A` appears instead of a converted value.
+
+## Root Cause Analysis
+The root cause is the lack of resilience in `fetchExchangeRates()`:
+- **No retry**: A single transient network failure (DNS timeout, TCP reset, API blip) causes the function to return `{}` immediately.
+- **No timeout**: The fetch has no explicit timeout, so it could potentially hang on slow connections before eventually failing.
+- **No fallback**: When the API is unreachable, there is no fallback rate. The empty map propagates through `buildCostBreakdown()` which filters out currencies with no rate, resulting in `currencies: []`.
+- **Division-by-zero**: In `workflowCompletion.ts:44` and `prReviewCompletion.ts:107`, the EUR rate is computed as `eurEntry.amount / costBreakdown.totalCostUsd`. If `totalCostUsd` is `0`, this produces `NaN` or `Infinity`, which corrupts the total-cost CSV.
+
+## Relevant Files
+Use these files to fix the bug:
+
+- `guidelines/coding_guidelines.md` — Coding guidelines to follow strictly during implementation.
+- `adws/core/costReport.ts` — Contains `fetchExchangeRates()` (the root cause), `buildCostBreakdown()`, and currency symbols. This is the primary file to modify.
+- `adws/core/__tests__/costReport.test.ts` — Existing tests for `fetchExchangeRates` and `buildCostBreakdown`. Must be updated with new test cases for retry, timeout, fallback, and the new helper.
+- `adws/phases/workflowCompletion.ts` — Contains `completeWorkflow()` with the EUR rate division-by-zero on line 44.
+- `adws/phases/prReviewCompletion.ts` — Contains `completePRReviewWorkflow()` with the same EUR rate division-by-zero on line 107.
+- `adws/triggers/webhookHandlers.ts` — Uses `fetchExchangeRates` directly; benefits from the retry/fallback fix automatically.
+- `adws/core/costCsvWriter.ts` — Reference file for understanding CSV format; no changes needed.
+
+## Step by Step Tasks
+IMPORTANT: Execute every step in order, top to bottom.
+
+### 1. Add retry, timeout, and fallback to `fetchExchangeRates` in `adws/core/costReport.ts`
+
+- Add a `FALLBACK_EUR_RATE` constant near the top of the file (approximate EUR/USD rate, e.g., `0.92`). Add a clear comment explaining this is a last-resort fallback when the API is unreachable.
+- Add a `MAX_EXCHANGE_RATE_RETRIES` constant set to `2` (for 3 total attempts).
+- Add a `EXCHANGE_RATE_TIMEOUT_MS` constant set to `5000` (5 seconds).
+- Modify `fetchExchangeRates()` to:
+  - Use `AbortSignal.timeout(EXCHANGE_RATE_TIMEOUT_MS)` on the fetch call for a 5-second timeout.
+  - Wrap the fetch in a retry loop that attempts up to `MAX_EXCHANGE_RATE_RETRIES + 1` total attempts.
+  - On failure, wait with exponential backoff (`500ms * 2^attempt`) before retrying.
+  - Log each retry attempt (e.g., `Retrying exchange rate fetch (attempt 2/3)...`).
+  - After all retries are exhausted, return fallback rates for any requested currencies that have a known fallback (EUR).
+
+### 2. Extract EUR rate calculation helper to avoid division-by-zero
+
+- Add a new exported function `computeEurRate(costBreakdown: CostBreakdown): number` in `adws/core/costReport.ts` that:
+  - Finds the EUR entry in `costBreakdown.currencies`.
+  - If `eurEntry` is found and `costBreakdown.totalCostUsd > 0`, returns `eurEntry.amount / costBreakdown.totalCostUsd`.
+  - Otherwise returns `0`.
+- Export this function from `adws/core/index.ts`.
+
+### 3. Fix EUR rate calculation in `adws/phases/workflowCompletion.ts`
+
+- Import `computeEurRate` from `../core`.
+- Replace lines 43-44 (the inline `eurEntry` lookup and division) with a call to `computeEurRate(costBreakdown)`.
+
+### 4. Fix EUR rate calculation in `adws/phases/prReviewCompletion.ts`
+
+- Import `computeEurRate` from `../core`.
+- Replace lines 106-107 (the inline `eurEntry` lookup and division) with a call to `computeEurRate(costBreakdown)`.
+
+### 5. Update tests in `adws/core/__tests__/costReport.test.ts`
+
+- Add tests for `fetchExchangeRates` retry behavior:
+  - Test that a transient failure followed by success returns correct rates (mock fetch to fail once then succeed).
+  - Test that after all retries are exhausted, fallback EUR rate is returned.
+  - Test that the timeout signal is passed to fetch.
+- Add tests for `computeEurRate`:
+  - Test with valid EUR entry and non-zero totalCostUsd — returns correct rate.
+  - Test with zero totalCostUsd — returns `0`.
+  - Test with no EUR entry in currencies — returns `0`.
+
+### 6. Run validation commands
+
+- Run all validation commands listed below to confirm the fix works with zero regressions.
+
+## Validation Commands
+Execute every command to validate the bug is fixed with zero regressions.
+
+- `bun run lint` — Run linter to check for code quality issues.
+- `bunx tsc --noEmit` — Type-check the main project.
+- `bunx tsc --noEmit -p adws/tsconfig.json` — Type-check the ADW scripts.
+- `bun run test` — Run all tests to validate the bug is fixed with zero regressions.
+
+## Notes
+- Follow `guidelines/coding_guidelines.md` strictly: use strict types (no `any`), prefer pure functions, meaningful error messages, and immutable data.
+- The `FALLBACK_EUR_RATE` is an approximate value meant as a last resort. It will be overwritten by live rates whenever the API is reachable. Add a comment explaining this.
+- The retry delay uses a simple `await new Promise(resolve => setTimeout(resolve, delay))` pattern — no external retry library needed.
+- `AbortSignal.timeout()` is available in Node.js 17.3+ and Bun, which this project uses.
+- The webhook handler in `webhookHandlers.ts` calls `fetchExchangeRates` directly and will automatically benefit from the retry and fallback improvements without any code changes.

--- a/specs/issue-99-plan.md
+++ b/specs/issue-99-plan.md
@@ -1,0 +1,89 @@
+# PR-Review: Update fallback rate with latest fetched rate
+
+## PR-Review Description
+The reviewer (`paysdoc`) commented on `adws/core/costReport.ts` (line 12) requesting that when a successful exchange rate fetch returns a valid rate, the fallback rate should be updated with the latest fetched rate. Currently, the `FALLBACK_EUR_RATE` is hardcoded to `0.92` and never updated at runtime. If a fetch succeeds and returns `EUR: 0.93`, a subsequent failed fetch would still fall back to the stale `0.92` value. The reviewer wants the fallback to always reflect the most recently known live rate, so that if the API becomes unreachable later, the fallback is as accurate as possible.
+
+## Summary of Original Implementation Plan
+The original plan (`specs/issue-99-adw-bug-in-currency-conv-kcbcrp-sdlc_planner-fix-currency-conversion.md`) added resilience to `fetchExchangeRates()`:
+1. Retry with exponential backoff (up to 3 total attempts)
+2. Fetch timeout via `AbortSignal.timeout(5000)`
+3. Hardcoded fallback EUR rate (`0.92`) when all retries fail
+4. Extracted `computeEurRate()` helper to prevent division-by-zero
+5. Updated consumers in `workflowCompletion.ts` and `prReviewCompletion.ts`
+6. Added comprehensive test coverage for retry, timeout, and fallback behavior
+
+## Relevant Files
+Use these files to resolve the review:
+
+- `guidelines/coding_guidelines.md` — Coding guidelines to follow (immutability principle, type safety, testing requirements).
+- `adws/core/costReport.ts` — Primary file to modify. Contains `FALLBACK_EUR_RATE`, `FALLBACK_RATES`, and `fetchExchangeRates()`. The fallback rates need to be dynamically updated on successful fetch.
+- `adws/core/__tests__/costReport.test.ts` — Tests for `fetchExchangeRates`. Must be updated to verify that a successful fetch updates the fallback rate used by subsequent failed fetches.
+
+## Step by Step Tasks
+IMPORTANT: Execute every step in order, top to bottom.
+
+### 1. Introduce a mutable cached rates store in `adws/core/costReport.ts`
+
+- Add a module-level mutable variable `let lastKnownRates: Record<string, number> = { ...FALLBACK_RATES };` below the `FALLBACK_RATES` constant.
+- This variable will hold the most recently fetched live rates, initialized with the hardcoded defaults.
+- The immutable `FALLBACK_RATES` constant remains unchanged as the initial seed value.
+
+### 2. Update `fetchExchangeRates()` to persist successful rates into `lastKnownRates`
+
+- After a successful fetch returns valid rates (inside the `for` loop on the success path), update `lastKnownRates` with each fetched rate:
+  ```typescript
+  for (const currency of targetCurrencies) {
+    const rate = data.rates[currency];
+    if (typeof rate === 'number') {
+      rates[currency] = rate;
+      lastKnownRates[currency] = rate; // Update fallback with latest rate
+    }
+  }
+  ```
+- This ensures the next time the function falls back, it uses the most recently known live rate instead of the hardcoded default.
+
+### 3. Update the fallback path to use `lastKnownRates` instead of `FALLBACK_RATES`
+
+- In the fallback section (after all retries are exhausted), change the lookup from `FALLBACK_RATES[currency]` to `lastKnownRates[currency]`:
+  ```typescript
+  for (const currency of targetCurrencies) {
+    const fallback = lastKnownRates[currency];
+    if (typeof fallback === 'number') {
+      fallbackRates[currency] = fallback;
+    }
+  }
+  ```
+- This means the fallback will use the latest live rate if one was ever fetched during this process's lifetime, and the hardcoded default otherwise.
+
+### 4. Export a test utility to reset cached rates (for test isolation)
+
+- Export a function `resetLastKnownRates(): void` that resets `lastKnownRates` back to `{ ...FALLBACK_RATES }`.
+- This function is only needed for test isolation so that tests don't leak state between test cases.
+- Mark with a JSDoc comment: `/** @internal Resets cached rates — for testing only. */`
+
+### 5. Update tests in `adws/core/__tests__/costReport.test.ts`
+
+- Import `resetLastKnownRates` from `../costReport`.
+- Call `resetLastKnownRates()` in the `beforeEach` of the `fetchExchangeRates` describe block to ensure test isolation.
+- Add a new test case: "updates fallback rate with latest fetched rate for subsequent failures":
+  1. Mock fetch to succeed once with `{ rates: { EUR: 0.95 } }`.
+  2. Call `fetchExchangeRates(['EUR'])` — expect `{ EUR: 0.95 }`.
+  3. Mock fetch to reject with a network error (all retries fail).
+  4. Call `fetchExchangeRates(['EUR'])` again — expect `{ EUR: 0.95 }` (the updated fallback, not `0.92`).
+
+### 6. Run validation commands
+
+- Run all validation commands listed below to confirm the review is resolved with zero regressions.
+
+## Validation Commands
+Execute every command to validate the review is complete with zero regressions.
+
+- `bun run lint` — Run linter to check for code quality issues.
+- `bunx tsc --noEmit` — Type-check the main project.
+- `bunx tsc --noEmit -p adws/tsconfig.json` — Type-check the ADW scripts.
+- `bun run test` — Run all tests to validate zero regressions.
+
+## Notes
+- Per `guidelines/coding_guidelines.md`, the immutable `FALLBACK_RATES` constant remains untouched. The mutable `lastKnownRates` is a separate runtime cache, keeping the initial defaults separate from the live cache.
+- The `resetLastKnownRates()` function is intentionally exported for test isolation. An alternative is to use `vi.importActual` and module re-imports, but a simple reset function is clearer and easier to maintain.
+- This change has no impact on other consumers (`workflowCompletion.ts`, `prReviewCompletion.ts`, `webhookHandlers.ts`) since they all call `fetchExchangeRates()` which now transparently caches rates.


### PR DESCRIPTION
## Summary

Fixes a bug where currency conversion fetch was failing with `TypeError: fetch failed`, causing issues during workflow cost reporting.

- Issue: [#99 - Bug in currency conversion](https://github.com/paysdoc/AI_Dev_Workflow/issues/99)
- ADW Tracking ID: `bug-in-currency-conv-kcbcrp`
- Plan: `specs/issue-99-adw-bug-in-currency-conv-kcbcrp-sdlc_planner-fix-currency-conversion.md`

## What was done

- [x] Added retry logic to currency fetch with configurable attempts
- [x] Added timeout handling to prevent indefinite hangs
- [x] Added fallback mechanism when exchange rate fetch fails
- [x] Updated `costReport.ts` with robust fetch error handling
- [x] Expanded `costReport.test.ts` with tests covering retry, timeout, and fallback scenarios
- [x] Exported updated module from `core/index.ts`

## Key changes

- `adws/core/costReport.ts`: Added retry, timeout, and fallback logic to the currency conversion fetch
- `adws/core/__tests__/costReport.test.ts`: Added test coverage for new retry/timeout/fallback behavior
- `adws/core/index.ts`: Exported `costReport` module
- `adws/phases/workflowCompletion.ts` / `prReviewCompletion.ts`: Minor updates to use improved cost reporting

Closes #99