### PR TITLE
feat: #114 - Implement GitHub IssueTracker provider

### DIFF
--- a/adws/providers/github/__tests__/githubIssueTracker.test.ts
+++ b/adws/providers/github/__tests__/githubIssueTracker.test.ts
@@ -1,0 +1,297 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import type { GitHubIssue, IssueCommentSummary } from '../../../types/issueTypes';
+import { Platform, type RepoIdentifier } from '../../types';
+
+vi.mock('../../../github/issueApi', () => ({
+  fetchGitHubIssue: vi.fn(),
+  commentOnIssue: vi.fn(),
+  deleteIssueComment: vi.fn(),
+  closeIssue: vi.fn(),
+  getIssueState: vi.fn(),
+  fetchIssueCommentsRest: vi.fn(),
+}));
+
+vi.mock('../../../github/projectBoardApi', () => ({
+  moveIssueToStatus: vi.fn(),
+}));
+
+import {
+  fetchGitHubIssue,
+  commentOnIssue as ghCommentOnIssue,
+  deleteIssueComment,
+  closeIssue as ghCloseIssue,
+  getIssueState as ghGetIssueState,
+  fetchIssueCommentsRest,
+} from '../../../github/issueApi';
+import { moveIssueToStatus } from '../../../github/projectBoardApi';
+import { createGitHubIssueTracker } from '../githubIssueTracker';
+
+const validRepoId: RepoIdentifier = {
+  owner: 'acme',
+  repo: 'widgets',
+  platform: Platform.GitHub,
+};
+
+const expectedRepoInfo = { owner: 'acme', repo: 'widgets' };
+
+const makeGitHubIssue = (overrides: Partial<GitHubIssue> = {}): GitHubIssue => ({
+  number: 42,
+  title: 'Test issue',
+  body: 'Issue body',
+  state: 'OPEN',
+  author: { login: 'bob', name: 'Bob', isBot: false },
+  assignees: [],
+  labels: [{ id: 'lbl-1', name: 'bug', color: 'red', description: null }],
+  milestone: null,
+  comments: [{
+    id: 'c1',
+    author: { login: 'alice', name: 'Alice', isBot: false },
+    body: 'A comment',
+    createdAt: '2026-01-15T10:00:00Z',
+    updatedAt: null,
+  }],
+  createdAt: '2026-01-01T00:00:00Z',
+  updatedAt: '2026-01-02T00:00:00Z',
+  closedAt: null,
+  url: 'https://github.com/acme/widgets/issues/42',
+  ...overrides,
+});
+
+describe('createGitHubIssueTracker', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe('construction', () => {
+    it('creates a tracker with a valid RepoIdentifier', () => {
+      expect(() => createGitHubIssueTracker(validRepoId)).not.toThrow();
+    });
+
+    it('throws on empty owner', () => {
+      const bad: RepoIdentifier = { owner: '', repo: 'widgets', platform: Platform.GitHub };
+      expect(() => createGitHubIssueTracker(bad)).toThrow('owner must not be empty');
+    });
+
+    it('throws on empty repo', () => {
+      const bad: RepoIdentifier = { owner: 'acme', repo: '', platform: Platform.GitHub };
+      expect(() => createGitHubIssueTracker(bad)).toThrow('repo must not be empty');
+    });
+
+    it('throws on whitespace-only owner', () => {
+      const bad: RepoIdentifier = { owner: '   ', repo: 'widgets', platform: Platform.GitHub };
+      expect(() => createGitHubIssueTracker(bad)).toThrow('owner must not be empty');
+    });
+
+    it('returns an object with all IssueTracker methods', () => {
+      const tracker = createGitHubIssueTracker(validRepoId);
+      expect(typeof tracker.fetchIssue).toBe('function');
+      expect(typeof tracker.commentOnIssue).toBe('function');
+      expect(typeof tracker.deleteComment).toBe('function');
+      expect(typeof tracker.closeIssue).toBe('function');
+      expect(typeof tracker.getIssueState).toBe('function');
+      expect(typeof tracker.fetchComments).toBe('function');
+      expect(typeof tracker.moveToStatus).toBe('function');
+    });
+  });
+
+  describe('fetchIssue', () => {
+    it('delegates to fetchGitHubIssue with bound repoInfo and maps result', async () => {
+      const ghIssue = makeGitHubIssue();
+      vi.mocked(fetchGitHubIssue).mockResolvedValue(ghIssue);
+
+      const tracker = createGitHubIssueTracker(validRepoId);
+      const result = await tracker.fetchIssue(42);
+
+      expect(fetchGitHubIssue).toHaveBeenCalledWith(42, expectedRepoInfo);
+      expect(result.id).toBe('42');
+      expect(result.number).toBe(42);
+      expect(result.title).toBe('Test issue');
+      expect(result.author).toBe('bob');
+      expect(result.labels).toEqual(['bug']);
+      expect(result.comments).toHaveLength(1);
+      expect(result.comments[0].author).toBe('alice');
+    });
+
+    it('passes bound repoInfo, not undefined', async () => {
+      vi.mocked(fetchGitHubIssue).mockResolvedValue(makeGitHubIssue());
+
+      const tracker = createGitHubIssueTracker(validRepoId);
+      await tracker.fetchIssue(1);
+
+      const calledWith = vi.mocked(fetchGitHubIssue).mock.calls[0];
+      expect(calledWith[1]).toEqual(expectedRepoInfo);
+      expect(calledWith[1]).not.toBeUndefined();
+    });
+  });
+
+  describe('commentOnIssue', () => {
+    it('delegates to underlying commentOnIssue with bound repoInfo', () => {
+      const tracker = createGitHubIssueTracker(validRepoId);
+      tracker.commentOnIssue(10, 'Hello');
+
+      expect(ghCommentOnIssue).toHaveBeenCalledWith(10, 'Hello', expectedRepoInfo);
+    });
+  });
+
+  describe('deleteComment', () => {
+    it('converts string ID to number and delegates with bound repoInfo', () => {
+      const tracker = createGitHubIssueTracker(validRepoId);
+      tracker.deleteComment('123');
+
+      expect(deleteIssueComment).toHaveBeenCalledWith(123, expectedRepoInfo);
+    });
+
+    it('handles string "0" correctly', () => {
+      const tracker = createGitHubIssueTracker(validRepoId);
+      tracker.deleteComment('0');
+
+      expect(deleteIssueComment).toHaveBeenCalledWith(0, expectedRepoInfo);
+    });
+  });
+
+  describe('closeIssue', () => {
+    it('delegates with comment and bound repoInfo', async () => {
+      vi.mocked(ghCloseIssue).mockResolvedValue(true);
+
+      const tracker = createGitHubIssueTracker(validRepoId);
+      const result = await tracker.closeIssue(42, 'Closing comment');
+
+      expect(ghCloseIssue).toHaveBeenCalledWith(42, 'Closing comment', expectedRepoInfo);
+      expect(result).toBe(true);
+    });
+
+    it('delegates without optional comment', async () => {
+      vi.mocked(ghCloseIssue).mockResolvedValue(true);
+
+      const tracker = createGitHubIssueTracker(validRepoId);
+      await tracker.closeIssue(42);
+
+      expect(ghCloseIssue).toHaveBeenCalledWith(42, undefined, expectedRepoInfo);
+    });
+
+    it('returns false when issue is already closed', async () => {
+      vi.mocked(ghCloseIssue).mockResolvedValue(false);
+
+      const tracker = createGitHubIssueTracker(validRepoId);
+      const result = await tracker.closeIssue(42);
+
+      expect(result).toBe(false);
+    });
+  });
+
+  describe('getIssueState', () => {
+    it('delegates and returns the state string', () => {
+      vi.mocked(ghGetIssueState).mockReturnValue('OPEN');
+
+      const tracker = createGitHubIssueTracker(validRepoId);
+      const result = tracker.getIssueState(42);
+
+      expect(ghGetIssueState).toHaveBeenCalledWith(42, expectedRepoInfo);
+      expect(result).toBe('OPEN');
+    });
+
+    it('returns CLOSED state', () => {
+      vi.mocked(ghGetIssueState).mockReturnValue('CLOSED');
+
+      const tracker = createGitHubIssueTracker(validRepoId);
+      const result = tracker.getIssueState(42);
+
+      expect(result).toBe('CLOSED');
+    });
+  });
+
+  describe('fetchComments', () => {
+    it('delegates and maps IssueCommentSummary to WorkItemComment', () => {
+      const summaries: IssueCommentSummary[] = [
+        { id: 100, body: 'First', authorLogin: 'alice', createdAt: '2026-01-01T00:00:00Z' },
+        { id: 200, body: 'Second', authorLogin: 'bob', createdAt: '2026-01-02T00:00:00Z' },
+      ];
+      vi.mocked(fetchIssueCommentsRest).mockReturnValue(summaries);
+
+      const tracker = createGitHubIssueTracker(validRepoId);
+      const result = tracker.fetchComments(42);
+
+      expect(fetchIssueCommentsRest).toHaveBeenCalledWith(42, expectedRepoInfo);
+      expect(result).toHaveLength(2);
+      expect(result[0]).toEqual({
+        id: '100',
+        body: 'First',
+        author: 'alice',
+        createdAt: '2026-01-01T00:00:00Z',
+      });
+      expect(result[1]).toEqual({
+        id: '200',
+        body: 'Second',
+        author: 'bob',
+        createdAt: '2026-01-02T00:00:00Z',
+      });
+    });
+
+    it('returns empty array when no comments', () => {
+      vi.mocked(fetchIssueCommentsRest).mockReturnValue([]);
+
+      const tracker = createGitHubIssueTracker(validRepoId);
+      const result = tracker.fetchComments(42);
+
+      expect(result).toEqual([]);
+    });
+  });
+
+  describe('moveToStatus', () => {
+    it('delegates to moveIssueToStatus with bound repoInfo', async () => {
+      vi.mocked(moveIssueToStatus).mockResolvedValue(undefined);
+
+      const tracker = createGitHubIssueTracker(validRepoId);
+      await tracker.moveToStatus(42, 'In Progress');
+
+      expect(moveIssueToStatus).toHaveBeenCalledWith(42, 'In Progress', expectedRepoInfo);
+    });
+  });
+
+  describe('repo binding', () => {
+    it('all methods use the bound repoInfo from construction', async () => {
+      const ghIssue = makeGitHubIssue();
+      vi.mocked(fetchGitHubIssue).mockResolvedValue(ghIssue);
+      vi.mocked(ghCloseIssue).mockResolvedValue(true);
+      vi.mocked(ghGetIssueState).mockReturnValue('OPEN');
+      vi.mocked(fetchIssueCommentsRest).mockReturnValue([]);
+      vi.mocked(moveIssueToStatus).mockResolvedValue(undefined);
+
+      const tracker = createGitHubIssueTracker(validRepoId);
+
+      await tracker.fetchIssue(1);
+      tracker.commentOnIssue(1, 'test');
+      tracker.deleteComment('1');
+      await tracker.closeIssue(1);
+      tracker.getIssueState(1);
+      tracker.fetchComments(1);
+      await tracker.moveToStatus(1, 'Done');
+
+      // Every underlying function received the bound repoInfo
+      expect(fetchGitHubIssue).toHaveBeenCalledWith(1, expectedRepoInfo);
+      expect(ghCommentOnIssue).toHaveBeenCalledWith(1, 'test', expectedRepoInfo);
+      expect(deleteIssueComment).toHaveBeenCalledWith(1, expectedRepoInfo);
+      expect(ghCloseIssue).toHaveBeenCalledWith(1, undefined, expectedRepoInfo);
+      expect(ghGetIssueState).toHaveBeenCalledWith(1, expectedRepoInfo);
+      expect(fetchIssueCommentsRest).toHaveBeenCalledWith(1, expectedRepoInfo);
+      expect(moveIssueToStatus).toHaveBeenCalledWith(1, 'Done', expectedRepoInfo);
+    });
+
+    it('two trackers with different repos are independent', () => {
+      vi.mocked(ghGetIssueState).mockReturnValue('OPEN');
+
+      const tracker1 = createGitHubIssueTracker(validRepoId);
+      const tracker2 = createGitHubIssueTracker({
+        owner: 'other',
+        repo: 'project',
+        platform: Platform.GitHub,
+      });
+
+      tracker1.getIssueState(1);
+      tracker2.getIssueState(2);
+
+      expect(ghGetIssueState).toHaveBeenCalledWith(1, { owner: 'acme', repo: 'widgets' });
+      expect(ghGetIssueState).toHaveBeenCalledWith(2, { owner: 'other', repo: 'project' });
+    });
+  });
+});

--- a/adws/providers/github/__tests__/mappers.test.ts
+++ b/adws/providers/github/__tests__/mappers.test.ts
@@ -1,0 +1,203 @@
+import { describe, it, expect } from 'vitest';
+import {
+  mapGitHubIssueToWorkItem,
+  mapGitHubCommentToWorkItemComment,
+  mapIssueCommentSummaryToWorkItemComment,
+  toRepoInfo,
+} from '../mappers';
+import type { GitHubIssue, GitHubComment, IssueCommentSummary } from '../../../types/issueTypes';
+import { Platform, type RepoIdentifier } from '../../types';
+
+const makeGitHubComment = (overrides: Partial<GitHubComment> = {}): GitHubComment => ({
+  id: 'comment-1',
+  author: { login: 'alice', name: 'Alice', isBot: false },
+  body: 'A comment',
+  createdAt: '2026-01-15T10:00:00Z',
+  updatedAt: '2026-01-15T11:00:00Z',
+  ...overrides,
+});
+
+const makeGitHubIssue = (overrides: Partial<GitHubIssue> = {}): GitHubIssue => ({
+  number: 42,
+  title: 'Test issue',
+  body: 'Issue body',
+  state: 'OPEN',
+  author: { login: 'bob', name: 'Bob', isBot: false },
+  assignees: [{ login: 'carol', name: 'Carol', isBot: false }],
+  labels: [{ id: 'lbl-1', name: 'bug', color: 'red', description: 'A bug' }],
+  milestone: { id: 'ms-1', number: 1, title: 'v1.0', description: 'First release', state: 'open' },
+  comments: [makeGitHubComment()],
+  createdAt: '2026-01-01T00:00:00Z',
+  updatedAt: '2026-01-02T00:00:00Z',
+  closedAt: null,
+  url: 'https://github.com/acme/widgets/issues/42',
+  ...overrides,
+});
+
+describe('mapGitHubCommentToWorkItemComment', () => {
+  it('maps all fields correctly', () => {
+    const comment = makeGitHubComment();
+    const result = mapGitHubCommentToWorkItemComment(comment);
+
+    expect(result).toEqual({
+      id: 'comment-1',
+      body: 'A comment',
+      author: 'alice',
+      createdAt: '2026-01-15T10:00:00Z',
+    });
+  });
+
+  it('maps comment with null updatedAt without affecting output', () => {
+    const comment = makeGitHubComment({ updatedAt: null });
+    const result = mapGitHubCommentToWorkItemComment(comment);
+
+    expect(result.id).toBe('comment-1');
+    expect(result.author).toBe('alice');
+    expect(result).not.toHaveProperty('updatedAt');
+  });
+
+  it('maps comment from bot author', () => {
+    const comment = makeGitHubComment({
+      author: { login: 'dependabot[bot]', name: null, isBot: true },
+    });
+    const result = mapGitHubCommentToWorkItemComment(comment);
+
+    expect(result.author).toBe('dependabot[bot]');
+  });
+});
+
+describe('mapGitHubIssueToWorkItem', () => {
+  it('maps a full issue with all fields populated', () => {
+    const issue = makeGitHubIssue();
+    const result = mapGitHubIssueToWorkItem(issue);
+
+    expect(result).toEqual({
+      id: '42',
+      number: 42,
+      title: 'Test issue',
+      body: 'Issue body',
+      state: 'OPEN',
+      author: 'bob',
+      labels: ['bug'],
+      comments: [{
+        id: 'comment-1',
+        body: 'A comment',
+        author: 'alice',
+        createdAt: '2026-01-15T10:00:00Z',
+      }],
+    });
+  });
+
+  it('id is the string version of number', () => {
+    const issue = makeGitHubIssue({ number: 999 });
+    const result = mapGitHubIssueToWorkItem(issue);
+
+    expect(result.id).toBe('999');
+    expect(result.number).toBe(999);
+  });
+
+  it('maps issue with empty comments, labels, and body', () => {
+    const issue = makeGitHubIssue({
+      comments: [],
+      labels: [],
+      body: '',
+    });
+    const result = mapGitHubIssueToWorkItem(issue);
+
+    expect(result.comments).toEqual([]);
+    expect(result.labels).toEqual([]);
+    expect(result.body).toBe('');
+  });
+
+  it('maps issue with bot author', () => {
+    const issue = makeGitHubIssue({
+      author: { login: 'github-actions[bot]', name: null, isBot: true },
+    });
+    const result = mapGitHubIssueToWorkItem(issue);
+
+    expect(result.author).toBe('github-actions[bot]');
+  });
+
+  it('maps multiple labels to string array', () => {
+    const issue = makeGitHubIssue({
+      labels: [
+        { id: 'lbl-1', name: 'bug', color: 'red', description: null },
+        { id: 'lbl-2', name: 'priority:high', color: 'orange', description: 'High priority' },
+        { id: 'lbl-3', name: 'enhancement', color: 'blue', description: null },
+      ],
+    });
+    const result = mapGitHubIssueToWorkItem(issue);
+
+    expect(result.labels).toEqual(['bug', 'priority:high', 'enhancement']);
+  });
+
+  it('maps multiple comments', () => {
+    const issue = makeGitHubIssue({
+      comments: [
+        makeGitHubComment({ id: 'c1', body: 'First' }),
+        makeGitHubComment({ id: 'c2', body: 'Second', author: { login: 'dan', name: 'Dan', isBot: false } }),
+      ],
+    });
+    const result = mapGitHubIssueToWorkItem(issue);
+
+    expect(result.comments).toHaveLength(2);
+    expect(result.comments[0].id).toBe('c1');
+    expect(result.comments[1].author).toBe('dan');
+  });
+});
+
+describe('mapIssueCommentSummaryToWorkItemComment', () => {
+  it('maps all fields correctly with numeric id converted to string', () => {
+    const comment: IssueCommentSummary = {
+      id: 12345,
+      body: 'REST comment',
+      authorLogin: 'eve',
+      createdAt: '2026-02-01T00:00:00Z',
+    };
+    const result = mapIssueCommentSummaryToWorkItemComment(comment);
+
+    expect(result).toEqual({
+      id: '12345',
+      body: 'REST comment',
+      author: 'eve',
+      createdAt: '2026-02-01T00:00:00Z',
+    });
+  });
+
+  it('converts numeric id to string', () => {
+    const comment: IssueCommentSummary = {
+      id: 0,
+      body: '',
+      authorLogin: 'bot',
+      createdAt: '2026-01-01T00:00:00Z',
+    };
+    const result = mapIssueCommentSummaryToWorkItemComment(comment);
+
+    expect(result.id).toBe('0');
+  });
+});
+
+describe('toRepoInfo', () => {
+  it('extracts only owner and repo, drops platform', () => {
+    const repoId: RepoIdentifier = {
+      owner: 'acme',
+      repo: 'widgets',
+      platform: Platform.GitHub,
+    };
+    const result = toRepoInfo(repoId);
+
+    expect(result).toEqual({ owner: 'acme', repo: 'widgets' });
+    expect(result).not.toHaveProperty('platform');
+  });
+
+  it('works with different platforms', () => {
+    const repoId: RepoIdentifier = {
+      owner: 'org',
+      repo: 'project',
+      platform: Platform.GitLab,
+    };
+    const result = toRepoInfo(repoId);
+
+    expect(result).toEqual({ owner: 'org', repo: 'project' });
+  });
+});

--- a/adws/providers/github/githubIssueTracker.ts
+++ b/adws/providers/github/githubIssueTracker.ts
@@ -1,0 +1,77 @@
+/**
+ * GitHub implementation of the IssueTracker provider interface.
+ * Wraps existing issueApi.ts and projectBoardApi.ts functions, binding them
+ * to a specific RepoIdentifier at construction time.
+ */
+
+import type { IssueTracker, RepoIdentifier, WorkItem, WorkItemComment } from '../types';
+import { validateRepoIdentifier } from '../types';
+import type { RepoInfo } from '../../github/githubApi';
+import {
+  fetchGitHubIssue,
+  commentOnIssue as ghCommentOnIssue,
+  deleteIssueComment,
+  closeIssue as ghCloseIssue,
+  getIssueState as ghGetIssueState,
+  fetchIssueCommentsRest,
+} from '../../github/issueApi';
+import { moveIssueToStatus } from '../../github/projectBoardApi';
+import {
+  mapGitHubIssueToWorkItem,
+  mapIssueCommentSummaryToWorkItemComment,
+  toRepoInfo,
+} from './mappers';
+
+/**
+ * IssueTracker implementation for GitHub Issues.
+ * Bound to a specific repository at construction time — every method
+ * passes the bound RepoInfo to the underlying function, never relying
+ * on the global getTargetRepo() registry.
+ */
+class GitHubIssueTracker implements IssueTracker {
+  private readonly repoInfo: RepoInfo;
+
+  constructor(private readonly repoId: RepoIdentifier) {
+    validateRepoIdentifier(repoId);
+    this.repoInfo = toRepoInfo(repoId);
+  }
+
+  async fetchIssue(issueNumber: number): Promise<WorkItem> {
+    const issue = await fetchGitHubIssue(issueNumber, this.repoInfo);
+    return mapGitHubIssueToWorkItem(issue);
+  }
+
+  commentOnIssue(issueNumber: number, body: string): void {
+    ghCommentOnIssue(issueNumber, body, this.repoInfo);
+  }
+
+  deleteComment(commentId: string): void {
+    deleteIssueComment(Number(commentId), this.repoInfo);
+  }
+
+  async closeIssue(issueNumber: number, comment?: string): Promise<boolean> {
+    return ghCloseIssue(issueNumber, comment, this.repoInfo);
+  }
+
+  getIssueState(issueNumber: number): string {
+    return ghGetIssueState(issueNumber, this.repoInfo);
+  }
+
+  fetchComments(issueNumber: number): WorkItemComment[] {
+    const comments = fetchIssueCommentsRest(issueNumber, this.repoInfo);
+    return comments.map(mapIssueCommentSummaryToWorkItemComment);
+  }
+
+  async moveToStatus(issueNumber: number, status: string): Promise<void> {
+    await moveIssueToStatus(issueNumber, status, this.repoInfo);
+  }
+}
+
+/**
+ * Factory function to create a GitHub IssueTracker provider.
+ * @param repoId - The repository identifier to bind the provider to.
+ * @returns An IssueTracker instance bound to the specified repository.
+ */
+export function createGitHubIssueTracker(repoId: RepoIdentifier): IssueTracker {
+  return new GitHubIssueTracker(repoId);
+}

--- a/adws/providers/github/index.ts
+++ b/adws/providers/github/index.ts
@@ -1,0 +1,2 @@
+export { createGitHubIssueTracker } from './githubIssueTracker';
+export * from './mappers';

--- a/adws/providers/github/mappers.ts
+++ b/adws/providers/github/mappers.ts
@@ -1,0 +1,56 @@
+/**
+ * Type mapping functions between GitHub-specific types and platform-agnostic provider types.
+ * All functions are pure — no side effects, no imports of global state.
+ */
+
+import type { GitHubIssue, GitHubComment, IssueCommentSummary } from '../../types/issueTypes';
+import type { WorkItem, WorkItemComment } from '../types';
+import type { RepoInfo } from '../../github/githubApi';
+import type { RepoIdentifier } from '../types';
+
+/**
+ * Maps a GitHubComment to a platform-agnostic WorkItemComment.
+ */
+export function mapGitHubCommentToWorkItemComment(comment: GitHubComment): WorkItemComment {
+  return {
+    id: comment.id,
+    body: comment.body,
+    author: comment.author.login,
+    createdAt: comment.createdAt,
+  };
+}
+
+/**
+ * Maps a GitHubIssue to a platform-agnostic WorkItem.
+ */
+export function mapGitHubIssueToWorkItem(issue: GitHubIssue): WorkItem {
+  return {
+    id: issue.number.toString(),
+    number: issue.number,
+    title: issue.title,
+    body: issue.body,
+    state: issue.state,
+    author: issue.author.login,
+    labels: issue.labels.map((l) => l.name),
+    comments: issue.comments.map(mapGitHubCommentToWorkItemComment),
+  };
+}
+
+/**
+ * Maps an IssueCommentSummary (REST API format) to a platform-agnostic WorkItemComment.
+ */
+export function mapIssueCommentSummaryToWorkItemComment(comment: IssueCommentSummary): WorkItemComment {
+  return {
+    id: comment.id.toString(),
+    body: comment.body,
+    author: comment.authorLogin,
+    createdAt: comment.createdAt,
+  };
+}
+
+/**
+ * Converts a provider RepoIdentifier to the RepoInfo format used by existing GitHub API functions.
+ */
+export function toRepoInfo(repoId: RepoIdentifier): RepoInfo {
+  return { owner: repoId.owner, repo: repoId.repo };
+}

--- a/adws/providers/index.ts
+++ b/adws/providers/index.ts
@@ -1,1 +1,2 @@
 export * from './types';
+export * from './github';

--- a/specs/issue-114-adw-1773070548003-fbxjed-sdlc_planner-github-issue-tracker-provider.md
+++ b/specs/issue-114-adw-1773070548003-fbxjed-sdlc_planner-github-issue-tracker-provider.md
@@ -1,0 +1,198 @@
+# Feature: GitHub IssueTracker Provider
+
+## Metadata
+issueNumber: `114`
+adwId: `1773070548003-fbxjed`
+issueJson: `{"number":114,"title":"Implement GitHub IssueTracker provider","body":"## Summary\nWrap the existing GitHub issue operations (`issueApi.ts`, `projectBoardApi.ts`) behind the `IssueTracker` interface, creating the first concrete provider implementation.\n\n## Dependencies\n- #113 — Provider interfaces must be defined first\n\n## User Story\nAs a developer, I want the existing GitHub issue functionality wrapped in the IssueTracker interface so that phases can consume it through the abstraction without behavior changes.\n\n## Acceptance Criteria\n\n### Create `adws/providers/github/githubIssueTracker.ts`\n- Implement `IssueTracker` interface\n- Constructor takes `RepoIdentifier` — the provider is bound to a specific repo at creation time (no global registry fallback)\n- Wrap existing functions from `issueApi.ts`:\n  - `fetchGitHubIssue` → `fetchIssue` (transform `GitHubIssue` → `WorkItem`)\n  - `commentOnIssue` → `commentOnIssue`\n  - `deleteIssueComment` → `deleteComment`\n  - `closeIssue` → `closeIssue`\n  - `getIssueState` → `getIssueState`\n  - `fetchIssueCommentsRest` → `fetchComments` (transform `IssueCommentSummary` → `WorkItemComment`)\n- Wrap `moveIssueToStatus` from `projectBoardApi.ts` → `moveToStatus`\n- Factory function: `createGitHubIssueTracker(repoId: RepoIdentifier): IssueTracker`\n\n### Type mapping\n- Create mapping functions between `GitHubIssue` ↔ `WorkItem` and `IssueCommentSummary` ↔ `WorkItemComment`\n- These mappers live in `adws/providers/github/mappers.ts`\n\n### Tests\n- Unit tests for the provider in `adws/providers/github/__tests__/`\n- Test that the provider is correctly bound to its repo — calling methods should always use the bound repo, never fall back to global state\n- Test type mapping functions\n\n## Notes\n- The underlying `issueApi.ts` functions stay intact during this phase — the provider is a wrapper, not a replacement.\n- Each method must pass the bound `RepoIdentifier` explicitly to the underlying function — no reliance on `getTargetRepo()`.","state":"OPEN","author":"paysdoc","labels":["enhancement"],"createdAt":"2026-03-09T15:17:35Z","comments":[],"actionableComment":null}`
+
+## Feature Description
+Implement the first concrete provider for the `IssueTracker` interface defined in #113. This wraps the existing GitHub-specific issue operations (`issueApi.ts` and `projectBoardApi.ts`) behind the platform-agnostic `IssueTracker` interface. The provider is bound to a specific `RepoIdentifier` at construction time, passing it explicitly to every underlying function call — eliminating reliance on the global `getTargetRepo()` registry. Mapper functions translate between GitHub-specific types (`GitHubIssue`, `IssueCommentSummary`) and provider-agnostic types (`WorkItem`, `WorkItemComment`).
+
+## User Story
+As a developer
+I want the existing GitHub issue functionality wrapped in the IssueTracker interface
+So that workflow phases can consume it through the abstraction without behavior changes, enabling future support for other issue trackers (Jira, Linear, GitLab)
+
+## Problem Statement
+The ADW workflow phases currently call GitHub-specific functions directly (`fetchGitHubIssue`, `commentOnIssue`, etc.) and rely on the global `getTargetRepo()` registry for repository context. This tightly couples the workflow logic to GitHub and makes it impossible to support alternative issue trackers without modifying every phase.
+
+## Solution Statement
+Create a `GitHubIssueTracker` class that implements the `IssueTracker` interface from `adws/providers/types.ts`. The class is bound to a `RepoIdentifier` at construction time and delegates to the existing `issueApi.ts` and `projectBoardApi.ts` functions, converting its `RepoIdentifier` to the `RepoInfo` format those functions expect. Separate mapper functions handle type conversions between GitHub-specific types and the provider-agnostic `WorkItem`/`WorkItemComment` types.
+
+## Relevant Files
+Use these files to implement the feature:
+
+- `adws/providers/types.ts` — Defines the `IssueTracker` interface, `WorkItem`, `WorkItemComment`, `RepoIdentifier`, and `Platform` enum that the provider must implement.
+- `adws/providers/index.ts` — Provider barrel export; must be updated to re-export the new GitHub provider module.
+- `adws/providers/__tests__/types.test.ts` — Existing tests for provider types; reference for test patterns and conventions.
+- `adws/github/issueApi.ts` — Contains the underlying GitHub issue functions to wrap: `fetchGitHubIssue`, `commentOnIssue`, `deleteIssueComment`, `closeIssue`, `getIssueState`, `fetchIssueCommentsRest`.
+- `adws/github/projectBoardApi.ts` — Contains `moveIssueToStatus` to wrap for the `moveToStatus` method.
+- `adws/github/githubApi.ts` — Defines `RepoInfo` type used by the underlying functions; the provider must convert `RepoIdentifier` → `RepoInfo`.
+- `adws/types/issueTypes.ts` — Defines `GitHubIssue`, `IssueCommentSummary`, `GitHubUser`, `GitHubLabel`, `GitHubComment` types used for mapping.
+- `adws/core/index.ts` — Core barrel export; reference for export patterns.
+- `guidelines/coding_guidelines.md` — Coding guidelines that must be followed (immutability, pure functions, strict types, no decorators).
+
+### New Files
+- `adws/providers/github/mappers.ts` — Type mapping functions: `mapGitHubIssueToWorkItem`, `mapIssueCommentSummaryToWorkItemComment`.
+- `adws/providers/github/githubIssueTracker.ts` — `GitHubIssueTracker` class implementing `IssueTracker`, plus `createGitHubIssueTracker` factory function.
+- `adws/providers/github/index.ts` — Barrel export for the GitHub provider module.
+- `adws/providers/github/__tests__/mappers.test.ts` — Unit tests for the mapper functions.
+- `adws/providers/github/__tests__/githubIssueTracker.test.ts` — Unit tests for the provider class.
+
+## Implementation Plan
+### Phase 1: Foundation
+Create the mapper functions that convert between GitHub-specific types (`GitHubIssue`, `IssueCommentSummary`) and the platform-agnostic types (`WorkItem`, `WorkItemComment`). These are pure functions with no side effects, making them easy to test in isolation. Also create a helper to convert `RepoIdentifier` → `RepoInfo`.
+
+### Phase 2: Core Implementation
+Implement the `GitHubIssueTracker` class that implements the `IssueTracker` interface. The class stores a `RepoIdentifier` at construction time (validated via `validateRepoIdentifier`), converts it to `RepoInfo`, and delegates each method to the corresponding function from `issueApi.ts` or `projectBoardApi.ts`. The `deleteComment` method receives a `string` ID per the interface but must convert it to a `number` for `deleteIssueComment`.
+
+### Phase 3: Integration
+Export the new module through barrel files (`adws/providers/github/index.ts` and `adws/providers/index.ts`) so it is available to consumers. Write comprehensive tests verifying repo-binding, type mapping correctness, and delegation behavior.
+
+## Step by Step Tasks
+
+### Step 1: Create mapper functions
+- Create `adws/providers/github/mappers.ts`
+- Implement `mapGitHubIssueToWorkItem(issue: GitHubIssue): WorkItem`:
+  - Map `issue.number` → `WorkItem.number`
+  - Map `issue.number.toString()` → `WorkItem.id` (GitHub issues use number as ID)
+  - Map `issue.title`, `issue.body`, `issue.state` directly
+  - Map `issue.author.login` → `WorkItem.author`
+  - Map `issue.labels.map(l => l.name)` → `WorkItem.labels`
+  - Map `issue.comments.map(c => mapGitHubCommentToWorkItemComment(c))` → `WorkItem.comments`
+- Implement `mapGitHubCommentToWorkItemComment(comment: GitHubComment): WorkItemComment`:
+  - Map `comment.id` → `WorkItemComment.id`
+  - Map `comment.body` → `WorkItemComment.body`
+  - Map `comment.author.login` → `WorkItemComment.author`
+  - Map `comment.createdAt` → `WorkItemComment.createdAt`
+- Implement `mapIssueCommentSummaryToWorkItemComment(comment: IssueCommentSummary): WorkItemComment`:
+  - Map `comment.id.toString()` → `WorkItemComment.id` (numeric ID → string)
+  - Map `comment.body` → `WorkItemComment.body`
+  - Map `comment.authorLogin` → `WorkItemComment.author`
+  - Map `comment.createdAt` → `WorkItemComment.createdAt`
+- Implement `toRepoInfo(repoId: RepoIdentifier): RepoInfo`:
+  - Return `{ owner: repoId.owner, repo: repoId.repo }`
+  - This is the bridge between the provider's `RepoIdentifier` and the existing functions' `RepoInfo`
+
+### Step 2: Create mapper unit tests
+- Create `adws/providers/github/__tests__/mappers.test.ts`
+- Test `mapGitHubIssueToWorkItem`:
+  - Full issue with all fields populated (comments, labels, milestone, assignees)
+  - Issue with empty comments, labels, body
+  - Issue with bot author
+  - Verify `id` is string version of `number`
+- Test `mapGitHubCommentToWorkItemComment`:
+  - Standard comment mapping
+  - Comment with null `updatedAt` (should not affect output)
+- Test `mapIssueCommentSummaryToWorkItemComment`:
+  - Standard mapping with numeric id converted to string
+  - Verify all fields mapped correctly
+- Test `toRepoInfo`:
+  - Verify only `owner` and `repo` are extracted, `platform` is dropped
+
+### Step 3: Implement GitHubIssueTracker class
+- Create `adws/providers/github/githubIssueTracker.ts`
+- Import `IssueTracker`, `RepoIdentifier`, `validateRepoIdentifier`, `WorkItem`, `WorkItemComment` from `../../types`
+- Import mapper functions from `./mappers`
+- Import underlying functions from `../../github/issueApi` and `../../github/projectBoardApi`
+- Implement class `GitHubIssueTracker` implementing `IssueTracker`:
+  - Private readonly `repoId: RepoIdentifier`
+  - Private readonly `repoInfo: RepoInfo` (pre-computed via `toRepoInfo`)
+  - Constructor takes `repoId: RepoIdentifier`, calls `validateRepoIdentifier(repoId)`, stores both
+  - `async fetchIssue(issueNumber: number): Promise<WorkItem>` — calls `fetchGitHubIssue(issueNumber, this.repoInfo)`, maps result via `mapGitHubIssueToWorkItem`
+  - `commentOnIssue(issueNumber: number, body: string): void` — calls `commentOnIssue(issueNumber, body, this.repoInfo)` from issueApi (note: import with alias to avoid name collision)
+  - `deleteComment(commentId: string): void` — calls `deleteIssueComment(Number(commentId), this.repoInfo)`
+  - `async closeIssue(issueNumber: number, comment?: string): Promise<boolean>` — calls `closeIssue(issueNumber, comment, this.repoInfo)` from issueApi
+  - `getIssueState(issueNumber: number): string` — calls `getIssueState(issueNumber, this.repoInfo)` from issueApi
+  - `fetchComments(issueNumber: number): WorkItemComment[]` — calls `fetchIssueCommentsRest(issueNumber, this.repoInfo)`, maps each via `mapIssueCommentSummaryToWorkItemComment`
+  - `async moveToStatus(issueNumber: number, status: string): Promise<void>` — calls `moveIssueToStatus(issueNumber, status, this.repoInfo)` from projectBoardApi
+- Export factory function `createGitHubIssueTracker(repoId: RepoIdentifier): IssueTracker` that returns `new GitHubIssueTracker(repoId)`
+
+### Step 4: Create barrel exports
+- Create `adws/providers/github/index.ts`:
+  - `export { createGitHubIssueTracker } from './githubIssueTracker';`
+  - `export * from './mappers';`
+- Update `adws/providers/index.ts`:
+  - Add `export * from './github';` alongside the existing `export * from './types';`
+
+### Step 5: Write GitHubIssueTracker unit tests
+- Create `adws/providers/github/__tests__/githubIssueTracker.test.ts`
+- Mock `adws/github/issueApi` (all 6 functions)
+- Mock `adws/github/projectBoardApi` (`moveIssueToStatus`)
+- Test construction:
+  - Valid `RepoIdentifier` with `Platform.GitHub` — no error
+  - Invalid `RepoIdentifier` (empty owner/repo) — throws validation error
+- Test repo binding:
+  - Call each method on the provider
+  - Verify the underlying function was called with the bound `RepoInfo` (`{ owner, repo }`) — never `undefined`
+  - Verify `getTargetRepo()` is never called (it should not be imported by the provider)
+- Test `fetchIssue`:
+  - Mock `fetchGitHubIssue` to return a `GitHubIssue`
+  - Verify result is a properly mapped `WorkItem`
+  - Verify `repoInfo` was passed to the underlying function
+- Test `commentOnIssue`:
+  - Verify delegates to underlying `commentOnIssue` with correct args and bound `repoInfo`
+- Test `deleteComment`:
+  - Pass string ID `"123"`
+  - Verify underlying `deleteIssueComment` receives numeric `123` and bound `repoInfo`
+- Test `closeIssue`:
+  - With and without optional comment
+  - Verify delegates correctly
+- Test `getIssueState`:
+  - Verify delegates and returns the state string
+- Test `fetchComments`:
+  - Mock `fetchIssueCommentsRest` to return `IssueCommentSummary[]`
+  - Verify result is properly mapped `WorkItemComment[]`
+- Test `moveToStatus`:
+  - Verify delegates to `moveIssueToStatus` with correct args
+- Test `createGitHubIssueTracker` factory:
+  - Returns an object satisfying `IssueTracker` interface
+  - Methods are callable
+
+### Step 6: Validate
+- Run `bun run lint` — verify no lint errors
+- Run `bunx tsc --noEmit` — verify no TypeScript errors
+- Run `bunx tsc --noEmit -p adws/tsconfig.json` — verify adws-specific type check passes
+- Run `bun run test` — verify all tests pass with zero regressions
+
+## Testing Strategy
+### Unit Tests
+- **Mapper tests** (`mappers.test.ts`): Pure function tests covering all field mappings, edge cases (empty arrays, null fields, bot users), and the `toRepoInfo` helper.
+- **Provider tests** (`githubIssueTracker.test.ts`): Mock-based tests verifying delegation to underlying functions, repo-binding correctness (every call passes bound `RepoInfo`), type conversion through mappers, factory function behavior, and constructor validation.
+
+### Edge Cases
+- `GitHubIssue` with no comments, no labels, empty body
+- `GitHubIssue` with bot author (`isBot: true`) — `WorkItem.author` should still be the login string
+- `deleteComment` receiving string ID that must be parsed to number — verify `Number("123")` works correctly
+- `deleteComment` with non-numeric string — this should not happen per the interface contract but worth documenting
+- `closeIssue` called without optional `comment` parameter
+- `moveToStatus` when underlying function resolves silently (no project board linked)
+- Constructor with invalid `RepoIdentifier` — should throw synchronously
+
+## Acceptance Criteria
+- `adws/providers/github/githubIssueTracker.ts` exists and exports `createGitHubIssueTracker`
+- `GitHubIssueTracker` class implements all 7 methods of `IssueTracker` interface
+- Constructor validates and stores `RepoIdentifier`; every method passes bound `RepoInfo` to underlying functions
+- `adws/providers/github/mappers.ts` exports `mapGitHubIssueToWorkItem`, `mapGitHubCommentToWorkItemComment`, `mapIssueCommentSummaryToWorkItemComment`, and `toRepoInfo`
+- All mapper functions are pure — no side effects, no imports of global state
+- Unit tests for mappers cover all field mappings and edge cases
+- Unit tests for provider verify repo-binding, delegation, and type mapping
+- `bun run lint` passes
+- `bunx tsc --noEmit` passes
+- `bunx tsc --noEmit -p adws/tsconfig.json` passes
+- `bun run test` passes with zero regressions
+
+## Validation Commands
+Execute every command to validate the feature works correctly with zero regressions.
+
+- `bun run lint` — Run linter to check for code quality issues
+- `bunx tsc --noEmit` — Run root TypeScript type check
+- `bunx tsc --noEmit -p adws/tsconfig.json` — Run adws-specific TypeScript type check
+- `bun run test` — Run full test suite to validate zero regressions
+
+## Notes
+- The underlying `issueApi.ts` and `projectBoardApi.ts` functions remain unchanged — the provider is a pure wrapper.
+- The `deleteComment` method on the `IssueTracker` interface takes a `string` ID, but GitHub's `deleteIssueComment` expects a `number`. The provider handles this conversion via `Number(commentId)`.
+- The existing `commentOnIssue` function name in `issueApi.ts` collides with the `IssueTracker` method name. Use import aliasing (`import { commentOnIssue as ghCommentOnIssue }`) to avoid confusion.
+- `guidelines/coding_guidelines.md` must be strictly followed: immutability, pure functions for mappers, strict TypeScript types, no decorators, functional style.
+- No new libraries are required.

--- a/specs/issue-114-adw-1773070563762-kzngns-sdlc_planner-github-issue-tracker-provider.md
+++ b/specs/issue-114-adw-1773070563762-kzngns-sdlc_planner-github-issue-tracker-provider.md
@@ -1,0 +1,214 @@
+# Feature: GitHub IssueTracker Provider
+
+## Metadata
+issueNumber: `114`
+adwId: `1773070563762-kzngns`
+issueJson: `{"number":114,"title":"Implement GitHub IssueTracker provider","body":"## Summary\nWrap the existing GitHub issue operations (`issueApi.ts`, `projectBoardApi.ts`) behind the `IssueTracker` interface, creating the first concrete provider implementation.\n\n## Dependencies\n- #113 — Provider interfaces must be defined first\n\n## User Story\nAs a developer, I want the existing GitHub issue functionality wrapped in the IssueTracker interface so that phases can consume it through the abstraction without behavior changes.\n\n## Acceptance Criteria\n\n### Create `adws/providers/github/githubIssueTracker.ts`\n- Implement `IssueTracker` interface\n- Constructor takes `RepoIdentifier` — the provider is bound to a specific repo at creation time (no global registry fallback)\n- Wrap existing functions from `issueApi.ts`:\n  - `fetchGitHubIssue` → `fetchIssue` (transform `GitHubIssue` → `WorkItem`)\n  - `commentOnIssue` → `commentOnIssue`\n  - `deleteIssueComment` → `deleteComment`\n  - `closeIssue` → `closeIssue`\n  - `getIssueState` → `getIssueState`\n  - `fetchIssueCommentsRest` → `fetchComments` (transform `IssueCommentSummary` → `WorkItemComment`)\n- Wrap `moveIssueToStatus` from `projectBoardApi.ts` → `moveToStatus`\n- Factory function: `createGitHubIssueTracker(repoId: RepoIdentifier): IssueTracker`\n\n### Type mapping\n- Create mapping functions between `GitHubIssue` ↔ `WorkItem` and `IssueCommentSummary` ↔ `WorkItemComment`\n- These mappers live in `adws/providers/github/mappers.ts`\n\n### Tests\n- Unit tests for the provider in `adws/providers/github/__tests__/`\n- Test that the provider is correctly bound to its repo — calling methods should always use the bound repo, never fall back to global state\n- Test type mapping functions\n\n## Notes\n- The underlying `issueApi.ts` functions stay intact during this phase — the provider is a wrapper, not a replacement.\n- Each method must pass the bound `RepoIdentifier` explicitly to the underlying function — no reliance on `getTargetRepo()`.","state":"OPEN","author":"paysdoc","labels":["enhancement"],"createdAt":"2026-03-09T15:17:35Z","comments":[],"actionableComment":null}`
+
+## Feature Description
+Wrap the existing GitHub issue operations (`issueApi.ts`, `projectBoardApi.ts`) behind the `IssueTracker` interface defined in #113, creating the first concrete provider implementation. This establishes the adapter pattern that decouples workflow phases from GitHub-specific APIs, enabling future support for alternative issue trackers (Jira, Linear, GitLab Issues) without modifying consuming code.
+
+## User Story
+As a developer
+I want the existing GitHub issue functionality wrapped in the IssueTracker interface
+So that phases can consume it through the abstraction without behavior changes
+
+## Problem Statement
+The ADW workflow phases currently call GitHub-specific functions directly (`fetchGitHubIssue`, `commentOnIssue`, etc.), tightly coupling them to GitHub. The provider interfaces were defined in #113, but no concrete implementation exists yet. Without a GitHub adapter, the abstraction layer has no usable implementation and phases cannot begin migrating to the platform-agnostic API.
+
+## Solution Statement
+Create a `GitHubIssueTracker` class that implements the `IssueTracker` interface by delegating to the existing `issueApi.ts` and `projectBoardApi.ts` functions. The class is bound to a specific `RepoIdentifier` at construction time and converts between GitHub-specific types (`GitHubIssue`, `IssueCommentSummary`) and platform-agnostic types (`WorkItem`, `WorkItemComment`) using dedicated mapper functions. A factory function `createGitHubIssueTracker` provides a clean creation API. The underlying GitHub functions remain unchanged — this is purely an adapter layer.
+
+## Relevant Files
+Use these files to implement the feature:
+
+- `adws/providers/types.ts` — Contains the `IssueTracker`, `WorkItem`, `WorkItemComment`, `RepoIdentifier`, and `Platform` type definitions that the provider must implement.
+- `adws/providers/index.ts` — Barrel export for providers; must be updated to re-export the new GitHub provider.
+- `adws/providers/__tests__/types.test.ts` — Existing provider type tests; reference for test patterns and mock structures.
+- `adws/github/issueApi.ts` — Contains the GitHub issue functions to wrap: `fetchGitHubIssue`, `commentOnIssue`, `deleteIssueComment`, `closeIssue`, `getIssueState`, `fetchIssueCommentsRest`.
+- `adws/github/projectBoardApi.ts` — Contains `moveIssueToStatus` to wrap.
+- `adws/github/githubApi.ts` — Contains the `RepoInfo` interface used by the underlying functions.
+- `adws/types/issueTypes.ts` — Contains `GitHubIssue`, `GitHubComment`, `GitHubUser`, `GitHubLabel`, `IssueCommentSummary` type definitions needed for mapper functions.
+- `adws/core/targetRepoRegistry.ts` — Contains `getTargetRepo()` — the provider must NOT use this; it must pass its bound `RepoIdentifier` explicitly.
+- `adws/README.md` — Architecture overview for understanding existing patterns.
+- `guidelines/coding_guidelines.md` — Coding standards that must be followed.
+
+### New Files
+- `adws/providers/github/mappers.ts` — Mapper functions to convert `GitHubIssue` → `WorkItem` and `IssueCommentSummary` → `WorkItemComment`.
+- `adws/providers/github/githubIssueTracker.ts` — The `GitHubIssueTracker` class implementing `IssueTracker`, plus `createGitHubIssueTracker` factory function.
+- `adws/providers/github/index.ts` — Barrel export for the GitHub provider module.
+- `adws/providers/github/__tests__/mappers.test.ts` — Unit tests for mapper functions.
+- `adws/providers/github/__tests__/githubIssueTracker.test.ts` — Unit tests for the provider class.
+
+## Implementation Plan
+### Phase 1: Foundation
+Create the mapper functions in `adws/providers/github/mappers.ts` that convert between GitHub-specific types and platform-agnostic types. These are pure functions with no side effects, making them easy to test in isolation. The two key mappers are:
+- `mapGitHubIssueToWorkItem(issue: GitHubIssue): WorkItem` — Converts `GitHubIssue` to `WorkItem`, flattening `author.login` to a string, `labels[].name` to `string[]`, and `comments[]` to `WorkItemComment[]`.
+- `mapIssueCommentSummaryToWorkItemComment(comment: IssueCommentSummary): WorkItemComment` — Converts `IssueCommentSummary` to `WorkItemComment`, converting numeric `id` to string and `authorLogin` to `author`.
+
+### Phase 2: Core Implementation
+Create the `GitHubIssueTracker` class in `adws/providers/github/githubIssueTracker.ts`:
+- The class stores a `RepoIdentifier` at construction time.
+- Each method extracts `{ owner, repo }` from the stored `RepoIdentifier` and passes it as `RepoInfo` to the underlying GitHub function.
+- `fetchIssue` and `fetchComments` use the mapper functions to convert return types.
+- `deleteComment` converts the string `commentId` to a number before calling `deleteIssueComment`.
+- A `createGitHubIssueTracker(repoId: RepoIdentifier): IssueTracker` factory function is exported for clean instantiation.
+
+### Phase 3: Integration
+- Create barrel export in `adws/providers/github/index.ts` re-exporting the provider class, factory function, and mappers.
+- Update `adws/providers/index.ts` to re-export from the GitHub provider module.
+- No changes needed to existing workflow phases in this issue — migration happens in subsequent issues.
+
+## Step by Step Tasks
+
+### Step 1: Create mapper functions
+- Create `adws/providers/github/mappers.ts`
+- Import `GitHubIssue`, `IssueCommentSummary` from `../../types/issueTypes`
+- Import `WorkItem`, `WorkItemComment` from `../types`
+- Implement `mapGitHubIssueToWorkItem(issue: GitHubIssue): WorkItem`:
+  - `id`: use `String(issue.number)` (GitHub issues don't have a separate string ID; the number serves as the unique identifier)
+  - `number`: `issue.number`
+  - `title`: `issue.title`
+  - `body`: `issue.body`
+  - `state`: `issue.state`
+  - `author`: `issue.author.login`
+  - `labels`: `issue.labels.map(l => l.name)`
+  - `comments`: `issue.comments.map(mapGitHubCommentToWorkItemComment)`
+- Implement helper `mapGitHubCommentToWorkItemComment(comment: GitHubComment): WorkItemComment`:
+  - `id`: `comment.id` (already a string)
+  - `body`: `comment.body`
+  - `author`: `comment.author.login`
+  - `createdAt`: `comment.createdAt`
+- Implement `mapIssueCommentSummaryToWorkItemComment(comment: IssueCommentSummary): WorkItemComment`:
+  - `id`: `String(comment.id)` (numeric → string)
+  - `body`: `comment.body`
+  - `author`: `comment.authorLogin`
+  - `createdAt`: `comment.createdAt`
+
+### Step 2: Create mapper unit tests
+- Create `adws/providers/github/__tests__/mappers.test.ts`
+- Test `mapGitHubIssueToWorkItem`:
+  - Maps a full `GitHubIssue` with comments, labels, assignees, milestone to `WorkItem`
+  - Correctly extracts `author.login` as flat string
+  - Correctly maps `labels[].name` to `string[]`
+  - Correctly maps nested `comments[]` to `WorkItemComment[]`
+  - Handles empty labels array
+  - Handles empty comments array
+  - Handles missing/null optional fields (milestone, closedAt)
+- Test `mapGitHubCommentToWorkItemComment`:
+  - Maps comment id, body, author.login, createdAt correctly
+- Test `mapIssueCommentSummaryToWorkItemComment`:
+  - Converts numeric `id` to string
+  - Maps `authorLogin` to `author`
+  - Preserves `body` and `createdAt`
+
+### Step 3: Create GitHubIssueTracker class
+- Create `adws/providers/github/githubIssueTracker.ts`
+- Import `IssueTracker`, `WorkItem`, `WorkItemComment`, `RepoIdentifier` from `../types`
+- Import `fetchGitHubIssue`, `commentOnIssue`, `deleteIssueComment`, `closeIssue`, `getIssueState`, `fetchIssueCommentsRest` from `../../github/issueApi`
+- Import `moveIssueToStatus` from `../../github/projectBoardApi`
+- Import `type RepoInfo` from `../../github/githubApi`
+- Import `mapGitHubIssueToWorkItem`, `mapIssueCommentSummaryToWorkItemComment` from `./mappers`
+- Implement `GitHubIssueTracker` class:
+  - Private readonly `repoId: RepoIdentifier` field
+  - Constructor takes `RepoIdentifier`, stores it
+  - Private helper `toRepoInfo(): RepoInfo` that returns `{ owner: this.repoId.owner, repo: this.repoId.repo }`
+  - `async fetchIssue(issueNumber: number): Promise<WorkItem>` — calls `fetchGitHubIssue(issueNumber, this.toRepoInfo())`, maps result with `mapGitHubIssueToWorkItem`
+  - `commentOnIssue(issueNumber: number, body: string): void` — calls `commentOnIssue(issueNumber, body, this.toRepoInfo())`
+  - `deleteComment(commentId: string): void` — calls `deleteIssueComment(Number(commentId), this.toRepoInfo())`
+  - `closeIssue(issueNumber: number, comment?: string): Promise<boolean>` — calls `closeIssue(issueNumber, comment, this.toRepoInfo())`
+  - `getIssueState(issueNumber: number): string` — calls `getIssueState(issueNumber, this.toRepoInfo())`
+  - `fetchComments(issueNumber: number): WorkItemComment[]` — calls `fetchIssueCommentsRest(issueNumber, this.toRepoInfo())`, maps each result with `mapIssueCommentSummaryToWorkItemComment`
+  - `async moveToStatus(issueNumber: number, status: string): Promise<void>` — calls `moveIssueToStatus(issueNumber, status, this.toRepoInfo())`
+- Export factory function `createGitHubIssueTracker(repoId: RepoIdentifier): IssueTracker` that returns `new GitHubIssueTracker(repoId)`
+
+### Step 4: Create GitHubIssueTracker unit tests
+- Create `adws/providers/github/__tests__/githubIssueTracker.test.ts`
+- Mock `../../github/issueApi` (all 6 functions)
+- Mock `../../github/projectBoardApi` (`moveIssueToStatus`)
+- Do NOT mock `../../core/targetRepoRegistry` — the provider should never import or call `getTargetRepo()`
+- Create a test `RepoIdentifier` fixture: `{ owner: 'test-owner', repo: 'test-repo', platform: Platform.GitHub }`
+- Test `createGitHubIssueTracker`:
+  - Returns an object that satisfies `IssueTracker` interface
+- Test `fetchIssue`:
+  - Calls `fetchGitHubIssue` with correct issue number and `{ owner: 'test-owner', repo: 'test-repo' }`
+  - Returns a properly mapped `WorkItem`
+- Test `commentOnIssue`:
+  - Calls underlying `commentOnIssue` with correct args and bound repo info
+- Test `deleteComment`:
+  - Converts string commentId to number before calling `deleteIssueComment`
+  - Passes bound repo info
+- Test `closeIssue`:
+  - Delegates to underlying `closeIssue` with bound repo info
+  - Passes optional comment parameter
+- Test `getIssueState`:
+  - Delegates to underlying `getIssueState` with bound repo info
+- Test `fetchComments`:
+  - Calls `fetchIssueCommentsRest` with bound repo info
+  - Maps results to `WorkItemComment[]`
+- Test `moveToStatus`:
+  - Calls `moveIssueToStatus` with bound repo info
+- Test repo binding:
+  - Create two trackers with different `RepoIdentifier`s
+  - Call the same method on each
+  - Verify each passes its own repo info, not the other's
+- Test that `getTargetRepo` is never imported or called (verify the mock is not called if set up, or verify the module is not imported)
+
+### Step 5: Create barrel exports
+- Create `adws/providers/github/index.ts`:
+  - Export `{ GitHubIssueTracker, createGitHubIssueTracker }` from `./githubIssueTracker`
+  - Export `{ mapGitHubIssueToWorkItem, mapGitHubCommentToWorkItemComment, mapIssueCommentSummaryToWorkItemComment }` from `./mappers`
+- Update `adws/providers/index.ts`:
+  - Add `export * from './github';` after existing `export * from './types';`
+
+### Step 6: Run validation commands
+- Run `bun run lint` to check for code quality issues
+- Run `bunx tsc --noEmit` to verify no TypeScript errors
+- Run `bunx tsc --noEmit -p adws/tsconfig.json` for ADW-specific type checking
+- Run `bun run test` to validate all tests pass with zero regressions
+
+## Testing Strategy
+### Unit Tests
+- **Mapper tests** (`mappers.test.ts`): Test pure mapping functions in isolation with various input shapes — full data, minimal data, empty arrays, null optional fields.
+- **Provider tests** (`githubIssueTracker.test.ts`): Mock the underlying `issueApi` and `projectBoardApi` functions. Verify the provider delegates correctly with the bound `RepoInfo`, converts types via mappers, and never falls back to `getTargetRepo()`.
+- **Factory function test**: Verify `createGitHubIssueTracker` returns an object satisfying the `IssueTracker` interface.
+
+### Edge Cases
+- `GitHubIssue` with empty labels array → `WorkItem.labels` should be `[]`
+- `GitHubIssue` with empty comments array → `WorkItem.comments` should be `[]`
+- `GitHubIssue` with null milestone → should not affect mapping
+- `IssueCommentSummary` with numeric id `0` → should map to string `"0"`
+- `deleteComment` with string id `"12345"` → should pass `12345` (number) to underlying function
+- Two providers bound to different repos calling the same method → each uses its own repo info
+- `closeIssue` without optional comment parameter → should pass `undefined` for comment
+- `GitHubIssue` with author having no name (null) → should still extract `login` correctly
+
+## Acceptance Criteria
+- `adws/providers/github/mappers.ts` exports `mapGitHubIssueToWorkItem`, `mapGitHubCommentToWorkItemComment`, and `mapIssueCommentSummaryToWorkItemComment`
+- `adws/providers/github/githubIssueTracker.ts` exports `GitHubIssueTracker` class implementing `IssueTracker` and `createGitHubIssueTracker` factory function
+- Constructor takes `RepoIdentifier` and binds it — no reliance on `getTargetRepo()`
+- Each method passes the bound repo as `RepoInfo` to the underlying GitHub function
+- `fetchIssue` returns a `WorkItem` mapped from `GitHubIssue`
+- `fetchComments` returns `WorkItemComment[]` mapped from `IssueCommentSummary[]`
+- `deleteComment` converts string `commentId` to number
+- All existing tests continue to pass (zero regressions)
+- All new tests pass
+- TypeScript compiles without errors
+- Linter passes without errors
+- The underlying `issueApi.ts` and `projectBoardApi.ts` functions are unchanged
+
+## Validation Commands
+Execute every command to validate the feature works correctly with zero regressions.
+
+- `bun run lint` — Run linter to check for code quality issues
+- `bunx tsc --noEmit` — Root-level TypeScript type check
+- `bunx tsc --noEmit -p adws/tsconfig.json` — ADW-specific TypeScript type check
+- `bun run test` — Run all tests to validate zero regressions
+- `bun run test adws/providers/github` — Run GitHub provider tests specifically to verify new functionality
+
+## Notes
+- The `guidelines/coding_guidelines.md` must be followed: no `any` types, interfaces for object shapes, `Readonly<>` for immutability, files under 300 lines, meaningful error messages.
+- The underlying `issueApi.ts` and `projectBoardApi.ts` functions remain completely unchanged — the provider is a pure wrapper/adapter.
+- The `commentOnIssue` name collision between the interface method and the imported function from `issueApi.ts` must be handled with an import alias (e.g., `import { commentOnIssue as ghCommentOnIssue } from '../../github/issueApi'`).
+- This issue only covers `IssueTracker`. The `CodeHost` provider implementation will be a separate issue.
+- No new libraries are needed for this implementation.


### PR DESCRIPTION
## Summary

Wraps the existing GitHub issue operations (`issueApi.ts`, `projectBoardApi.ts`) behind the `IssueTracker` interface, creating the first concrete provider implementation for the ADW provider abstraction layer.

## Plan

Implementation spec: `specs/issue-114-adw-1773070548003-fbxjed-sdlc_planner-github-issue-tracker-provider.md`

## Changes

- **`adws/providers/github/githubIssueTracker.ts`** — Concrete `IssueTracker` implementation bound to a `RepoIdentifier` at construction time; wraps `issueApi.ts` and `projectBoardApi.ts` functions; exports `createGitHubIssueTracker` factory
- **`adws/providers/github/mappers.ts`** — Type mapping functions: `GitHubIssue` ↔ `WorkItem` and `IssueCommentSummary` ↔ `WorkItemComment`
- **`adws/providers/github/index.ts`** — Re-exports provider and factory
- **`adws/providers/index.ts`** — Re-exports GitHub provider
- **`adws/providers/github/__tests__/githubIssueTracker.test.ts`** — Unit tests verifying repo binding, method delegation, and no global state fallback
- **`adws/providers/github/__tests__/mappers.test.ts`** — Unit tests for all type mapping functions

## Checklist

- [x] `IssueTracker` interface implemented
- [x] Provider bound to `RepoIdentifier` at construction (no `getTargetRepo()` fallback)
- [x] All `issueApi.ts` functions wrapped (`fetchIssue`, `commentOnIssue`, `deleteComment`, `closeIssue`, `getIssueState`, `fetchComments`)
- [x] `moveIssueToStatus` from `projectBoardApi.ts` wrapped as `moveToStatus`
- [x] `createGitHubIssueTracker` factory function exported
- [x] Type mappers in `mappers.ts`
- [x] Unit tests for provider repo binding
- [x] Unit tests for type mapping functions
- [x] Underlying `issueApi.ts` functions left intact

Closes #114

---
**ADW tracking ID:** `1773070548003-fbxjed`