### PR TITLE
chore: #156 - Reduce reasoning effort for structurally deterministic operations

### DIFF
--- a/adws/core/__tests__/slashCommandModelMap.test.ts
+++ b/adws/core/__tests__/slashCommandModelMap.test.ts
@@ -219,12 +219,12 @@ describe('SLASH_COMMAND_EFFORT_MAP', () => {
     expect(SLASH_COMMAND_EFFORT_MAP['/resolve_failed_e2e_test']).toBe('high');
     expect(SLASH_COMMAND_EFFORT_MAP['/generate_branch_name']).toBe('low');
     expect(SLASH_COMMAND_EFFORT_MAP['/commit']).toBe('medium');
-    expect(SLASH_COMMAND_EFFORT_MAP['/pull_request']).toBe('high');
-    expect(SLASH_COMMAND_EFFORT_MAP['/document']).toBe('high');
+    expect(SLASH_COMMAND_EFFORT_MAP['/pull_request']).toBe('medium');
+    expect(SLASH_COMMAND_EFFORT_MAP['/document']).toBe('medium');
     expect(SLASH_COMMAND_EFFORT_MAP['/commit_cost']).toBeUndefined();
     expect(SLASH_COMMAND_EFFORT_MAP['/track_agentic_kpis']).toBe('medium');
     expect(SLASH_COMMAND_EFFORT_MAP['/find_plan_file']).toBe('low');
-    expect(SLASH_COMMAND_EFFORT_MAP['/adw_init']).toBe('high');
+    expect(SLASH_COMMAND_EFFORT_MAP['/adw_init']).toBe('medium');
   });
 
   it('has exactly 20 entries', () => {
@@ -243,8 +243,8 @@ describe('SLASH_COMMAND_EFFORT_MAP_FAST', () => {
     expect(SLASH_COMMAND_EFFORT_MAP_FAST['/patch']).toBe('high');
     expect(SLASH_COMMAND_EFFORT_MAP_FAST['/review']).toBe('high');
     expect(SLASH_COMMAND_EFFORT_MAP_FAST['/test']).toBeUndefined();
-    expect(SLASH_COMMAND_EFFORT_MAP_FAST['/resolve_failed_test']).toBe('high');
-    expect(SLASH_COMMAND_EFFORT_MAP_FAST['/resolve_failed_e2e_test']).toBe('high');
+    expect(SLASH_COMMAND_EFFORT_MAP_FAST['/resolve_failed_test']).toBe('medium');
+    expect(SLASH_COMMAND_EFFORT_MAP_FAST['/resolve_failed_e2e_test']).toBe('medium');
     expect(SLASH_COMMAND_EFFORT_MAP_FAST['/generate_branch_name']).toBe('low');
     expect(SLASH_COMMAND_EFFORT_MAP_FAST['/commit']).toBe('low');
     expect(SLASH_COMMAND_EFFORT_MAP_FAST['/pull_request']).toBe('medium');

--- a/adws/core/config.ts
+++ b/adws/core/config.ts
@@ -263,13 +263,13 @@ export const SLASH_COMMAND_EFFORT_MAP: Record<SlashCommand, ReasoningEffort | un
   '/resolve_failed_e2e_test': 'high',
   '/generate_branch_name': 'low',
   '/commit': 'medium',
-  '/pull_request': 'high',
-  '/document': 'high',
+  '/pull_request': 'medium',
+  '/document': 'medium',
   '/commit_cost': undefined,
   '/track_agentic_kpis': 'medium',
   '/find_plan_file': 'low',
   '/find_issue_dependencies': 'low',
-  '/adw_init': 'high',
+  '/adw_init': 'medium',
 };
 
 /** Cost-optimized reasoning effort map used when the issue body contains `/fast` or `/cheap`. */
@@ -283,8 +283,8 @@ export const SLASH_COMMAND_EFFORT_MAP_FAST: Record<SlashCommand, ReasoningEffort
   '/patch': 'high',
   '/review': 'high',
   '/test': undefined,
-  '/resolve_failed_test': 'high',
-  '/resolve_failed_e2e_test': 'high',
+  '/resolve_failed_test': 'medium',
+  '/resolve_failed_e2e_test': 'medium',
   '/generate_branch_name': 'low',
   '/commit': 'low',
   '/pull_request': 'medium',

--- a/app_docs/feature-add-resoning-effort-4wna6z-reasoning-effort-slash-commands.md
+++ b/app_docs/feature-add-resoning-effort-4wna6z-reasoning-effort-slash-commands.md
@@ -67,15 +67,15 @@ Effort levels are defined in `adws/core/config.ts`:
 | `/patch` | `high` | `high` |
 | `/review` | `high` | `high` |
 | `/test` | `undefined` | `undefined` |
-| `/resolve_failed_test` | `high` | `high` |
-| `/resolve_failed_e2e_test` | `high` | `high` |
+| `/resolve_failed_test` | `high` | `medium` |
+| `/resolve_failed_e2e_test` | `high` | `medium` |
 | `/generate_branch_name` | `low` | `low` |
 | `/commit` | `medium` | `low` |
-| `/pull_request` | `high` | `medium` |
-| `/document` | `high` | `medium` |
+| `/pull_request` | `medium` | `medium` |
+| `/document` | `medium` | `medium` |
 | `/commit_cost` | `undefined` | `undefined` |
 | `/find_plan_file` | `low` | `low` |
-| `/adw_init` | `high` | `medium` |
+| `/adw_init` | `medium` | `medium` |
 
 `undefined` means no `--effort` flag is passed (haiku commands where the flag may not apply).
 

--- a/specs/issue-156-adw-snqk14-reduce-reasoning-eff-sdlc_planner-reduce-effort-deterministic-ops.md
+++ b/specs/issue-156-adw-snqk14-reduce-reasoning-eff-sdlc_planner-reduce-effort-deterministic-ops.md
@@ -1,0 +1,76 @@
+# Chore: Reduce reasoning effort for structurally deterministic operations
+
+## Metadata
+issueNumber: `156`
+adwId: `snqk14-reduce-reasoning-eff`
+issueJson: `{"number":156,"title":"Reduce reasoning effort for structurally deterministic operations","body":"## Problem\n\nSeveral slash commands are configured at \\`high\\` reasoning effort despite being structurally deterministic — their output format is well-defined, not open-ended. High effort is wasted on operations where the model is essentially filling in a template or following a mechanical procedure.\n\nCurrent over-specified settings in \\`adws/core/config.ts\\`:\n\n**Default effort map (\\`SLASH_COMMAND_EFFORT_MAP\\`):**\n- ``` `/pull_request` ```: \\`'high'\\` — creates a PR from a completed implementation (structured, templated)\n- ``` `/document` ```: \\`'high'\\` — reads a git diff and writes docs (structured output)\n- ``` `/adw_init` ```: \\`'high'\\` — detects project structure and writes config files (structured output)\n\n**Fast effort map (\\`SLASH_COMMAND_EFFORT_MAP_FAST\\`):**\n- ``` `/resolve_failed_test` ```: \\`'high'\\` — already using fast mode; high effort is contradictory\n- ``` `/resolve_failed_e2e_test` ```: \\`'high'\\` — same as above\n\n## Solution\n\nUpdate \\`adws/core/config.ts\\`:\n\n1. In \\`SLASH_COMMAND_EFFORT_MAP\\` (default):\n   - ``` `/pull_request` ```: \\`'high'\\` → \\`'medium'\\`\n   - ``` `/document` ```: \\`'high'\\` → \\`'medium'\\`\n   - ``` `/adw_init` ```: \\`'high'\\` → \\`'medium'\\`\n\n2. In \\`SLASH_COMMAND_EFFORT_MAP_FAST\\`:\n   - ``` `/resolve_failed_test` ```: \\`'high'\\` → \\`'medium'\\`\n   - ``` `/resolve_failed_e2e_test` ```: \\`'high'\\` → \\`'medium'\\`\n\n## Acceptance Criteria\n\n- All five effort values are updated in \\`config.ts\\` as specified\n- Existing tests in \\`adws/core/__tests__/slashCommandModelMap.test.ts\\` are updated to reflect the new values\n- \\`bun run test\\` passes with zero regressions","state":"OPEN","author":"paysdoc","labels":[],"createdAt":"2026-03-12T22:36:52Z","comments":[{"author":"paysdoc","createdAt":"2026-03-12T22:56:52Z","body":"## Take action"}],"actionableComment":null}`
+
+## Chore Description
+Five slash command reasoning effort levels in `adws/core/config.ts` are set to `'high'` despite their operations being structurally deterministic (templated or mechanical output). This chore reduces them to `'medium'` to save cost and latency without sacrificing quality:
+
+1. **Default effort map (`SLASH_COMMAND_EFFORT_MAP`):** `/pull_request`, `/document`, and `/adw_init` change from `'high'` to `'medium'`.
+2. **Fast effort map (`SLASH_COMMAND_EFFORT_MAP_FAST`):** `/resolve_failed_test` and `/resolve_failed_e2e_test` change from `'high'` to `'medium'` (high effort contradicts fast mode intent).
+
+## Relevant Files
+Use these files to resolve the chore:
+
+- `adws/core/config.ts` — Contains `SLASH_COMMAND_EFFORT_MAP` and `SLASH_COMMAND_EFFORT_MAP_FAST` where the five effort values must be changed.
+- `adws/core/__tests__/slashCommandModelMap.test.ts` — Contains test assertions for both effort maps that must be updated to expect `'medium'` instead of `'high'` for the five affected commands.
+- `app_docs/feature-add-resoning-effort-4wna6z-reasoning-effort-slash-commands.md` — Documents the effort configuration table; must be updated to reflect the new values.
+- `guidelines/coding_guidelines.md` — Coding guidelines to follow during implementation.
+
+## Step by Step Tasks
+IMPORTANT: Execute every step in order, top to bottom.
+
+### Step 1: Update default effort map in `adws/core/config.ts`
+
+- In the `SLASH_COMMAND_EFFORT_MAP` object (line 252–273), change:
+  - `/pull_request`: `'high'` → `'medium'` (line 266)
+  - `/document`: `'high'` → `'medium'` (line 267)
+  - `/adw_init`: `'high'` → `'medium'` (line 272)
+
+### Step 2: Update fast effort map in `adws/core/config.ts`
+
+- In the `SLASH_COMMAND_EFFORT_MAP_FAST` object (line 276–297), change:
+  - `/resolve_failed_test`: `'high'` → `'medium'` (line 286)
+  - `/resolve_failed_e2e_test`: `'high'` → `'medium'` (line 287)
+
+### Step 3: Update default effort map tests in `adws/core/__tests__/slashCommandModelMap.test.ts`
+
+- In the `SLASH_COMMAND_EFFORT_MAP` test block (lines 207–233), update:
+  - Line 222: `expect(SLASH_COMMAND_EFFORT_MAP['/pull_request']).toBe('high')` → `.toBe('medium')`
+  - Line 223: `expect(SLASH_COMMAND_EFFORT_MAP['/document']).toBe('high')` → `.toBe('medium')`
+  - Line 227: `expect(SLASH_COMMAND_EFFORT_MAP['/adw_init']).toBe('high')` → `.toBe('medium')`
+
+### Step 4: Update fast effort map tests in `adws/core/__tests__/slashCommandModelMap.test.ts`
+
+- In the `SLASH_COMMAND_EFFORT_MAP_FAST` test block (lines 235–261), update:
+  - Line 246: `expect(SLASH_COMMAND_EFFORT_MAP_FAST['/resolve_failed_test']).toBe('high')` → `.toBe('medium')`
+  - Line 247: `expect(SLASH_COMMAND_EFFORT_MAP_FAST['/resolve_failed_e2e_test']).toBe('high')` → `.toBe('medium')`
+
+### Step 5: Update the effort configuration documentation
+
+- In `app_docs/feature-add-resoning-effort-4wna6z-reasoning-effort-slash-commands.md`, update the Configuration table:
+  - `/pull_request` row: Default Effort `high` → `medium`
+  - `/document` row: Default Effort `high` → `medium`
+  - `/adw_init` row: Default Effort `high` → `medium`
+  - `/resolve_failed_test` row: Fast Effort `high` → `medium`
+  - `/resolve_failed_e2e_test` row: Fast Effort `high` → `medium`
+
+### Step 6: Run validation commands
+
+- Execute all validation commands listed below to confirm zero regressions.
+
+## Validation Commands
+Execute every command to validate the chore is complete with zero regressions.
+
+- `bun run lint` - Run linter to check for code quality issues
+- `bunx tsc --noEmit` - Type check main project
+- `bunx tsc --noEmit -p adws/tsconfig.json` - Type check adws scripts
+- `bun run test` - Run full test suite to validate zero regressions
+
+## Notes
+- IMPORTANT: Strictly adhere to `guidelines/coding_guidelines.md`.
+- This is a purely mechanical change — only literal string values in config maps, their corresponding test assertions, and the documentation table need updating. No logic, type, or signature changes are required.
+- The total number of entries in each map (20) remains unchanged.
+- No changes to agent caller files are needed since they read effort via `getEffortForCommand()` which is unaffected.


### PR DESCRIPTION
## Summary

Reduces reasoning effort from `high` to `medium` for slash commands that perform structurally deterministic operations — operations where the output format is well-defined and the model is essentially filling a template or following a mechanical procedure.

**Plan:** `snqk14-reduce-reasoning-eff`
**Spec:** `specs/issue-156-adw-snqk14-reduce-reasoning-eff-sdlc_planner-reduce-effort-deterministic-ops.md`

## Changes

- **`adws/core/config.ts`** — Updated effort values in `SLASH_COMMAND_EFFORT_MAP` and `SLASH_COMMAND_EFFORT_MAP_FAST`:
  - `/pull_request`: `high` → `medium` (PR creation is templated, implementation already done)
  - `/document`: `high` → `medium` (reads git diff and produces structured docs)
  - `/adw_init`: `high` → `medium` (detects project structure, writes config files)
  - `/resolve_failed_test`: `high` → `medium` (fast mode already active; high effort contradicts intent)
  - `/resolve_failed_e2e_test`: `high` → `medium` (same as above)
- **`adws/core/__tests__/slashCommandModelMap.test.ts`** — Updated test expectations to reflect new `medium` values
- **`app_docs/`** — Updated feature documentation
- **`specs/`** — Added spec for this change

## Checklist

- [x] Five effort values updated in `config.ts` as specified
- [x] Tests in `slashCommandModelMap.test.ts` updated to reflect new values
- [x] `bun run test` passes with zero regressions

Closes #156

---
*ADW tracking ID: snqk14-reduce-reasoning-eff*