### PR TITLE
feat: #175 - Add logging when determining whether there is an issue dependency

### DIFF
--- a/.claude/commands/conditional_docs.md
+++ b/.claude/commands/conditional_docs.md
@@ -74,3 +74,10 @@ This prompt helps you determine what documentation you should read based on the 
     - When configuring ADW to use GitLab as the code hosting backend
     - When troubleshooting GitLab API authentication, merge request creation, or review fetching
     - When adding support for a new code host platform following the CodeHost interface
+
+- app_docs/feature-74itmf-dependency-logging.md
+  - Conditions:
+    - When working with `findOpenDependencies()` or `checkIssueEligibility()` in `adws/triggers/`
+    - When adding or modifying logging in the dependency resolution pipeline
+    - When troubleshooting why an issue was deferred due to blocking dependencies
+    - When diagnosing silent failures in `getIssueState()` dependency lookups

--- a/adws/triggers/issueDependencies.ts
+++ b/adws/triggers/issueDependencies.ts
@@ -7,6 +7,7 @@
 
 import { getIssueState } from '../github/issueApi';
 import type { RepoInfo } from '../github/githubApi';
+import { log } from '../core';
 
 /**
  * Parses issue dependency numbers from the `## Dependencies` section of an issue body.
@@ -54,19 +55,31 @@ export function parseDependencies(issueBody: string): number[] {
  */
 export async function findOpenDependencies(issueBody: string, repoInfo: RepoInfo): Promise<number[]> {
   const deps = parseDependencies(issueBody);
-  if (deps.length === 0) return [];
+
+  if (deps.length === 0) {
+    log('No dependencies found, skipping dependency check');
+    return [];
+  }
+
+  log(`Checking dependencies: found ${deps.length} dependency(ies) to resolve`);
 
   const openDeps: number[] = [];
   for (const dep of deps) {
     try {
       const state = getIssueState(dep, repoInfo);
+      log(`Dependency #${dep}: ${state}`);
       if (state === 'OPEN') {
         openDeps.push(dep);
       }
-    } catch {
-      // If we can't check the state, skip this dependency
+    } catch (err) {
+      log(`Failed to check state of dependency #${dep}: ${err}`, 'warn');
     }
   }
+
+  const summary = openDeps.length > 0
+    ? `Dependency check complete: ${openDeps.length} open dependency(ies) found (${openDeps.map(n => `#${n}`).join(', ')})`
+    : `Dependency check complete: 0 open dependency(ies) found`;
+  log(summary);
 
   return openDeps;
 }

--- a/adws/triggers/issueEligibility.ts
+++ b/adws/triggers/issueEligibility.ts
@@ -8,6 +8,7 @@
 import type { RepoInfo } from '../github/githubApi';
 import { findOpenDependencies } from './issueDependencies';
 import { isConcurrencyLimitReached } from './concurrencyGuard';
+import { log } from '../core';
 
 /** Result of an issue eligibility check. */
 export interface EligibilityResult {
@@ -27,6 +28,8 @@ export async function checkIssueEligibility(
   issueBody: string,
   repoInfo: RepoInfo,
 ): Promise<EligibilityResult> {
+  log(`Checking eligibility for issue #${issueNumber}`);
+
   // Check dependencies first
   const openDeps = await findOpenDependencies(issueBody, repoInfo);
   if (openDeps.length > 0) {

--- a/app_docs/feature-74itmf-dependency-logging.md
+++ b/app_docs/feature-74itmf-dependency-logging.md
@@ -1,0 +1,65 @@
+# Dependency Resolution Logging
+
+**ADW ID:** 74itmf-add-logging-when-det
+**Date:** 2026-03-13
+**Specification:** specs/issue-175-adw-74itmf-add-logging-when-det-sdlc_planner-add-dependency-logging.md
+
+## Overview
+
+Adds structured observability logging to the dependency resolution pipeline so operators can trace how ADW determines whether an issue has blocking dependencies. Previously, `findOpenDependencies()` operated silently — making it impossible to diagnose why issues were deferred or why dependency state lookups failed. All logging uses the existing `log()` function from `adws/core`.
+
+## What Was Built
+
+- Entry log in `checkIssueEligibility()` reporting which issue number is being evaluated
+- Entry log in `findOpenDependencies()` reporting how many dependencies were parsed (or that none were found)
+- Per-dependency log inside the resolution loop reporting each dependency number and its resolved state (`OPEN` / `CLOSED`)
+- Error log at `'warn'` level when `getIssueState()` throws, replacing the previous silent `catch {}` block
+- Exit log summarizing the count of open (blocking) dependencies, including their issue numbers when any are found
+
+## Technical Implementation
+
+### Files Modified
+
+- `adws/triggers/issueDependencies.ts`: Added `log` import from `'../core'`; added 5 log call-sites to `findOpenDependencies()` covering entry, per-dependency state, error handling, and exit
+- `adws/triggers/issueEligibility.ts`: Added `log` import from `'../core'`; added entry-level log to `checkIssueEligibility()` reporting the issue number being checked
+
+### Key Changes
+
+- `findOpenDependencies()` now logs `"No dependencies found, skipping dependency check"` and returns early when `deps.length === 0`
+- Each dependency resolved in the for-loop emits `"Dependency #<N>: <STATE>"` at `'info'` level
+- The previously silent `catch {}` block now logs `"Failed to check state of dependency #<N>: <err>"` at `'warn'` level, preserving the continue-on-error behavior while surfacing failures
+- On exit, the function logs either `"Dependency check complete: N open dependency(ies) found (#X, #Y)"` or `"Dependency check complete: 0 open dependency(ies) found"`
+- `checkIssueEligibility()` logs `"Checking eligibility for issue #<issueNumber>"` at the start of each evaluation
+
+## How to Use
+
+No configuration or code changes are required by consumers. Log output appears automatically in the existing log stream whenever `checkIssueEligibility()` is called (e.g., from `trigger_cron.ts` or `webhookGatekeeper.ts`).
+
+Example log output for an issue with one open and one closed dependency:
+
+```
+[INFO] Checking eligibility for issue #180
+[INFO] Checking dependencies: found 2 dependency(ies) to resolve
+[INFO] Dependency #175: CLOSED
+[INFO] Dependency #176: OPEN
+[INFO] Dependency check complete: 1 open dependency(ies) found (#176)
+```
+
+## Configuration
+
+None. The `log()` function from `adws/core` writes to stdout with timestamps and propagates the optional ADW ID context automatically.
+
+## Testing
+
+Unit tests are disabled for ADW per `.adw/project.md`. Validate manually by triggering an eligibility check on an issue that has a `## Dependencies` section, then inspecting the log output. Validation commands:
+
+```sh
+bun run lint
+bunx tsc --noEmit
+bunx tsc --noEmit -p adws/tsconfig.json
+```
+
+## Notes
+
+- No function signatures or return values were changed — this is a pure observability addition.
+- The existing silent `catch {}` was an anti-pattern per `guidelines/coding_guidelines.md` ("Provide meaningful error messages"); this feature replaces it with a `'warn'`-level log while preserving the continue-on-error semantics.

--- a/specs/issue-175-adw-74itmf-add-logging-when-det-sdlc_planner-add-dependency-logging.md
+++ b/specs/issue-175-adw-74itmf-add-logging-when-det-sdlc_planner-add-dependency-logging.md
@@ -1,0 +1,106 @@
+# Feature: Add Logging When Determining Issue Dependencies
+
+## Metadata
+issueNumber: `175`
+adwId: `74itmf-add-logging-when-det`
+issueJson: `{"number":175,"title":"Add logging when determining whether there is an issue dependency","body":"","state":"OPEN","author":"paysdoc","labels":[],"createdAt":"2026-03-13T13:38:31Z","comments":[{"author":"paysdoc","createdAt":"2026-03-13T13:44:05Z","body":"## Take action"},{"author":"paysdoc","createdAt":"2026-03-13T13:48:22Z","body":"## Take action"}],"actionableComment":null}`
+
+## Feature Description
+Add observability logging to the dependency resolution pipeline so operators can trace how ADW determines whether an issue has blocking dependencies. Currently, `findOpenDependencies()` in `adws/triggers/issueDependencies.ts` silently parses dependencies, checks their states, and silently swallows errors — making it difficult to diagnose why an issue was deferred or why a dependency check failed. This feature adds structured `log()` calls at key decision points: entry, per-dependency state resolution, error handling, and exit.
+
+## User Story
+As an ADW operator
+I want to see log output when dependencies are parsed and resolved
+So that I can diagnose why issues are deferred due to dependencies and detect failures in dependency state lookups
+
+## Problem Statement
+The `findOpenDependencies()` function operates silently — it parses dependencies, queries GitHub for each dependency's state, and returns results without any logging. Errors in `getIssueState()` calls are caught and silently ignored. This makes it impossible to determine from logs: (1) how many dependencies were found for an issue, (2) which dependencies were checked and their resolved states, (3) whether any dependency lookups failed, and (4) the final determination of open vs. closed dependencies.
+
+## Solution Statement
+Add `log()` calls to `findOpenDependencies()` and `checkIssueEligibility()` at the following decision points:
+1. **Entry**: Log the number of parsed dependencies found (or that none were found).
+2. **Per-dependency**: Log each dependency's resolved state (OPEN or CLOSED).
+3. **Error handling**: Log errors when `getIssueState()` fails for a dependency instead of silently catching.
+4. **Exit**: Log the final result — how many open (blocking) dependencies were found.
+5. **Eligibility entry**: Log that dependency checking is starting for a given issue number in `checkIssueEligibility()`.
+
+Use the existing `log()` function from `adws/core` with appropriate log levels (`'info'` for progress, `'warn'` for errors that are handled gracefully).
+
+## Relevant Files
+Use these files to implement the feature:
+
+- `adws/triggers/issueDependencies.ts` — Primary target. Contains `parseDependencies()` and `findOpenDependencies()`. Logging will be added to `findOpenDependencies()`.
+- `adws/triggers/issueEligibility.ts` — Contains `checkIssueEligibility()` which calls `findOpenDependencies()`. Add entry-level logging here to trace which issue is being checked.
+- `adws/core/utils.ts` — Contains the `log()` function and `LogLevel` type. Already imported by other trigger files; will be imported into `issueDependencies.ts`.
+- `adws/core/index.ts` — Barrel export for core utilities including `log`. Used for imports.
+- `adws/triggers/webhookGatekeeper.ts` — Reference file showing existing logging patterns for dependency-related operations (e.g., `logDeferral()`).
+- `adws/triggers/trigger_cron.ts` — Reference file showing existing logging patterns for eligibility checks.
+- `guidelines/coding_guidelines.md` — Coding guidelines that must be followed.
+
+## Implementation Plan
+### Phase 1: Foundation
+Import the `log` function into `issueDependencies.ts` from `../core`. No new dependencies or libraries are needed — the logging infrastructure already exists.
+
+### Phase 2: Core Implementation
+Add `log()` calls to `findOpenDependencies()` at four decision points:
+1. After parsing dependencies — log the count (or early return if zero).
+2. Inside the per-dependency loop — log each dependency number and its resolved state.
+3. In the catch block — log the error with the dependency number instead of silently ignoring.
+4. After the loop — log the final count of open (blocking) dependencies.
+
+Add a log call to `checkIssueEligibility()` at entry to trace which issue number is being evaluated.
+
+### Phase 3: Integration
+No integration work needed — the `log()` function writes to stdout with timestamps and optional ADW IDs, which is already how all trigger logging works. The new log lines will appear naturally in the existing log stream.
+
+## Step by Step Tasks
+
+### Step 1: Add logging to `findOpenDependencies()` in `issueDependencies.ts`
+- Import `log` from `'../core'`
+- After `parseDependencies()` call: log `"Checking dependencies: found {N} dependency(ies) to resolve"` at `'info'` level
+- If `deps.length === 0`, log `"No dependencies found, skipping dependency check"` before returning
+- Inside the for-loop, after resolving state: log `"Dependency #{dep}: {state}"` at `'info'` level
+- In the catch block: log `"Failed to check state of dependency #{dep}: {error}"` at `'warn'` level (replacing the silent catch)
+- After the loop: log `"Dependency check complete: {openDeps.length} open dependency(ies) found"` at `'info'` level; if open deps exist, include the issue numbers
+
+### Step 2: Add logging to `checkIssueEligibility()` in `issueEligibility.ts`
+- Import `log` from `'../core'`
+- At the start of the function: log `"Checking eligibility for issue #{issueNumber}"` at `'info'` level
+
+### Step 3: Run validation commands
+- Run `bun run lint` to check for linting errors
+- Run `bunx tsc --noEmit` to verify TypeScript compilation
+- Run `bunx tsc --noEmit -p adws/tsconfig.json` to verify ADW-specific TypeScript compilation
+
+## Testing Strategy
+### Unit Tests
+Unit tests are disabled for ADW per `.adw/project.md`. No new unit tests will be added.
+
+### Edge Cases
+- Issue body with no `## Dependencies` section — should log "No dependencies found" and return early
+- Issue body with dependencies that all resolve to CLOSED — should log each as CLOSED and report 0 open
+- Issue body with dependencies where `getIssueState()` throws — should log the error at `'warn'` level and continue checking remaining dependencies
+- Issue body with a mix of OPEN and CLOSED dependencies — should log each state and report correct open count
+
+## Acceptance Criteria
+- `findOpenDependencies()` logs the number of parsed dependencies on entry
+- `findOpenDependencies()` logs each dependency's resolved state (OPEN/CLOSED)
+- `findOpenDependencies()` logs errors from `getIssueState()` at `'warn'` level instead of silently catching
+- `findOpenDependencies()` logs the final count of open dependencies on exit
+- `checkIssueEligibility()` logs the issue number being checked on entry
+- All logging uses the existing `log()` function from `adws/core`
+- No changes to function signatures or return values
+- TypeScript compiles without errors
+- Linter passes without errors
+
+## Validation Commands
+Execute every command to validate the feature works correctly with zero regressions.
+
+- `bun run lint` — Run linter to check for code quality issues
+- `bunx tsc --noEmit` — Type check the project
+- `bunx tsc --noEmit -p adws/tsconfig.json` — Type check ADW-specific code
+
+## Notes
+- The `guidelines/coding_guidelines.md` says to "isolate side effects at the boundaries." Logging in `findOpenDependencies()` is appropriate because this function is already at a side-effect boundary (it calls `getIssueState()` which executes shell commands via `execSync`).
+- No new libraries are needed.
+- The existing silent `catch {}` block in `findOpenDependencies()` is an anti-pattern per the coding guidelines ("Provide meaningful error messages"). This feature improves it by logging the error at `'warn'` level while still continuing to check remaining dependencies.


### PR DESCRIPTION
## Summary

Adds logging to the issue dependency check process to improve observability when the system determines whether an issue has dependencies that block it from being eligible for processing.

Closes #175

**ADW Tracking ID:** 74itmf-add-logging-when-det

## Changes

- [x] Added detailed logging to `issueDependencies.ts` to log each dependency check step
- [x] Updated `issueEligibility.ts` to surface dependency logging output
- [x] Added implementation spec: `specs/issue-175-adw-74itmf-add-logging-when-det-sdlc_planner-add-dependency-logging.md`

## Key Changes

- **`adws/triggers/issueDependencies.ts`**: Enhanced with structured logging that records when dependencies are found, when issues are blocked, and when issues are clear to proceed
- **`adws/triggers/issueEligibility.ts`**: Integrated dependency logging into the eligibility check flow for end-to-end visibility