### PR TITLE
bug: #150 - Race condition for starting workflow

### DIFF
--- a/adws/__tests__/workflowPhases.test.ts
+++ b/adws/__tests__/workflowPhases.test.ts
@@ -206,7 +206,6 @@ import {
   findWorktreeForIssue,
   inferIssueTypeFromBranch,
 } from '../vcs';
-import { getDefaultBranch } from '../vcs/branchOperations';
 import { runPlanAgent, planFileExists, readPlanFile, runBuildAgent, runPrReviewPlanAgent, runPrReviewBuildAgent, runGenerateBranchNameAgent, runCommitAgent, runUnitTestsWithRetry, runE2ETestsWithRetry, runReviewWithRetry, runPullRequestAgent } from '../agents';
 import { classifyGitHubIssue } from '../core/issueClassifier';
 

--- a/adws/core/workflowCommentParsing.ts
+++ b/adws/core/workflowCommentParsing.ts
@@ -146,8 +146,6 @@ export function extractPlanPathFromComment(commentBody: string): string | null {
   return match ? match[1] : null;
 }
 
-const TERMINAL_STAGES: ReadonlyArray<WorkflowStage> = ['completed', 'error'];
-
 /** Detects recovery state from GitHub comments. */
 export function detectRecoveryState(comments: GitHubComment[]): RecoveryState {
   const defaultState: RecoveryState = {

--- a/adws/triggers/__tests__/triggerWebhookGatekeeper.test.ts
+++ b/adws/triggers/__tests__/triggerWebhookGatekeeper.test.ts
@@ -15,10 +15,6 @@ vi.mock('../../core/issueClassifier', () => ({
   getWorkflowScript: vi.fn(),
 }));
 
-vi.mock('../../github/workflowCommentsIssue', () => ({
-  postWorkflowComment: vi.fn(),
-}));
-
 vi.mock('../issueEligibility', () => ({
   checkIssueEligibility: vi.fn(),
 }));
@@ -29,7 +25,7 @@ vi.mock('../issueDependencies', () => ({
 
 import { spawn, execSync } from 'child_process';
 import { classifyIssueForTrigger, getWorkflowScript } from '../../core/issueClassifier';
-import { postWorkflowComment } from '../../github/workflowCommentsIssue';
+
 import { checkIssueEligibility } from '../issueEligibility';
 import { parseDependencies } from '../issueDependencies';
 import { classifyAndSpawnWorkflow, handleIssueClosedDependencyUnblock, ensureCronProcess, resetCronSpawnedForRepo, logDeferral } from '../webhookGatekeeper';
@@ -41,13 +37,12 @@ describe('classifyAndSpawnWorkflow', () => {
     vi.clearAllMocks();
   });
 
-  it('posts starting comment and spawns workflow', async () => {
+  it('classifies issue and spawns workflow', async () => {
     vi.mocked(classifyIssueForTrigger).mockResolvedValue({ issueType: '/feature', success: true });
     vi.mocked(getWorkflowScript).mockReturnValue('adws/adwSdlc.tsx');
 
     await classifyAndSpawnWorkflow(42, repoInfo, ['--target-repo', 'test/repo']);
 
-    expect(postWorkflowComment).toHaveBeenCalledWith(42, 'starting', expect.objectContaining({ issueNumber: 42 }), repoInfo);
     expect(spawn).toHaveBeenCalledWith('bunx', expect.arrayContaining(['tsx', 'adws/adwSdlc.tsx', '42']), expect.any(Object));
   });
 
@@ -57,7 +52,7 @@ describe('classifyAndSpawnWorkflow', () => {
 
     await classifyAndSpawnWorkflow(10, repoInfo, []);
 
-    expect(postWorkflowComment).toHaveBeenCalledWith(10, 'starting', expect.objectContaining({ adwId: 'adw-custom-id' }), repoInfo);
+    expect(spawn).toHaveBeenCalledWith('bunx', expect.arrayContaining(['tsx', expect.any(String), '10', 'adw-custom-id']), expect.any(Object));
   });
 });
 

--- a/adws/triggers/webhookGatekeeper.ts
+++ b/adws/triggers/webhookGatekeeper.ts
@@ -10,7 +10,7 @@ import { log, generateAdwId } from '../core';
 import type { RepoInfo } from '../github/githubApi';
 import { getRepoInfo } from '../github';
 import { classifyIssueForTrigger, getWorkflowScript } from '../core/issueClassifier';
-import { postWorkflowComment } from '../github/workflowCommentsIssue';
+
 import { checkIssueEligibility } from './issueEligibility';
 import { parseDependencies } from './issueDependencies';
 
@@ -28,7 +28,6 @@ export function spawnDetached(command: string, args: string[]): void {
 
 /**
  * Classifies and spawns a workflow for an eligible issue.
- * Posts the "starting" workflow comment immediately before spawning.
  */
 export async function classifyAndSpawnWorkflow(
   issueNumber: number,
@@ -39,9 +38,6 @@ export async function classifyAndSpawnWorkflow(
   const classification = await classifyIssueForTrigger(issueNumber, resolvedRepoInfo);
   const workflowScript = getWorkflowScript(classification.issueType, classification.adwCommand);
   const adwId = classification.adwId || generateAdwId(classification.issueTitle);
-
-  // Post "starting" comment immediately to signal ownership
-  postWorkflowComment(issueNumber, 'starting', { issueNumber, adwId }, resolvedRepoInfo);
 
   log(`Issue #${issueNumber} classified as ${classification.issueType}, spawning ${workflowScript}`, 'success');
   spawnDetached('bunx', ['tsx', workflowScript, String(issueNumber), adwId, '--issue-type', classification.issueType, ...targetRepoArgs]);

--- a/specs/issue-150-adw-5nn1tu-race-condition-for-s-sdlc_planner-fix-duplicate-start-comment.md
+++ b/specs/issue-150-adw-5nn1tu-race-condition-for-s-sdlc_planner-fix-duplicate-start-comment.md
@@ -1,0 +1,88 @@
+# Bug: Race condition causes duplicate workflow start comments
+
+## Metadata
+issueNumber: `150`
+adwId: `5nn1tu-race-condition-for-s`
+issueJson: `{"number":150,"title":"Race condition for starting workflow","body":"Each issue has either two comments showing that the workflow has started or one comment started and one comment resuming.","state":"OPEN","author":"paysdoc","labels":[],"createdAt":"2026-03-12T19:11:51Z"}`
+
+## Bug Description
+When a workflow is triggered via webhook, each GitHub issue receives **two** comments indicating the workflow has started instead of one. The symptom manifests in two variants:
+
+1. **Two "started" comments**: Both `## :rocket: ADW Workflow Started` appear on the issue
+2. **One "started" + one "resuming"**: `## :rocket: ADW Workflow Started` followed by `## :arrows_counterclockwise: ADW Workflow Resuming`
+
+**Expected behavior:** A single `## :rocket: ADW Workflow Started` comment is posted when a fresh workflow begins.
+
+**Actual behavior:** Two comments are posted due to a race condition between the webhook gatekeeper and the orchestrator initialization.
+
+## Problem Statement
+There are two independent code paths that both post workflow start comments:
+
+1. **Webhook gatekeeper** (`adws/triggers/webhookGatekeeper.ts:44`): Posts "starting" immediately before spawning the orchestrator process
+2. **Workflow initialization** (`adws/phases/workflowInit.ts:243-247`): Posts "starting" or "resuming" after detecting recovery state
+
+These two paths are not coordinated, causing duplicate comments. The timing determines the variant:
+- If the orchestrator fetches issue comments **before** GitHub indexes the gatekeeper's comment → two "starting" comments
+- If the orchestrator fetches issue comments **after** GitHub indexes the gatekeeper's comment → `detectRecoveryState()` treats "starting" as a completed stage, sets `canResume = true`, and posts "resuming"
+
+## Solution Statement
+Remove the premature `postWorkflowComment()` call from `webhookGatekeeper.ts`. The orchestrator's `initializeWorkflow()` in `workflowInit.ts` is the canonical place to post the "starting" comment because it runs after fetching the issue, detecting recovery state, and setting up the workflow context. This eliminates the race condition with a single-line removal (plus import cleanup).
+
+## Steps to Reproduce
+1. Trigger a workflow via webhook (e.g., open an issue or post a `## Take action` comment)
+2. The webhook handler calls `classifyAndSpawnWorkflow()` which posts "starting" comment and spawns the orchestrator
+3. The spawned orchestrator calls `initializeWorkflow()` which fetches issue comments and posts either "starting" or "resuming"
+4. Observe two comments on the issue instead of one
+
+## Root Cause Analysis
+The race condition exists because `classifyAndSpawnWorkflow()` in `webhookGatekeeper.ts` was designed to post a "starting" comment "immediately to signal ownership" (line 43 comment). However, `initializeWorkflow()` in `workflowInit.ts` independently posts its own "starting" or "resuming" comment without checking if one already exists.
+
+The `detectRecoveryState()` function in `workflowCommentParsing.ts` compounds the problem: it treats `'starting'` as a valid completed stage (it's in `STAGE_ORDER` at index 0), so when it finds the gatekeeper's "starting" comment, it sets `canResume = true` and `lastCompletedStage = 'starting'`. This causes `workflowInit.ts` to post a "resuming" comment instead of recognizing it as a fresh start.
+
+The fix is straightforward: remove the gatekeeper's premature comment posting and let the orchestrator be the single source of truth for workflow start comments.
+
+## Relevant Files
+Use these files to fix the bug:
+
+- `adws/triggers/webhookGatekeeper.ts` — Contains the premature `postWorkflowComment()` call on line 44 that must be removed, along with the now-unused import of `postWorkflowComment` on line 13.
+- `adws/triggers/__tests__/triggerWebhookGatekeeper.test.ts` — Tests for `classifyAndSpawnWorkflow` that assert `postWorkflowComment` is called; these assertions must be removed since the gatekeeper will no longer post comments.
+- `adws/phases/workflowInit.ts` — Contains the canonical "starting"/"resuming" comment posting logic (lines 232-249). No changes needed here, but read to confirm the orchestrator handles this correctly.
+- `adws/core/workflowCommentParsing.ts` — Contains `detectRecoveryState()` and `STAGE_ORDER`. No changes needed; the fix at the gatekeeper level prevents the race entirely.
+- `guidelines/coding_guidelines.md` — Coding guidelines to follow.
+
+## Step by Step Tasks
+IMPORTANT: Execute every step in order, top to bottom.
+
+### 1. Remove premature "starting" comment from webhookGatekeeper
+
+- Read `adws/triggers/webhookGatekeeper.ts`
+- Remove the `postWorkflowComment` import from line 13 (`import { postWorkflowComment } from '../github/workflowCommentsIssue';`)
+- Remove line 43 (comment: `// Post "starting" comment immediately to signal ownership`) and line 44 (`postWorkflowComment(issueNumber, 'starting', { issueNumber, adwId }, resolvedRepoInfo);`) from the `classifyAndSpawnWorkflow()` function
+- Verify no other code in this file references `postWorkflowComment`
+
+### 2. Update webhookGatekeeper tests
+
+- Read `adws/triggers/__tests__/triggerWebhookGatekeeper.test.ts`
+- Remove the mock for `../../github/workflowCommentsIssue` (lines 18-20) since `postWorkflowComment` is no longer imported
+- Remove the import of `postWorkflowComment` (line 32)
+- In the `'posts starting comment and spawns workflow'` test (line 44): remove the `postWorkflowComment` assertion (line 50) and rename the test to `'classifies issue and spawns workflow'` since it no longer posts a comment
+- In the `'uses classification adwId when available'` test (line 54): remove the `postWorkflowComment` assertion (line 60) and update the test to verify the adwId is passed to `spawnDetached` instead
+
+### 3. Run validation commands
+
+- Execute the validation commands listed below to verify the fix is correct with zero regressions.
+
+## Validation Commands
+Execute every command to validate the bug is fixed with zero regressions.
+
+- `bun run lint` - Run linter to check for code quality issues
+- `bunx tsc --noEmit` - Type check the main project
+- `bunx tsc --noEmit -p adws/tsconfig.json` - Type check the adws scripts
+- `bun run test` - Run all tests to validate the fix with zero regressions
+
+## Notes
+- This is a minimal, surgical fix: removing the premature comment from the gatekeeper eliminates the race condition without changing any other behavior.
+- The `initializeWorkflow()` function in `workflowInit.ts` already correctly handles both fresh starts (posts "starting") and recovery (posts "resuming"), so no changes are needed there.
+- The `detectRecoveryState()` function correctly treats `'starting'` as a stage — this is useful for actual recovery scenarios (e.g., if the process crashes after posting "starting" but before completing later stages). The bug was not in recovery detection but in having two code paths both posting comments.
+- `adwBuild.tsx` has a separate `detectRecoveryState()` + `postWorkflowComment()` flow (lines 136-160) but it is NOT triggered from the webhook path — it only runs as a standalone orchestrator with pre-provided branch/plan args, so it is not affected by this bug.
+- Strictly adhere to the coding guidelines in `guidelines/coding_guidelines.md`.


### PR DESCRIPTION
## Summary

Fixes a race condition where each issue received two workflow start comments instead of one. The root cause was two independent code paths both posting workflow start comments:

1. **Webhook gatekeeper** posted a `"starting"` comment immediately before spawning the orchestrator
2. **Workflow initialization** posted its own `"starting"` or `"resuming"` comment after detecting recovery state

The timing between these two paths determined which variant appeared:
- Two `## :rocket: ADW Workflow Started` comments (gatekeeper comment not yet indexed by GitHub when orchestrator runs)
- One `## :rocket: ADW Workflow Started` + one `## :arrows_counterclockwise: ADW Workflow Resuming` (gatekeeper comment was indexed, causing `detectRecoveryState()` to treat it as a completed stage and trigger "resuming")

## Key Changes

- **`adws/triggers/webhookGatekeeper.ts`**: Removed premature `postWorkflowComment()` call and unused import — the orchestrator's `initializeWorkflow()` is the single source of truth for posting workflow start comments
- **`adws/triggers/__tests__/triggerWebhookGatekeeper.test.ts`**: Updated tests to remove assertions about `postWorkflowComment` being called from the gatekeeper, renamed tests to reflect the new behavior

## Implementation Plan

See [`specs/issue-150-adw-5nn1tu-race-condition-for-s-sdlc_planner-fix-duplicate-start-comment.md`](specs/issue-150-adw-5nn1tu-race-condition-for-s-sdlc_planner-fix-duplicate-start-comment.md)

## Checklist

- [x] Removed premature `postWorkflowComment` call from `webhookGatekeeper.ts`
- [x] Removed unused `postWorkflowComment` import from `webhookGatekeeper.ts`
- [x] Updated tests in `triggerWebhookGatekeeper.test.ts` to reflect new behavior
- [x] All tests pass with zero regressions

Closes #150

---
**ADW ID:** `5nn1tu-race-condition-for-s`