### PR TITLE
bug: #126 - JSON Error

### DIFF
--- a/adws/triggers/__tests__/concurrencyGuard.test.ts
+++ b/adws/triggers/__tests__/concurrencyGuard.test.ts
@@ -51,7 +51,7 @@ describe('getInProgressIssueCount', () => {
       { number: 2, comments: [{ body: '## :rocket: ADW Workflow Started\n\n<!-- adw-bot -->' }] },
     ];
     const prs = [
-      { number: 10, body: 'Implements #1', state: 'MERGED', merged: true },
+      { number: 10, body: 'Implements #1', state: 'MERGED', mergedAt: '2026-01-01T00:00:00Z' },
     ];
     mockGhCalls(issues, prs);
     expect(await getInProgressIssueCount(repoInfo)).toBe(1);
@@ -72,7 +72,7 @@ describe('getInProgressIssueCount', () => {
       { number: 5, comments: [{ body: '## :rocket: ADW Workflow Started\n\n<!-- adw-bot -->' }] },
     ];
     const prs = [
-      { number: 20, body: 'Implements #5', state: 'CLOSED', merged: false },
+      { number: 20, body: 'Implements #5', state: 'CLOSED', mergedAt: null },
     ];
     mockGhCalls(issues, prs);
     expect(await getInProgressIssueCount(repoInfo)).toBe(0);

--- a/adws/triggers/concurrencyGuard.ts
+++ b/adws/triggers/concurrencyGuard.ts
@@ -19,7 +19,7 @@ interface RawPR {
   number: number;
   body: string;
   state: string;
-  merged: boolean;
+  mergedAt: string | null;
 }
 
 /**
@@ -44,7 +44,7 @@ function fetchOpenIssuesWithComments(repoInfo: RepoInfo): RawIssueWithComments[]
 function fetchPRsForRepo(repoInfo: RepoInfo): RawPR[] {
   try {
     const json = execSync(
-      `gh pr list --repo ${repoInfo.owner}/${repoInfo.repo} --state all --json number,body,state,merged --limit 200`,
+      `gh pr list --repo ${repoInfo.owner}/${repoInfo.repo} --state all --json number,body,state,mergedAt --limit 200`,
       { encoding: 'utf-8' },
     );
     return JSON.parse(json);
@@ -62,7 +62,7 @@ function hasLinkedMergedOrClosedPR(issueNumber: number, prs: RawPR[]): boolean {
   return prs.some(
     (pr) =>
       pr.body?.includes(`Implements #${issueNumber}`) &&
-      (pr.merged || pr.state === 'CLOSED'),
+      (pr.mergedAt != null || pr.state === 'CLOSED'),
   );
 }
 

--- a/specs/issue-126-adw-1773071145299-jiod5x-sdlc_planner-fix-gh-pr-merged-field.md
+++ b/specs/issue-126-adw-1773071145299-jiod5x-sdlc_planner-fix-gh-pr-merged-field.md
@@ -1,0 +1,72 @@
+# Bug: gh pr list uses invalid "merged" JSON field
+
+## Metadata
+issueNumber: `126`
+adwId: `1773071145299-jiod5x`
+issueJson: `{"number":126,"title":"JSON Error","body":"The logs show the following error: ...Unknown JSON field: \"merged\"..."}`
+
+## Bug Description
+The `concurrencyGuard.ts` module calls `gh pr list --json number,body,state,merged` but `merged` is not a valid JSON field for the `gh pr list` command. The GitHub CLI (`gh`) does not expose a `merged` boolean field on PR list output. The available fields include `mergedAt` (an ISO 8601 timestamp or null) but not `merged`.
+
+**Actual behavior:** The `gh pr list` command fails with `Unknown JSON field: "merged"`, causing `fetchPRsForRepo()` to return an empty array. This means all open issues with ADW comments are incorrectly counted as in-progress (since no PRs are returned to exclude them), potentially blocking new workflows due to a false concurrency limit.
+
+**Expected behavior:** The command should use `mergedAt` instead of `merged` and correctly determine whether a PR was merged by checking if `mergedAt` is non-null.
+
+## Problem Statement
+The `gh` CLI's `--json` flag for `gh pr list` does not support a `merged` boolean field. The code assumes this field exists, causing the command to fail entirely and breaking the concurrency guard logic.
+
+## Solution Statement
+Replace the `merged` field with `mergedAt` in the `gh pr list --json` arguments, update the `RawPR` interface to use `mergedAt: string | null` instead of `merged: boolean`, and update the merged-check logic to use `pr.mergedAt != null` instead of `pr.merged`.
+
+## Steps to Reproduce
+1. Run the cron trigger or any workflow that invokes `getInProgressIssueCount()` or `isConcurrencyLimitReached()` from `concurrencyGuard.ts`
+2. The `gh pr list --repo <owner>/<repo> --state all --json number,body,state,merged --limit 200` command is executed
+3. The command fails with: `Unknown JSON field: "merged"`
+4. `fetchPRsForRepo()` catches the error and returns an empty array
+5. All open issues with ADW comments are counted as in-progress, potentially hitting the concurrency limit incorrectly
+
+## Root Cause Analysis
+The `gh` CLI does not have a `merged` boolean field in its PR JSON output schema. The GitHub REST/GraphQL API webhook payloads do include a `merged` boolean (used correctly in `PullRequestWebhookPayload` in `issueTypes.ts`), but the `gh pr list --json` command uses a different field set. The correct field is `mergedAt`, which is a timestamp string when the PR was merged or `null`/empty when it was not.
+
+The bug is isolated to `adws/triggers/concurrencyGuard.ts` — the `RawPR` interface and the `gh pr list` command on line 47 use `merged` which doesn't exist in the `gh` CLI's JSON output.
+
+## Relevant Files
+Use these files to fix the bug:
+
+- `adws/triggers/concurrencyGuard.ts` — Contains the broken `gh pr list` command with `merged` field, the `RawPR` interface, and the `hasLinkedMergedOrClosedPR` logic that checks `pr.merged`. This is the only file that needs code changes.
+- `adws/triggers/__tests__/concurrencyGuard.test.ts` — Contains tests for the concurrency guard. Tests need to be updated to use `mergedAt` instead of `merged` in mock PR data.
+- `guidelines/coding_guidelines.md` — Coding guidelines to follow during the fix.
+
+## Step by Step Tasks
+IMPORTANT: Execute every step in order, top to bottom.
+
+### 1. Update `RawPR` interface in `concurrencyGuard.ts`
+- Change the `merged: boolean` property to `mergedAt: string | null` in the `RawPR` interface (line 22)
+
+### 2. Update the `gh pr list` command in `fetchPRsForRepo()`
+- Replace `merged` with `mergedAt` in the `--json` argument on line 47
+- The command should become: `gh pr list --repo ${repoInfo.owner}/${repoInfo.repo} --state all --json number,body,state,mergedAt --limit 200`
+
+### 3. Update the merged check in `hasLinkedMergedOrClosedPR()`
+- Change `pr.merged` to `pr.mergedAt != null` on line 65
+- This correctly checks whether the PR was merged by testing if the `mergedAt` timestamp is present
+
+### 4. Update test mock data in `concurrencyGuard.test.ts`
+- In the "excludes issues with merged PRs" test (line 54): change `merged: true` to `mergedAt: '2026-01-01T00:00:00Z'`
+- In the "excludes issues with closed PRs" test (line 75): change `merged: false` to `mergedAt: null`
+
+### 5. Run validation commands
+- Run all validation commands listed below to confirm the fix works with zero regressions
+
+## Validation Commands
+Execute every command to validate the bug is fixed with zero regressions.
+
+- `bun run lint` — Run linter to check for code quality issues
+- `bunx tsc --noEmit` — Type check the main project
+- `bunx tsc --noEmit -p adws/tsconfig.json` — Type check the adws project
+- `bun run test` — Run all tests to validate the fix with zero regressions
+
+## Notes
+- The `PullRequestWebhookPayload` type in `adws/types/issueTypes.ts` correctly uses `merged: boolean` — this is the GitHub webhook payload format (not `gh` CLI output) and should NOT be changed.
+- The fix is minimal: only `concurrencyGuard.ts` and its test file need changes.
+- Strictly adhere to the coding guidelines in `guidelines/coding_guidelines.md`.


### PR DESCRIPTION
## Summary

Fixes a crash in the concurrency guard caused by using `merged` as a JSON field in `gh pr list`, which is not a valid field in the GitHub CLI.

- The `gh pr list --json` command does not support a `merged` boolean field; the correct field is `mergedAt` (a timestamp string, `null` when not merged)
- Updated `RawPR` interface to use `mergedAt: string | null` instead of `merged: boolean`
- Updated the merge check to use `pr.mergedAt != null`
- Updated tests to reflect the new field shape

## Plan

Plan file: `specs/issue-126-adw-1773071145299-jiod5x-sdlc_planner-fix-gh-pr-merged-field.md`

## Changes

- `adws/triggers/concurrencyGuard.ts`: Replace `merged: boolean` with `mergedAt: string | null` in `RawPR` interface; replace `merged` in `gh pr list --json` args; update merge check to `pr.mergedAt != null`
- `adws/triggers/__tests__/concurrencyGuard.test.ts`: Update test fixtures to use `mergedAt` field

## Checklist

- [x] Root cause identified (`merged` is not a valid `gh pr list --json` field)
- [x] `concurrencyGuard.ts` updated to use `mergedAt`
- [x] Tests updated and passing

Closes #126

---
**ADW ID:** `1773072031861-ym6eyf`