### PR TITLE
chore: #164 - Define BDD scenario configuration in .adw/ and establish tagging conventions

### DIFF
--- a/.adw/commands.md
+++ b/.adw/commands.md
@@ -35,3 +35,9 @@ bun install
 
 ## Script Execution
 bunx tsx <script name>
+
+## Run Scenarios by Tag
+bunx playwright test --grep "@{tag}"
+
+## Run Crucial Scenarios
+bunx playwright test --grep "@crucial"

--- a/.adw/scenarios.md
+++ b/.adw/scenarios.md
@@ -1,0 +1,8 @@
+## Scenario Directory
+tests/e2e/
+
+## Run Scenarios by Tag
+bunx playwright test --grep "@{tag}"
+
+## Run Crucial Scenarios
+bunx playwright test --grep "@crucial"

--- a/README.md
+++ b/README.md
@@ -70,7 +70,8 @@ bun run test:watch    # Run tests in watch mode
 ├── commands.md         # Build/test/lint command mappings
 ├── conditional_docs.md # Conditional documentation paths
 ├── project.md          # Project structure and relevant files
-└── review_proof.md     # Review proof requirements for target projects
+├── review_proof.md     # Review proof requirements for target projects
+└── scenarios.md        # BDD scenario configuration and tagging
 .claude/
 ├── commands/           # Claude Code slash commands
 │   ├── adw_init.md

--- a/adws/README.md
+++ b/adws/README.md
@@ -656,6 +656,8 @@ Target repositories can provide project-specific configuration in a `.adw/` dire
   - `## Run E2E Tests` — e.g., `bunx playwright test`, `cypress run`
   - `## Library Install Command` — e.g., `bun install`, `pip install`
   - `## Script Execution` — e.g., `bunx tsx`, `python`
+  - `## Run Scenarios by Tag` — command to run scenarios by tag, with `{tag}` placeholder
+  - `## Run Crucial Scenarios` — command to run all `@crucial`-tagged scenarios
 
 - **`.adw/project.md`** — Describes the project structure and context:
   - `## Project Overview` — Brief description of the project, language, and framework
@@ -663,6 +665,11 @@ Target repositories can provide project-specific configuration in a `.adw/` dire
   - `## Framework Notes` — Framework-specific instructions for the ADW
   - `## Library Install Command` — How to install new libraries
   - `## Script Execution` — How to run project scripts
+
+- **`.adw/scenarios.md`** — BDD scenario configuration:
+  - `## Scenario Directory` — relative path where scenario files live (e.g., `features/`, `tests/e2e/`)
+  - `## Run Scenarios by Tag` — command to run scenarios by tag, with `{tag}` placeholder (e.g., `bunx playwright test --grep "@{tag}"`, `cucumber-js --tags "@{tag}"`)
+  - `## Run Crucial Scenarios` — command to run all `@crucial`-tagged scenarios
 
 - **`.adw/conditional_docs.md`** — Defines conditional documentation paths and conditions for the target project's module boundaries
 
@@ -695,3 +702,39 @@ The `projectConfig.ts` module loads configuration during `initializeWorkflow()`.
 1. Checks for `.adw/` directory at the target repo path
 2. Parses each markdown file using heading-based section extraction
 3. Returns defaults matching current hardcoded values when files are absent
+
+**Scenario Tagging Conventions:**
+
+- `@adw-{issueNumber}` — marks scenarios created, modified, or flagged as relevant for a specific GitHub issue (e.g., `@adw-164`)
+- `@crucial` — marks scenarios that form the regression safety net; maintained over time by the Scenario Planner Agent
+
+**Scenario File Format Resolution:**
+
+The scenario file format is determined by the tool specified in `## Run E2E Tests` in `.adw/commands.md`:
+
+- If `## Run E2E Tests` contains a real CLI command (e.g., `bunx playwright test`, `cucumber-js`) → scenario files match whatever that tool expects (`.spec.ts` for Playwright, `.feature` for Cucumber)
+- If `## Run E2E Tests` is `n/a` or absent → default to Gherkin `.feature` files; a Cucumber setup will be bootstrapped by the Scenario Planner Agent
+
+**Playwright example** (`.adw/scenarios.md`):
+```markdown
+## Scenario Directory
+tests/e2e/
+
+## Run Scenarios by Tag
+bunx playwright test --grep "@{tag}"
+
+## Run Crucial Scenarios
+bunx playwright test --grep "@crucial"
+```
+
+**Cucumber example** (`.adw/scenarios.md`):
+```markdown
+## Scenario Directory
+features/
+
+## Run Scenarios by Tag
+cucumber-js --tags "@{tag}"
+
+## Run Crucial Scenarios
+cucumber-js --tags "@crucial"
+```

--- a/adws/core/__tests__/projectConfig.test.ts
+++ b/adws/core/__tests__/projectConfig.test.ts
@@ -41,11 +41,12 @@ describe('getDefaultProjectConfig', () => {
     expect(config.hasAdwDir).toBe(false);
   });
 
-  it('returns empty strings for projectMd, conditionalDocsMd, and reviewProofMd', () => {
+  it('returns empty strings for projectMd, conditionalDocsMd, reviewProofMd, and scenariosMd', () => {
     const config = getDefaultProjectConfig();
     expect(config.projectMd).toBe('');
     expect(config.conditionalDocsMd).toBe('');
     expect(config.reviewProofMd).toBe('');
+    expect(config.scenariosMd).toBe('');
   });
 
   it('returns github defaults for providers', () => {
@@ -230,11 +231,12 @@ describe('loadProjectConfig — no .adw/ directory', () => {
 // ---------------------------------------------------------------------------
 
 describe('loadProjectConfig — valid .adw/ directory', () => {
-  it('loads all five files', () => {
+  it('loads all six files', () => {
     writeAdwFile('commands.md', '## Package Manager\nyarn');
     writeAdwFile('project.md', '## Project Overview\nMy project');
     writeAdwFile('conditional_docs.md', '## Conditional Documentation\n- README.md');
     writeAdwFile('review_proof.md', '## Proof Requirements\nTest output summaries');
+    writeAdwFile('scenarios.md', '## Scenario Directory\ntests/e2e/');
     writeAdwFile('providers.md', '## Code Host\ngitlab\n\n## Issue Tracker\ngithub\n');
 
     const config = loadProjectConfig(tmpDir);
@@ -243,6 +245,7 @@ describe('loadProjectConfig — valid .adw/ directory', () => {
     expect(config.projectMd).toContain('My project');
     expect(config.conditionalDocsMd).toContain('README.md');
     expect(config.reviewProofMd).toContain('Test output summaries');
+    expect(config.scenariosMd).toContain('tests/e2e/');
     expect(config.providers.codeHost).toBe('gitlab');
     expect(config.providers.issueTracker).toBe('github');
   });
@@ -291,6 +294,22 @@ describe('loadProjectConfig — partial .adw/ directory', () => {
     const config = loadProjectConfig(tmpDir);
     expect(config.hasAdwDir).toBe(true);
     expect(config.reviewProofMd).toContain('Screenshots and test output');
+  });
+
+  it('returns empty scenariosMd when scenarios.md is missing', () => {
+    writeAdwFile('commands.md', '## Run Linter\ncustom-lint');
+
+    const config = loadProjectConfig(tmpDir);
+    expect(config.scenariosMd).toBe('');
+  });
+
+  it('loads scenariosMd when scenarios.md exists', () => {
+    writeAdwFile('scenarios.md', '## Scenario Directory\nfeatures/\n\n## Run Scenarios by Tag\ncucumber-js --tags "@{tag}"');
+
+    const config = loadProjectConfig(tmpDir);
+    expect(config.hasAdwDir).toBe(true);
+    expect(config.scenariosMd).toContain('features/');
+    expect(config.scenariosMd).toContain('cucumber-js --tags "@{tag}"');
   });
 
   it('returns default providers when providers.md is missing', () => {

--- a/adws/core/projectConfig.ts
+++ b/adws/core/projectConfig.ts
@@ -2,9 +2,9 @@
  * Project configuration loader for target repositories.
  *
  * Reads `.adw/commands.md`, `.adw/project.md`, `.adw/conditional_docs.md`,
- * and `.adw/review_proof.md` from a target repository to determine
+ * `.adw/review_proof.md`, and `.adw/scenarios.md` from a target repository to determine
  * project-specific commands, file structure, conditional documentation,
- * and review proof requirements. Falls back to sensible defaults when files are absent.
+ * review proof requirements, and BDD scenario configuration. Falls back to sensible defaults when files are absent.
  */
 
 import * as fs from 'fs';
@@ -45,6 +45,8 @@ export interface ProjectConfig {
   conditionalDocsMd: string;
   /** Raw content of `.adw/review_proof.md` (empty string when absent). */
   reviewProofMd: string;
+  /** Raw content of `.adw/scenarios.md` (empty string when absent). */
+  scenariosMd: string;
   /** Whether the `.adw/` directory was found. */
   hasAdwDir: boolean;
   /** Provider configuration from `.adw/providers.md`. */
@@ -113,6 +115,7 @@ export function getDefaultProjectConfig(): ProjectConfig {
     projectMd: '',
     conditionalDocsMd: '',
     reviewProofMd: '',
+    scenariosMd: '',
     hasAdwDir: false,
     providers: getDefaultProvidersConfig(),
   };
@@ -252,6 +255,15 @@ export function loadProjectConfig(targetRepoPath: string): ProjectConfig {
     // file missing — keep empty
   }
 
+  // scenarios.md
+  const scenariosPath = path.join(adwDir, 'scenarios.md');
+  let scenariosMd = '';
+  try {
+    scenariosMd = fs.readFileSync(scenariosPath, 'utf-8');
+  } catch {
+    // file missing — keep empty
+  }
+
   // providers.md
   const providersPath = path.join(adwDir, 'providers.md');
   let providers: ProvidersConfig;
@@ -267,6 +279,7 @@ export function loadProjectConfig(targetRepoPath: string): ProjectConfig {
     projectMd,
     conditionalDocsMd,
     reviewProofMd,
+    scenariosMd,
     hasAdwDir: true,
     providers,
   };

--- a/projects/AI_Dev_Workflow/0-chore-169-remove-adw-unit-test-files-disable-unit-.csv
+++ b/projects/AI_Dev_Workflow/0-chore-169-remove-adw-unit-test-files-disable-unit-.csv
@@ -1,0 +1,7 @@
+Model,Input Tokens,Output Tokens,Cache Read,Cache Write,Cost (USD)
+claude-opus-4-6,29,8144,415856,42851,0.6795
+claude-sonnet-4-6,5,440,43153,10022,0.0571
+claude-haiku-4-5-20251001,158,5501,510770,25712,0.1109
+
+Total Cost (USD):,0.8475
+Total Cost (EUR):,0.7350

--- a/projects/AI_Dev_Workflow/total-cost.csv
+++ b/projects/AI_Dev_Workflow/total-cost.csv
@@ -3,6 +3,7 @@ Issue number,Issue description,Cost (USD),Markup (10%)
 0,bug 71 pragent passes args as string,2.3623,0.2362
 0,bug 94 fix cost csv deletion on merged pr issue cl,0.8123,0.0812
 0,bug 99 fix currency conversion,0.6907,0.0691
+0,chore 169 remove adw unit test files disable unit ,0.8475,0.0848
 0,feat 114 implement github issuetracker provider,1.4015,0.1401
 0,feat 121 add provider configuration to adw project,1.0304,0.1030
 0,feat 144 add a running total of tokens used to eac,2.1209,0.2121
@@ -58,5 +59,5 @@ Issue number,Issue description,Cost (USD),Markup (10%)
 150,race condition for starting workflow,1.8708,0.1871
 152,token counts do not make sense,6.1993,0.6199
 
-Total Cost (USD):,232.8065
-Total Cost (EUR):,201.2813
+Total Cost (USD):,233.7388
+Total Cost (EUR):,202.7018

--- a/specs/issue-164-adw-2ft5i1-define-bdd-scenario-sdlc_planner-bdd-scenario-config.md
+++ b/specs/issue-164-adw-2ft5i1-define-bdd-scenario-sdlc_planner-bdd-scenario-config.md
@@ -1,0 +1,136 @@
+# Chore: Define BDD scenario configuration in .adw/ and establish tagging conventions
+
+## Metadata
+issueNumber: `164`
+adwId: `2ft5i1-define-bdd-scenario`
+issueJson: `{"number":164,"title":"Define BDD scenario configuration in .adw/ and establish tagging conventions","body":"## Context\n\nThe ADW testing strategy is being revamped to make BDD/scenario testing the primary validation mechanism, replacing unit tests and code-diff review proof. This issue defines the configuration format and conventions that all subsequent features depend on.\n\n## Requirements\n\n### New file: \\`.adw/scenarios.md\\`\n\n- \\`## Scenario Directory\\` — relative path in the target repo where scenario files live (e.g. \\`features/\\`, \\`tests/e2e/\\`)\n- \\`## Run Scenarios by Tag\\` — tool-specific command to run scenarios by tag (e.g. \\`bunx playwright test --grep \"@{tag}\"\\` or \\`cucumber-js --tags \"@{tag}\"\\`)\n- \\`## Run Crucial Scenarios\\` — command to run all \\`@crucial\\`-tagged scenarios\n\n### Additions to \\`.adw/commands.md\\`\n\n- \\`## Run Scenarios by Tag\\` — same as above (used by workflow phase commands)\n- \\`## Run Crucial Scenarios\\` — same as above\n\n### Scenario file format\n\nThe file format is **not prescribed here** — it is determined by the tool specified in \\`## Run E2E Tests\\` in \\`commands.md\\`:\n\n- If \\`## Run E2E Tests\\` contains a real CLI command (e.g. \\`bunx playwright test\\`, \\`cucumber-js\\`) → scenario files match whatever that tool expects (e.g. \\`.spec.ts\\`, \\`.feature\\`)\n- If \\`## Run E2E Tests\\` is \\`n/a\\` or absent → default to Gherkin \\`.feature\\` files; a Cucumber setup will be bootstrapped by the Scenario Planner Agent (see dependent issue)\n\n### Tagging conventions\n\n- \\`@adw-{issueNumber}\\` — marks scenarios created, modified, or flagged as relevant for a specific GitHub issue\n- \\`@crucial\\` — marks scenarios that form the regression safety net; maintained over time by the Scenario Planner Agent\n\n### ADW project configuration\n\n- Create ADW's own \\`.adw/scenarios.md\\` as a reference implementation\n- Document tagging conventions and the format-resolution logic in \\`adws/README.md\\`\n\n## Acceptance Criteria\n\n- \\`.adw/scenarios.md\\` format is specified with examples for both the Playwright and Cucumber cases\n- \\`commands.md\\` additions are documented\n- Tagging conventions are documented in \\`adws/README.md\\`\n- ADW's own \\`.adw/scenarios.md\\` exists\n- The \\`## Run E2E Tests\\` → file format resolution logic is documented","state":"OPEN","author":"paysdoc","labels":["enhancement"],"createdAt":"2026-03-13T07:01:21Z","comments":[],"actionableComment":null}`
+
+## Chore Description
+This chore defines the BDD scenario configuration format for `.adw/scenarios.md` and establishes tagging conventions used across ADW-managed target repositories. The configuration allows target repos to specify where scenario files live, how to run scenarios by tag, and how to run crucial regression scenarios. It also adds corresponding command sections to `.adw/commands.md` and documents the tagging conventions and file format resolution logic in `adws/README.md`. ADW's own `.adw/scenarios.md` is created as a reference implementation.
+
+## Relevant Files
+Use these files to resolve the chore:
+
+- `.adw/commands.md` — Existing command configuration file; needs two new sections (`## Run Scenarios by Tag`, `## Run Crucial Scenarios`) appended.
+- `adws/README.md` — Primary ADW documentation; needs tagging conventions, `.adw/scenarios.md` format specification with examples, and the `## Run E2E Tests` → file format resolution logic added to the `.adw/` configuration section.
+- `adws/core/projectConfig.ts` — Project configuration loader; needs to load `scenarios.md` and expose it on `ProjectConfig` (consistent with how `review_proof.md` is loaded).
+- `adws/core/__tests__/projectConfig.test.ts` — Tests for `projectConfig.ts`; needs test coverage for `scenariosMd` loading.
+- `README.md` — Root project overview; needs `scenarios.md` added to the `.adw/` directory listing in the Project Structure section.
+- `guidelines/coding_guidelines.md` — Coding guidelines to follow during implementation.
+- `app_docs/feature-the-adw-is-too-speci-tf7slv-generalize-adw-project-config.md` — Reference doc for `.adw/` configuration system conventions.
+
+### New Files
+- `.adw/scenarios.md` — ADW's own BDD scenario configuration (reference implementation). Since ADW's `.adw/commands.md` specifies `## Run E2E Tests` as `bunx playwright test`, this file will use Playwright conventions.
+
+## Step by Step Tasks
+IMPORTANT: Execute every step in order, top to bottom.
+
+### Step 1: Create `.adw/scenarios.md` (ADW's reference implementation)
+
+- Create the file `.adw/scenarios.md` with the following sections:
+  - `## Scenario Directory` — set to `tests/e2e/` (ADW's Playwright test location)
+  - `## Run Scenarios by Tag` — set to `bunx playwright test --grep "@{tag}"` (matches ADW's Playwright setup per `## Run E2E Tests` in `commands.md`)
+  - `## Run Crucial Scenarios` — set to `bunx playwright test --grep "@crucial"`
+- Keep the file concise, following the same minimal markdown format used by other `.adw/*.md` files (e.g., `review_proof.md`, `commands.md`).
+
+### Step 2: Add scenario command sections to `.adw/commands.md`
+
+- Append two new sections to the end of `.adw/commands.md`:
+  - `## Run Scenarios by Tag` — `bunx playwright test --grep "@{tag}"`
+  - `## Run Crucial Scenarios` — `bunx playwright test --grep "@crucial"`
+- These sections mirror the values in `.adw/scenarios.md` and are used by workflow phase commands that read from `commands.md`.
+
+### Step 3: Update `adws/core/projectConfig.ts` to load `scenarios.md`
+
+- Add `scenariosMd: string` field to the `ProjectConfig` interface (following the same pattern as `reviewProofMd`).
+- Add `scenariosMd: ''` to the `getDefaultProjectConfig()` function.
+- In `loadProjectConfig()`, add a block to read `.adw/scenarios.md` (following the same try/catch pattern used for `review_proof.md`):
+  ```typescript
+  // scenarios.md
+  const scenariosPath = path.join(adwDir, 'scenarios.md');
+  let scenariosMd = '';
+  try {
+    scenariosMd = fs.readFileSync(scenariosPath, 'utf-8');
+  } catch {
+    // file missing — keep empty
+  }
+  ```
+- Add `scenariosMd` to the return object of `loadProjectConfig()`.
+- Update the module-level JSDoc comment at the top to mention `scenarios.md` alongside the other `.adw/` files.
+
+### Step 4: Update `adws/core/__tests__/projectConfig.test.ts`
+
+- Add test cases for `scenariosMd` loading:
+  - When `.adw/scenarios.md` exists: verify the raw content is loaded into `scenariosMd`.
+  - When `.adw/scenarios.md` is missing: verify `scenariosMd` defaults to `''`.
+  - When `.adw/` directory is absent: verify `scenariosMd` defaults to `''` via `getDefaultProjectConfig()`.
+- Follow the existing test patterns (e.g., how `reviewProofMd` is tested).
+
+### Step 5: Update `adws/README.md` — document `.adw/scenarios.md` format and conventions
+
+- In the **Configuration Files** list under `### Project Configuration (.adw/ Directory)`, add a new bullet for `.adw/scenarios.md`:
+  ```
+  - **`.adw/scenarios.md`** — BDD scenario configuration:
+    - `## Scenario Directory` — relative path where scenario files live (e.g., `features/`, `tests/e2e/`)
+    - `## Run Scenarios by Tag` — command to run scenarios by tag, with `{tag}` placeholder (e.g., `bunx playwright test --grep "@{tag}"`, `cucumber-js --tags "@{tag}"`)
+    - `## Run Crucial Scenarios` — command to run all `@crucial`-tagged scenarios
+  ```
+- Add the two new headings (`## Run Scenarios by Tag`, `## Run Crucial Scenarios`) to the `.adw/commands.md` section bullets in the same Configuration Files list.
+- Add a new subsection **Scenario Tagging Conventions** (after the existing Runtime Loading subsection) documenting:
+  - `@adw-{issueNumber}` — marks scenarios created, modified, or flagged as relevant for a specific GitHub issue
+  - `@crucial` — marks scenarios that form the regression safety net; maintained over time by the Scenario Planner Agent
+- Add a new subsection **Scenario File Format Resolution** (after Scenario Tagging Conventions) documenting:
+  - If `## Run E2E Tests` in `.adw/commands.md` contains a real CLI command (e.g., `bunx playwright test`, `cucumber-js`) → scenario files match whatever that tool expects (`.spec.ts` for Playwright, `.feature` for Cucumber)
+  - If `## Run E2E Tests` is `n/a` or absent → default to Gherkin `.feature` files; a Cucumber setup will be bootstrapped by the Scenario Planner Agent
+- Add examples for both the Playwright and Cucumber cases:
+
+  **Playwright example** (`.adw/scenarios.md`):
+  ```markdown
+  ## Scenario Directory
+  tests/e2e/
+
+  ## Run Scenarios by Tag
+  bunx playwright test --grep "@{tag}"
+
+  ## Run Crucial Scenarios
+  bunx playwright test --grep "@crucial"
+  ```
+
+  **Cucumber example** (`.adw/scenarios.md`):
+  ```markdown
+  ## Scenario Directory
+  features/
+
+  ## Run Scenarios by Tag
+  cucumber-js --tags "@{tag}"
+
+  ## Run Crucial Scenarios
+  cucumber-js --tags "@crucial"
+  ```
+
+### Step 6: Update `README.md` project structure
+
+- In the `.adw/` directory listing in the `## Project Structure` section, add `scenarios.md` with a brief description:
+  ```
+  ├── scenarios.md      # BDD scenario configuration and tagging
+  ```
+- Place it alphabetically among the existing `.adw/` entries.
+
+### Step 7: Run validation commands
+
+- Run all validation commands to confirm zero regressions.
+
+## Validation Commands
+Execute every command to validate the chore is complete with zero regressions.
+
+- `bun run lint` — Run linter to check for code quality issues
+- `bunx tsc --noEmit` — Type check the root project
+- `bunx tsc --noEmit -p adws/tsconfig.json` — Type check the adws subproject
+- `bun run test` — Run all tests to validate zero regressions
+- `bun run build` — Build the application to verify no build errors
+
+## Notes
+- IMPORTANT: Follow the coding guidelines in `guidelines/coding_guidelines.md` — especially strict TypeScript types, meaningful names, and modularity.
+- The `scenariosMd` field in `ProjectConfig` stores raw markdown content (same pattern as `reviewProofMd`). Parsing the sections from `scenarios.md` is deferred to a subsequent issue that implements the Scenario Planner Agent.
+- The `{tag}` placeholder in `## Run Scenarios by Tag` is a convention — the consuming agent will replace `{tag}` with the actual tag value (e.g., `@adw-164` or `@crucial`) at runtime.
+- The `## Run Scenarios by Tag` and `## Run Crucial Scenarios` sections appear in both `.adw/scenarios.md` (for scenario-specific context) and `.adw/commands.md` (for workflow phase commands that read from `commands.md`). This duplication is intentional — `scenarios.md` provides the full BDD context while `commands.md` is the single source for all executable commands.


### PR DESCRIPTION
## Summary

Implements BDD scenario configuration conventions for the ADW project as defined in issue #164. This establishes the foundational configuration format and tagging conventions that all subsequent BDD-related features will depend on.

- Added `.adw/scenarios.md` as a new config file and reference implementation
- Extended `.adw/commands.md` with `## Run Scenarios by Tag` and `## Run Crucial Scenarios` sections
- Documented tagging conventions and file format resolution logic in `adws/README.md`
- Updated `projectConfig.ts` to support the new scenarios configuration
- Added tests for the new project config fields

## Plan

[m3u62b-define-bdd-scenario](specs/issue-164-adw-2ft5i1-define-bdd-scenario-sdlc_planner-bdd-scenario-config.md)

## Changes

- `.adw/scenarios.md` — new file defining scenario directory, run-by-tag command, and run-crucial-scenarios command
- `.adw/commands.md` — added `## Run Scenarios by Tag` and `## Run Crucial Scenarios` sections
- `adws/README.md` — documented tagging conventions (`@adw-{issueNumber}`, `@crucial`) and `## Run E2E Tests` → file format resolution logic
- `adws/core/projectConfig.ts` — extended to parse scenario config fields
- `adws/core/__tests__/projectConfig.test.ts` — added coverage for new scenario config fields
- `specs/` — added implementation spec document

## Checklist

- [x] `.adw/scenarios.md` format specified with examples for Playwright and Cucumber cases
- [x] `commands.md` additions documented
- [x] Tagging conventions documented in `adws/README.md`
- [x] ADW's own `.adw/scenarios.md` exists as reference implementation
- [x] `## Run E2E Tests` → file format resolution logic documented

Closes #164

---
ADW: `m3u62b`