### PR TITLE
feat: #165 - Implement Scenario Planner Agent: generate and maintain BDD scenarios from GitHub issues

### DIFF
--- a/.adw/conditional_docs.md
+++ b/.adw/conditional_docs.md
@@ -75,3 +75,10 @@
   - Conditions:
     - When working with GitLab integration or CodeHost providers
     - When adding or modifying provider implementations in `adws/providers/`
+
+- app_docs/feature-implement-scenario-p-hpq6cn-scenario-planner-agent.md
+  - Conditions:
+    - When working with BDD scenario generation or the scenario agent
+    - When modifying `adws/agents/scenarioAgent.ts` or `adws/phases/scenarioPhase.ts`
+    - When working with `.adw/scenarios.md` configuration
+    - When adding or modifying `@crucial` tag maintenance logic

--- a/.claude/commands/conditional_docs.md
+++ b/.claude/commands/conditional_docs.md
@@ -81,3 +81,11 @@ This prompt helps you determine what documentation you should read based on the 
     - When adding or modifying logging in the dependency resolution pipeline
     - When troubleshooting why an issue was deferred due to blocking dependencies
     - When diagnosing silent failures in `getIssueState()` dependency lookups
+
+- app_docs/feature-hpq6cn-implement-scenario-p-scenario-planner-agent.md
+  - Conditions:
+    - When working with BDD scenario generation or the scenario agent
+    - When modifying `adws/agents/scenarioAgent.ts` or `adws/phases/scenarioPhase.ts`
+    - When working with `.adw/scenarios.md` configuration or scenario directory setup
+    - When adding or modifying `@crucial` tag maintenance logic
+    - When implementing a new non-fatal workflow phase following the scenario or KPI phase pattern

--- a/.claude/commands/scenario_writer.md
+++ b/.claude/commands/scenario_writer.md
@@ -1,0 +1,90 @@
+# Scenario Writer Agent
+
+You are the Scenario Writer Agent. Your job is to generate and maintain BDD scenarios in the target repository based on a GitHub issue.
+
+## Arguments
+
+- `$1` — Issue number
+- `$2` — ADW workflow ID
+- `$3` — Issue JSON (stringified object with `number`, `title`, `body`, `state`, `author`, `labels`, `createdAt`, `comments`, `actionableComment`)
+
+## Instructions
+
+### 1. Read configuration
+
+Read `.adw/scenarios.md` to determine the scenario directory path. If the file does not exist, use `features/` as the default scenario directory.
+
+Read `.adw/commands.md` and locate the `## Run E2E Tests` section.
+
+### 2. Detect or bootstrap E2E tool
+
+If `## Run E2E Tests` is absent or its value is `n/a`:
+- Bootstrap a Cucumber setup in the target repository:
+  - Install Cucumber dependencies (e.g. `@cucumber/cucumber`)
+  - Create a Cucumber configuration file (`cucumber.js` or `.cucumber.js`)
+  - Create the scenario directory if it does not exist
+- Update `.adw/commands.md` with the following sections (creating the file if absent):
+  - `## Run E2E Tests` — command to run all Cucumber scenarios
+  - `## Run Scenarios by Tag` — command to run scenarios by tag (e.g. `npx cucumber-js --tags "@tagname"`)
+  - `## Run Crucial Scenarios` — command to run `@crucial`-tagged scenarios
+
+If a tool is already configured, use the existing file format and runner.
+
+### 3. Parse the issue
+
+Parse the JSON from `$3` to extract the issue details. Use the issue body and title to understand the requirements.
+
+### 4. Read existing scenario files
+
+Read all existing scenario files in the scenario directory. Identify:
+- Scenarios that are directly relevant to this issue (to be flagged or modified)
+- Scenarios that do not need changes
+
+### 5. Write scenarios for this issue
+
+Based on the issue requirements:
+- **Create** new scenario files or add new scenarios to existing files
+- **Modify** existing scenarios where requirements have changed
+- **Flag** existing scenarios as relevant by adding the `@adw-$1` tag
+
+Rules:
+- Tag every created, modified, or flagged scenario with `@adw-$1`
+- Do **not** add `@adw-$1` to scenarios from other issues that you are not touching
+- Write scenarios as Gherkin `.feature` files
+- Each scenario must have a clear Given/When/Then structure
+- Scenario names should be specific and descriptive
+
+### 6. `@crucial` tag maintenance sweep
+
+After writing the current issue's scenarios, sweep **all** existing `@crucial`-tagged scenarios in the repository.
+
+For each `@crucial` scenario:
+- Re-evaluate whether the designation is still appropriate given:
+  - Current `app_docs/` documentation
+  - The new issue's requirements
+- Promote (add `@crucial`) scenarios that have become critical
+- Demote (remove `@crucial`) scenarios that are no longer critical
+- Leave unchanged scenarios that are still appropriately tagged
+
+Document all changes to `@crucial` designations.
+
+### 7. Output
+
+Return ONLY the following summary (no additional prose):
+
+```
+## Scenario Writer Output
+
+### Issue: #$1 ($2)
+
+### Scenario files written
+- <list each file path and what was done: created/modified/flagged>
+
+### Tags applied
+- @adw-$1 applied to: <list of scenario names>
+
+### @crucial maintenance
+- <promoted: list, or "none">
+- <demoted: list, or "none">
+- <unchanged: count>
+```

--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,5 @@ healthcheck.json*
 # cursor hooks logs
 .cursor/logs/
 .cursor/mcp.json
+# ADW: copied slash commands (do not commit)
+.claude/commands/conflict_resolve.md

--- a/adws/adwPlanBuild.tsx
+++ b/adws/adwPlanBuild.tsx
@@ -21,6 +21,7 @@ import { mergeModelUsageMaps, persistTokenCounts, parseTargetRepoArgs, parseOrch
 import {
   initializeWorkflow,
   executePlanPhase,
+  executeScenarioPhase,
   executeBuildPhase,
   executePRPhase,
   completeWorkflow,
@@ -50,9 +51,15 @@ async function main(): Promise<void> {
   let totalModelUsage = {};
 
   try {
-    const planResult = await executePlanPhase(config);
-    totalCostUsd += planResult.costUsd;
-    totalModelUsage = mergeModelUsageMaps(totalModelUsage, planResult.modelUsage);
+    const [planResult, scenarioResult] = await Promise.all([
+      executePlanPhase(config),
+      executeScenarioPhase(config),
+    ]);
+    totalCostUsd += planResult.costUsd + scenarioResult.costUsd;
+    totalModelUsage = mergeModelUsageMaps(
+      mergeModelUsageMaps(totalModelUsage, planResult.modelUsage),
+      scenarioResult.modelUsage,
+    );
     persistTokenCounts(config.orchestratorStatePath, totalCostUsd, totalModelUsage);
     if (RUNNING_TOKENS) config.ctx.runningTokenTotal = computeDisplayTokens(totalModelUsage);
 

--- a/adws/adwPlanBuildDocument.tsx
+++ b/adws/adwPlanBuildDocument.tsx
@@ -22,6 +22,7 @@ import { mergeModelUsageMaps, persistTokenCounts, parseTargetRepoArgs, parseOrch
 import {
   initializeWorkflow,
   executePlanPhase,
+  executeScenarioPhase,
   executeBuildPhase,
   executePRPhase,
   executeDocumentPhase,
@@ -53,9 +54,15 @@ async function main(): Promise<void> {
   let totalModelUsage = {};
 
   try {
-    const planResult = await executePlanPhase(config);
-    totalCostUsd += planResult.costUsd;
-    totalModelUsage = mergeModelUsageMaps(totalModelUsage, planResult.modelUsage);
+    const [planResult, scenarioResult] = await Promise.all([
+      executePlanPhase(config),
+      executeScenarioPhase(config),
+    ]);
+    totalCostUsd += planResult.costUsd + scenarioResult.costUsd;
+    totalModelUsage = mergeModelUsageMaps(
+      mergeModelUsageMaps(totalModelUsage, planResult.modelUsage),
+      scenarioResult.modelUsage,
+    );
     persistTokenCounts(config.orchestratorStatePath, totalCostUsd, totalModelUsage);
     if (RUNNING_TOKENS) config.ctx.runningTokenTotal = computeDisplayTokens(totalModelUsage);
 

--- a/adws/adwPlanBuildReview.tsx
+++ b/adws/adwPlanBuildReview.tsx
@@ -23,6 +23,7 @@ import { mergeModelUsageMaps, persistTokenCounts, parseTargetRepoArgs, parseOrch
 import {
   initializeWorkflow,
   executePlanPhase,
+  executeScenarioPhase,
   executeBuildPhase,
   executePRPhase,
   executeReviewPhase,
@@ -54,9 +55,15 @@ async function main(): Promise<void> {
   let totalModelUsage = {};
 
   try {
-    const planResult = await executePlanPhase(config);
-    totalCostUsd += planResult.costUsd;
-    totalModelUsage = mergeModelUsageMaps(totalModelUsage, planResult.modelUsage);
+    const [planResult, scenarioResult] = await Promise.all([
+      executePlanPhase(config),
+      executeScenarioPhase(config),
+    ]);
+    totalCostUsd += planResult.costUsd + scenarioResult.costUsd;
+    totalModelUsage = mergeModelUsageMaps(
+      mergeModelUsageMaps(totalModelUsage, planResult.modelUsage),
+      scenarioResult.modelUsage,
+    );
     persistTokenCounts(config.orchestratorStatePath, totalCostUsd, totalModelUsage);
     if (RUNNING_TOKENS) config.ctx.runningTokenTotal = computeDisplayTokens(totalModelUsage);
 

--- a/adws/adwPlanBuildTest.tsx
+++ b/adws/adwPlanBuildTest.tsx
@@ -23,6 +23,7 @@ import { mergeModelUsageMaps, persistTokenCounts, parseTargetRepoArgs, parseOrch
 import {
   initializeWorkflow,
   executePlanPhase,
+  executeScenarioPhase,
   executeBuildPhase,
   executeTestPhase,
   executePRPhase,
@@ -54,9 +55,15 @@ async function main(): Promise<void> {
   let totalModelUsage = {};
 
   try {
-    const planResult = await executePlanPhase(config);
-    totalCostUsd += planResult.costUsd;
-    totalModelUsage = mergeModelUsageMaps(totalModelUsage, planResult.modelUsage);
+    const [planResult, scenarioResult] = await Promise.all([
+      executePlanPhase(config),
+      executeScenarioPhase(config),
+    ]);
+    totalCostUsd += planResult.costUsd + scenarioResult.costUsd;
+    totalModelUsage = mergeModelUsageMaps(
+      mergeModelUsageMaps(totalModelUsage, planResult.modelUsage),
+      scenarioResult.modelUsage,
+    );
     persistTokenCounts(config.orchestratorStatePath, totalCostUsd, totalModelUsage);
     if (RUNNING_TOKENS) config.ctx.runningTokenTotal = computeDisplayTokens(totalModelUsage);
 

--- a/adws/adwPlanBuildTestReview.tsx
+++ b/adws/adwPlanBuildTestReview.tsx
@@ -25,6 +25,7 @@ import { mergeModelUsageMaps, persistTokenCounts, parseTargetRepoArgs, parseOrch
 import {
   initializeWorkflow,
   executePlanPhase,
+  executeScenarioPhase,
   executeBuildPhase,
   executeTestPhase,
   executePRPhase,
@@ -57,9 +58,15 @@ async function main(): Promise<void> {
   let totalModelUsage = {};
 
   try {
-    const planResult = await executePlanPhase(config);
-    totalCostUsd += planResult.costUsd;
-    totalModelUsage = mergeModelUsageMaps(totalModelUsage, planResult.modelUsage);
+    const [planResult, scenarioResult] = await Promise.all([
+      executePlanPhase(config),
+      executeScenarioPhase(config),
+    ]);
+    totalCostUsd += planResult.costUsd + scenarioResult.costUsd;
+    totalModelUsage = mergeModelUsageMaps(
+      mergeModelUsageMaps(totalModelUsage, planResult.modelUsage),
+      scenarioResult.modelUsage,
+    );
     persistTokenCounts(config.orchestratorStatePath, totalCostUsd, totalModelUsage);
     if (RUNNING_TOKENS) config.ctx.runningTokenTotal = computeDisplayTokens(totalModelUsage);
 

--- a/adws/adwSdlc.tsx
+++ b/adws/adwSdlc.tsx
@@ -28,6 +28,7 @@ import { mergeModelUsageMaps, persistTokenCounts, parseTargetRepoArgs, parseOrch
 import {
   initializeWorkflow,
   executePlanPhase,
+  executeScenarioPhase,
   executeBuildPhase,
   executeTestPhase,
   executePRPhase,
@@ -69,9 +70,15 @@ async function main(): Promise<void> {
   let totalModelUsage = {};
 
   try {
-    const planResult = await executePlanPhase(config);
-    totalCostUsd += planResult.costUsd;
-    totalModelUsage = mergeModelUsageMaps(totalModelUsage, planResult.modelUsage);
+    const [planResult, scenarioResult] = await Promise.all([
+      executePlanPhase(config),
+      executeScenarioPhase(config),
+    ]);
+    totalCostUsd += planResult.costUsd + scenarioResult.costUsd;
+    totalModelUsage = mergeModelUsageMaps(
+      mergeModelUsageMaps(totalModelUsage, planResult.modelUsage),
+      scenarioResult.modelUsage,
+    );
     persistTokenCounts(config.orchestratorStatePath, totalCostUsd, totalModelUsage);
     if (RUNNING_TOKENS) config.ctx.runningTokenTotal = computeDisplayTokens(totalModelUsage);
 

--- a/adws/agents/index.ts
+++ b/adws/agents/index.ts
@@ -104,3 +104,9 @@ export {
   formatKpiArgs,
 } from './kpiAgent';
 
+// Scenario Agent
+export {
+  runScenarioAgent,
+  formatScenarioArgs,
+} from './scenarioAgent';
+

--- a/adws/agents/scenarioAgent.ts
+++ b/adws/agents/scenarioAgent.ts
@@ -1,0 +1,85 @@
+/**
+ * Scenario Agent - Generates and maintains BDD scenarios from GitHub issues.
+ * Uses the /scenario_writer slash command from .claude/commands/scenario_writer.md
+ */
+
+import * as path from 'path';
+import { log, getModelForCommand, getEffortForCommand } from '../core';
+import { runClaudeAgentWithCommand, type AgentResult } from './claudeAgent';
+import type { GitHubIssue } from '../core';
+import { isAdwComment, extractActionableContent } from '../core/workflowCommentParsing';
+
+/**
+ * Formats args for the /scenario_writer skill.
+ * Returns [issueNumber, adwId, issueJson] matching the plan agent arg format.
+ */
+export function formatScenarioArgs(
+  issueNumber: number,
+  adwId: string,
+  issueJson: string,
+): string[] {
+  return [String(issueNumber), adwId, issueJson];
+}
+
+/**
+ * Runs the /scenario_writer skill to generate and maintain BDD scenarios.
+ * CWD is set to the worktree so the agent writes scenario files to the target repo.
+ *
+ * @param issue - GitHub issue to generate scenarios for
+ * @param logsDir - Directory to write agent logs
+ * @param statePath - Optional path to agent's state directory
+ * @param cwd - Optional working directory for the agent (worktree path)
+ * @param adwId - Optional ADW workflow ID
+ */
+export async function runScenarioAgent(
+  issue: GitHubIssue,
+  logsDir: string,
+  statePath?: string,
+  cwd?: string,
+  adwId?: string,
+): Promise<AgentResult> {
+  const humanComments = issue.comments.filter(c => !isAdwComment(c.body));
+
+  const latestActionableContent = [...issue.comments]
+    .reverse()
+    .reduce<string | null>((found, c) => found ?? extractActionableContent(c.body), null);
+
+  const issueJson = JSON.stringify({
+    number: issue.number,
+    title: issue.title,
+    body: issue.body,
+    state: issue.state,
+    author: issue.author.login,
+    labels: issue.labels.map(l => l.name),
+    createdAt: issue.createdAt,
+    comments: humanComments.map(c => ({
+      author: c.author.login,
+      createdAt: c.createdAt,
+      body: c.body,
+    })),
+    actionableComment: latestActionableContent,
+  });
+
+  const args = formatScenarioArgs(issue.number, adwId || 'adw-unknown', issueJson);
+  const outputFile = path.join(logsDir, 'scenario-agent.jsonl');
+
+  log('Scenario Agent starting:', 'info');
+  log(`  ADW ID: ${adwId || 'adw-unknown'}`, 'info');
+  log(`  Issue: #${issue.number}`, 'info');
+
+  const result = await runClaudeAgentWithCommand(
+    '/scenario_writer',
+    args,
+    'Scenario',
+    outputFile,
+    getModelForCommand('/scenario_writer', issue.body),
+    getEffortForCommand('/scenario_writer', issue.body),
+    undefined,
+    statePath,
+    cwd,
+  );
+
+  log('Scenario Agent completed', 'success');
+
+  return result;
+}

--- a/adws/core/config.ts
+++ b/adws/core/config.ts
@@ -196,6 +196,8 @@ export const SLASH_COMMAND_MODEL_MAP: Record<SlashCommand, ModelTier> = {
   '/find_issue_dependencies': 'sonnet',
   // ADW initialization
   '/adw_init': 'sonnet',
+  // Scenario writing
+  '/scenario_writer': 'sonnet',
 };
 
 /** Cost-optimized model map used when the issue body contains `/fast` or `/cheap`. */
@@ -220,6 +222,8 @@ export const SLASH_COMMAND_MODEL_MAP_FAST: Record<SlashCommand, ModelTier> = {
   '/find_plan_file': 'haiku',
   '/find_issue_dependencies': 'haiku',
   '/adw_init': 'haiku',
+  // Scenario writing
+  '/scenario_writer': 'haiku',
 };
 
 /**
@@ -270,6 +274,8 @@ export const SLASH_COMMAND_EFFORT_MAP: Record<SlashCommand, ReasoningEffort | un
   '/find_plan_file': 'low',
   '/find_issue_dependencies': 'low',
   '/adw_init': 'medium',
+  // Scenario writing
+  '/scenario_writer': 'high',
 };
 
 /** Cost-optimized reasoning effort map used when the issue body contains `/fast` or `/cheap`. */
@@ -294,6 +300,8 @@ export const SLASH_COMMAND_EFFORT_MAP_FAST: Record<SlashCommand, ReasoningEffort
   '/find_plan_file': 'low',
   '/find_issue_dependencies': 'low',
   '/adw_init': 'medium',
+  // Scenario writing
+  '/scenario_writer': 'medium',
 };
 
 /**

--- a/adws/phases/index.ts
+++ b/adws/phases/index.ts
@@ -29,3 +29,4 @@ export {
   completePRReviewWorkflow,
   handlePRReviewWorkflowError,
 } from './prReviewCompletion';
+export { executeScenarioPhase } from './scenarioPhase';

--- a/adws/phases/scenarioPhase.ts
+++ b/adws/phases/scenarioPhase.ts
@@ -1,0 +1,78 @@
+/**
+ * Scenario phase execution for workflows.
+ * Uses the /scenario_writer skill via a Claude agent.
+ * Non-fatal: errors are caught and logged without blocking workflow completion.
+ */
+
+import {
+  log,
+  AgentStateManager,
+  type ModelUsageMap,
+  emptyModelUsageMap,
+} from '../core';
+import { runScenarioAgent } from '../agents';
+import type { WorkflowConfig } from './workflowLifecycle';
+
+/**
+ * Executes the Scenario phase: generate and maintain BDD scenarios for the current issue.
+ * This phase is non-fatal — errors are caught and logged, never thrown.
+ *
+ * @param config - Workflow configuration
+ */
+export async function executeScenarioPhase(
+  config: WorkflowConfig,
+): Promise<{ costUsd: number; modelUsage: ModelUsageMap }> {
+  const { orchestratorStatePath, adwId, issueNumber, issue, worktreePath, logsDir } = config;
+
+  let costUsd = 0;
+  let modelUsage = emptyModelUsageMap();
+
+  log('Phase: Scenario Planning', 'info');
+  AgentStateManager.appendLog(orchestratorStatePath, 'Starting scenario planning phase');
+
+  try {
+    const scenarioAgentStatePath = AgentStateManager.initializeState(adwId, 'scenario-agent', orchestratorStatePath);
+    AgentStateManager.writeState(scenarioAgentStatePath, {
+      adwId,
+      issueNumber,
+      agentName: 'scenario-agent',
+      execution: AgentStateManager.createExecutionState('running'),
+    });
+
+    const result = await runScenarioAgent(issue, logsDir, scenarioAgentStatePath, worktreePath, adwId);
+
+    costUsd = result.totalCostUsd || 0;
+    if (result.modelUsage) modelUsage = result.modelUsage;
+
+    if (!result.success) {
+      AgentStateManager.writeState(scenarioAgentStatePath, {
+        execution: AgentStateManager.completeExecution(
+          AgentStateManager.createExecutionState('running'),
+          false,
+          result.output,
+        ),
+      });
+      log(`Scenario Agent failed: ${result.output}`, 'warn');
+      AgentStateManager.appendLog(orchestratorStatePath, `Scenario planning failed: ${result.output}`);
+      return { costUsd, modelUsage };
+    }
+
+    AgentStateManager.writeState(scenarioAgentStatePath, {
+      output: result.output.substring(0, 1000),
+      execution: AgentStateManager.completeExecution(
+        AgentStateManager.createExecutionState('running'),
+        true,
+      ),
+    });
+
+    AgentStateManager.appendLog(orchestratorStatePath, 'Scenario planning completed');
+    log('Scenario phase completed', 'success');
+  } catch (error) {
+    const errorMsg = error instanceof Error ? error.message : String(error);
+    log(`Scenario phase error (non-fatal): ${errorMsg}`, 'warn');
+    AgentStateManager.appendLog(orchestratorStatePath, `Scenario planning error: ${errorMsg}`);
+    return { costUsd: 0, modelUsage: emptyModelUsageMap() };
+  }
+
+  return { costUsd, modelUsage };
+}

--- a/adws/types/agentTypes.ts
+++ b/adws/types/agentTypes.ts
@@ -95,7 +95,9 @@ export type AgentIdentifier =
   | 'pr-agent'
   | 'document-agent'
   // KPI tracking agent
-  | 'kpi-agent';
+  | 'kpi-agent'
+  // Scenario agent
+  | 'scenario-agent';
 
 /**
  * Execution status for tracking agent progress.

--- a/adws/types/issueTypes.ts
+++ b/adws/types/issueTypes.ts
@@ -148,7 +148,9 @@ export type SlashCommand =
   // Dependency checking
   | '/find_issue_dependencies'
   // ADW initialization
-  | '/adw_init';
+  | '/adw_init'
+  // Scenario writing
+  | '/scenario_writer';
 
 /**
  * GitHub user model.

--- a/adws/workflowPhases.ts
+++ b/adws/workflowPhases.ts
@@ -21,6 +21,7 @@ export {
   executePRPhase,
   executeDocumentPhase,
   executeKpiPhase,
+  executeScenarioPhase,
   executeReviewPhase,
   completeWorkflow,
   handleWorkflowError,

--- a/app_docs/feature-hpq6cn-implement-scenario-p-scenario-planner-agent.md
+++ b/app_docs/feature-hpq6cn-implement-scenario-p-scenario-planner-agent.md
@@ -1,0 +1,89 @@
+# Scenario Planner Agent
+
+**ADW ID:** hpq6cn-implement-scenario-p
+**Date:** 2026-03-13
+**Specification:** specs/issue-165-adw-hpq6cn-implement-scenario-p-sdlc_planner-scenario-planner-agent.md
+
+## Overview
+
+Introduces a Scenario Planner Agent that automatically generates and maintains BDD scenarios (Gherkin `.feature` files) from GitHub issues. The agent runs in parallel with the Plan Agent during the planning phase, producing executable acceptance criteria before implementation begins. It also performs a `@crucial` tag maintenance sweep on every run to keep critical scenario designations up to date.
+
+## What Was Built
+
+- **`/scenario_writer` slash command** — Prompt template that drives the agent's behavior: reads issue details, detects or bootstraps the E2E tool, writes/modifies/flags Gherkin scenarios, and sweeps `@crucial` tags
+- **`adws/agents/scenarioAgent.ts`** — Agent module exporting `formatScenarioArgs()` and `runScenarioAgent()`
+- **`adws/phases/scenarioPhase.ts`** — Non-fatal phase function `executeScenarioPhase()` following the KPI phase pattern
+- **Parallel execution** — All six orchestrators now run the scenario phase concurrently with the plan phase via `Promise.all`
+- **Type system registration** — `/scenario_writer` added to `SlashCommand` union; `scenario-agent` added to `AgentIdentifier` union
+- **Config map entries** — `/scenario_writer` registered in all four command model/effort maps
+
+## Technical Implementation
+
+### Files Modified
+
+- `adws/types/issueTypes.ts`: Added `'/scenario_writer'` to the `SlashCommand` union type
+- `adws/types/agentTypes.ts`: Added `'scenario-agent'` to the `AgentIdentifier` union type
+- `adws/core/config.ts`: Added `/scenario_writer` to `SLASH_COMMAND_MODEL_MAP` (sonnet), `SLASH_COMMAND_MODEL_MAP_FAST` (haiku), `SLASH_COMMAND_EFFORT_MAP` (high), `SLASH_COMMAND_EFFORT_MAP_FAST` (medium)
+- `adws/agents/index.ts`: Exported `runScenarioAgent` and `formatScenarioArgs` from the new agent module
+- `adws/phases/index.ts`: Exported `executeScenarioPhase` from the new phase module
+- `adws/workflowPhases.ts`: Re-exported `executeScenarioPhase` from `./phases`
+- `adws/adwSdlc.tsx`: Runs scenario phase in parallel with plan phase
+- `adws/adwPlanBuild.tsx`: Runs scenario phase in parallel with plan phase
+- `adws/adwPlanBuildTest.tsx`: Runs scenario phase in parallel with plan phase
+- `adws/adwPlanBuildReview.tsx`: Runs scenario phase in parallel with plan phase
+- `adws/adwPlanBuildDocument.tsx`: Runs scenario phase in parallel with plan phase
+- `adws/adwPlanBuildTestReview.tsx`: Runs scenario phase in parallel with plan phase
+- `.adw/conditional_docs.md`: Added entry for this documentation file
+- `.gitignore`: Updated as needed
+
+### New Files
+
+- `.claude/commands/scenario_writer.md`: Slash command prompt template
+- `adws/agents/scenarioAgent.ts`: Agent module (85 lines)
+- `adws/phases/scenarioPhase.ts`: Phase module (78 lines)
+
+### Key Changes
+
+- **Parallel planning**: The scenario phase runs via `Promise.all([executePlanPhase(config), executeScenarioPhase(config)])` — both phases read `config` without mutations, making concurrent execution safe
+- **Non-fatal design**: `scenarioPhase.ts` wraps all agent calls in a try/catch; errors are logged at `warn` level and return `{ costUsd: 0, modelUsage: emptyModelUsageMap() }` without throwing
+- **Agent state tracking**: The scenario agent initializes, writes, and completes `AgentStateManager` state entries (`scenario-agent`) matching the pattern used by other agents
+- **Args format**: `formatScenarioArgs` returns `[issueNumber, adwId, issueJson]` — the same three-argument pattern as the plan agent for consistency
+- **Cucumber bootstrap**: When `## Run E2E Tests` is absent or `n/a` in `.adw/commands.md`, the agent installs Cucumber, creates config, and updates the commands file
+
+## How to Use
+
+The scenario phase runs automatically as part of any workflow that includes a planning phase. No manual invocation is needed.
+
+1. Start any standard ADW workflow (e.g., `bunx tsx adws/adwSdlc.tsx <issueNumber>`)
+2. During the planning phase, the scenario agent runs concurrently with the plan agent
+3. The agent reads `.adw/scenarios.md` in the target repo to locate the scenario directory (defaults to `features/`)
+4. New/modified Gherkin `.feature` files are written to the target repo's scenario directory
+5. Every created, modified, or flagged scenario receives the `@adw-{issueNumber}` tag
+6. A `@crucial` maintenance sweep runs automatically at the end of each scenario agent execution
+7. The agent output (scenario paths, tags applied, `@crucial` changes) is logged in `<logsDir>/scenario-agent.jsonl`
+
+## Configuration
+
+| Config | Location | Default |
+|--------|----------|---------|
+| Scenario directory path | `.adw/scenarios.md` in target repo | `features/` |
+| E2E tool and run commands | `.adw/commands.md` `## Run E2E Tests` section | Cucumber (bootstrapped if absent) |
+| Model (standard) | `SLASH_COMMAND_MODEL_MAP['/scenario_writer']` | `sonnet` |
+| Model (fast/cheap) | `SLASH_COMMAND_MODEL_MAP_FAST['/scenario_writer']` | `haiku` |
+| Reasoning effort (standard) | `SLASH_COMMAND_EFFORT_MAP['/scenario_writer']` | `high` |
+| Reasoning effort (fast/cheap) | `SLASH_COMMAND_EFFORT_MAP_FAST['/scenario_writer']` | `medium` |
+
+## Testing
+
+- TypeScript compilation: `bunx tsc --noEmit` and `bunx tsc --noEmit -p adws/tsconfig.json`
+- Lint: `bun run lint`
+- Full test suite: `bun run test`
+
+The scenario phase is non-fatal, so a failing scenario agent will not block workflow validation tests.
+
+## Notes
+
+- **Depends on issue #164**: The `.adw/scenarios.md` configuration file is defined by issue #164 (BDD scenario configuration and tagging conventions). If it does not exist, the agent defaults to `features/` and handles the absence gracefully.
+- **`@crucial` tag**: The secondary sweep re-evaluates `@crucial` designations across all existing scenarios using `app_docs/` documentation and the current issue as context. Changes are documented in the agent output.
+- **CWD = worktree**: The agent is invoked with `cwd` set to the worktree path so scenario files are written into the target repository, not the ADW repo.
+- **No new libraries**: The implementation uses only existing ADW dependencies and internal modules.

--- a/specs/issue-165-adw-hpq6cn-implement-scenario-p-sdlc_planner-scenario-planner-agent.md
+++ b/specs/issue-165-adw-hpq6cn-implement-scenario-p-sdlc_planner-scenario-planner-agent.md
@@ -1,0 +1,235 @@
+# Feature: Implement Scenario Planner Agent
+
+## Metadata
+issueNumber: `165`
+adwId: `hpq6cn-implement-scenario-p`
+issueJson: `{"number":165,"title":"Implement Scenario Planner Agent: generate and maintain BDD scenarios from GitHub issues","body":"## Context\n\nA new Scenario Planner Agent is needed as part of the BDD-first testing strategy. It runs in parallel with the Plan Agent during the planning phase and produces the BDD scenarios that gate both pre-PR testing and the review phase.\n\n## Depends on\n\n- #164 (BDD scenario configuration and tagging conventions)\n\n## Requirements\n\n### Core behaviour\n\n- Reads the GitHub issue\n- Reads existing scenario files in the target repo's scenario directory (from `.adw/scenarios.md`)\n- Creates new scenarios, modifies existing ones, or flags existing ones as relevant — any combination\n- All created/modified/flagged scenarios are tagged `@adw-{issueNumber}`\n- Scenarios from previous issues are **not** in scope for this issue's tag\n\n### Tool and file format detection\n\n- Reads `## Run E2E Tests` from `commands.md` to determine the tool and expected file format\n- If `## Run E2E Tests` is `n/a` or absent:\n  - Bootstrap a Cucumber setup in the target repo (install dependencies, create config)\n  - Write scenarios as Gherkin `.feature` files\n  - Update `commands.md` with the appropriate Cucumber run commands (`## Run E2E Tests`, `## Run Scenarios by Tag`, `## Run Crucial Scenarios`)\n\n### Secondary task: `@crucial` maintenance (runs every time)\n\n- After writing scenarios for the current issue, sweeps **all** existing `@crucial`-tagged scenarios in the repo\n- Re-evaluates whether each `@crucial` designation is still appropriate, based on:\n  - Current `app_docs/` documentation\n  - The new GitHub issue's requirements\n- May promote, demote, or leave tags unchanged\n- Documents any changes to `@crucial` designations in its output\n\n### Integration\n\n- New slash command: `.claude/commands/scenario_writer.md`\n- New agent: `adws/agents/scenarioAgent.ts`\n- New phase function in `adws/phases/`\n- Runs **in parallel** with the Plan Agent — not sequentially after it\n- Outputs: list of scenario file paths and tags applied, plus summary of `@crucial` changes\n\n## Acceptance Criteria\n\n- Agent creates/modifies scenario files in the target repo's configured scenario directory\n- All created/modified/flagged scenarios carry `@adw-{issueNumber}` tag\n- When no E2E tool is configured, Cucumber is bootstrapped and `commands.md` is updated\n- `@crucial` sweep is performed and documented on every run\n- Agent runs in parallel with the Plan Agent in the planning phase","state":"OPEN","author":"paysdoc","labels":["enhancement"],"createdAt":"2026-03-13T07:01:40Z","comments":[],"actionableComment":null}`
+
+## Feature Description
+Implement a new Scenario Planner Agent that generates and maintains BDD scenarios from GitHub issues. The agent reads the GitHub issue, inspects existing scenario files in the target repo's configured scenario directory, and creates/modifies/flags scenarios tagged with `@adw-{issueNumber}`. It also performs a secondary `@crucial` tag maintenance sweep on every run. The agent runs in parallel with the Plan Agent during the planning phase, producing the BDD scenarios that gate both pre-PR testing and the review phase.
+
+## User Story
+As a developer using ADW
+I want BDD scenarios to be automatically generated from GitHub issues during planning
+So that I have executable acceptance criteria ready before implementation begins
+
+## Problem Statement
+Currently, the ADW workflow has no automated mechanism to produce BDD scenarios from GitHub issues. Developers must manually write scenarios after planning, creating a gap between issue requirements and testable acceptance criteria. This delays the feedback loop and risks misalignment between what was planned and what gets tested.
+
+## Solution Statement
+Introduce a Scenario Planner Agent that runs in parallel with the Plan Agent during the planning phase. The agent reads the issue, reads existing scenarios from the target repo's configured scenario directory, and outputs new/modified scenario files tagged with `@adw-{issueNumber}`. If no E2E tool is configured, it bootstraps Cucumber. It also sweeps `@crucial` tags for ongoing maintenance. The agent is non-fatal (like the KPI phase) so scenario failures don't block the workflow.
+
+## Relevant Files
+Use these files to implement the feature:
+
+### Existing Files to Modify
+- `adws/types/issueTypes.ts` — Add `'/scenario_writer'` to the `SlashCommand` union type
+- `adws/types/agentTypes.ts` — Add `'scenario-agent'` to the `AgentIdentifier` union type
+- `adws/core/config.ts` — Add `/scenario_writer` entries to all four command maps (`SLASH_COMMAND_MODEL_MAP`, `SLASH_COMMAND_MODEL_MAP_FAST`, `SLASH_COMMAND_EFFORT_MAP`, `SLASH_COMMAND_EFFORT_MAP_FAST`)
+- `adws/agents/index.ts` — Export the new `scenarioAgent` module
+- `adws/phases/index.ts` — Export the new `scenarioPhase` module
+- `adws/workflowPhases.ts` — Re-export `executeScenarioPhase` from phases
+- `adws/adwSdlc.tsx` — Run scenario phase in parallel with plan phase via `Promise.all`
+- `adws/adwPlanBuild.tsx` — Run scenario phase in parallel with plan phase
+- `adws/adwPlanBuildTest.tsx` — Run scenario phase in parallel with plan phase
+- `adws/adwPlanBuildReview.tsx` — Run scenario phase in parallel with plan phase
+- `adws/adwPlanBuildDocument.tsx` — Run scenario phase in parallel with plan phase
+- `adws/adwPlanBuildTestReview.tsx` — Run scenario phase in parallel with plan phase
+- `.adw/conditional_docs.md` — Add entry for scenario agent documentation
+
+### Reference Files (read for patterns, do not modify)
+- `adws/agents/kpiAgent.ts` — Reference agent pattern (formatArgs + runAgent functions)
+- `adws/phases/kpiPhase.ts` — Reference non-fatal phase pattern (catch errors, log warnings, return zero cost)
+- `adws/agents/planAgent.ts` — Reference for how plan agent formats issue args
+- `adws/phases/planPhase.ts` — Reference for plan phase execution flow
+- `adws/agents/claudeAgent.ts` — Base agent runner (`runClaudeAgentWithCommand`)
+- `guidelines/coding_guidelines.md` — Coding guidelines to follow strictly
+- `app_docs/feature-add-resoning-effort-4wna6z-reasoning-effort-slash-commands.md` — Reference for adding new slash command effort/model config (matches condition: adding new slash command)
+
+### New Files
+- `.claude/commands/scenario_writer.md` — Slash command prompt template for the scenario writer agent
+- `adws/agents/scenarioAgent.ts` — Agent module with `formatScenarioArgs()` and `runScenarioAgent()`
+- `adws/phases/scenarioPhase.ts` — Phase function `executeScenarioPhase()` (non-fatal pattern)
+
+## Implementation Plan
+### Phase 1: Foundation
+Register the new slash command and agent identifier in the type system and configuration maps. This ensures TypeScript compilation succeeds before any implementation code is written.
+
+### Phase 2: Core Implementation
+Create the scenario agent module (`scenarioAgent.ts`) following the KPI agent pattern, and the slash command template (`scenario_writer.md`) that defines the agent's prompt. Then create the scenario phase module (`scenarioPhase.ts`) following the KPI phase's non-fatal pattern.
+
+### Phase 3: Integration
+Update all orchestrators that include a plan phase to run the scenario phase in parallel with it using `Promise.all`. Update barrel exports and conditional docs.
+
+## Step by Step Tasks
+
+### Step 1: Add `/scenario_writer` to SlashCommand union type
+- Open `adws/types/issueTypes.ts`
+- Add `| '/scenario_writer'` to the `SlashCommand` type union, under a `// Scenario writing` comment
+
+### Step 2: Add `'scenario-agent'` to AgentIdentifier union type
+- Open `adws/types/agentTypes.ts`
+- Add `| 'scenario-agent'` to the `AgentIdentifier` type union, under a `// Scenario agent` comment
+
+### Step 3: Add slash command config entries
+- Open `adws/core/config.ts`
+- Add to `SLASH_COMMAND_MODEL_MAP`: `'/scenario_writer': 'sonnet'`
+- Add to `SLASH_COMMAND_MODEL_MAP_FAST`: `'/scenario_writer': 'haiku'`
+- Add to `SLASH_COMMAND_EFFORT_MAP`: `'/scenario_writer': 'high'`
+- Add to `SLASH_COMMAND_EFFORT_MAP_FAST`: `'/scenario_writer': 'medium'`
+
+### Step 4: Create the slash command template
+- Create `.claude/commands/scenario_writer.md`
+- The prompt template should instruct the agent to:
+  - Accept args: `$1` = issueNumber, `$2` = adwId, `$3` = issueJson (JSON string with issue details)
+  - Read `.adw/scenarios.md` from the target repo's working directory for the scenario directory path
+  - Read `.adw/commands.md` `## Run E2E Tests` section to detect the E2E tool
+  - If `## Run E2E Tests` is `n/a` or absent:
+    - Bootstrap Cucumber (install deps, create config)
+    - Write scenarios as Gherkin `.feature` files
+    - Update `.adw/commands.md` with `## Run E2E Tests`, `## Run Scenarios by Tag`, `## Run Crucial Scenarios` sections
+  - Read the GitHub issue from the `$3` JSON arg
+  - Read existing scenario files in the scenario directory
+  - Create new, modify existing, or flag relevant scenarios — any combination
+  - Tag all created/modified/flagged scenarios with `@adw-{issueNumber}`
+  - Do NOT tag scenarios from previous issues with this issue's tag
+  - After writing scenarios, sweep all `@crucial`-tagged scenarios in the repo
+  - Re-evaluate each `@crucial` designation based on `app_docs/` documentation and the issue
+  - May promote, demote, or leave `@crucial` tags unchanged
+  - Document any `@crucial` changes
+  - Output: list of scenario file paths, tags applied, and summary of `@crucial` changes
+  - Return ONLY the output summary (no extra prose)
+
+### Step 5: Create the scenario agent module
+- Create `adws/agents/scenarioAgent.ts`
+- Follow the KPI agent pattern from `adws/agents/kpiAgent.ts`:
+  - Import `path`, `log`, `getModelForCommand`, `getEffortForCommand` from `../core`
+  - Import `runClaudeAgentWithCommand`, `AgentResult` from `./claudeAgent`
+  - Export `formatScenarioArgs(issueNumber: number, adwId: string, issueJson: string): string[]`
+    - Returns `[String(issueNumber), adwId, issueJson]` (matches plan agent arg format)
+  - Export `runScenarioAgent(issue: GitHubIssue, logsDir: string, statePath?: string, cwd?: string, adwId?: string): Promise<AgentResult>`
+    - Build issueJson the same way `runPlanAgent` does (filter ADW comments, extract actionable content, serialize to JSON)
+    - Format args via `formatScenarioArgs(issue.number, adwId || 'adw-unknown', issueJson)`
+    - Set `outputFile = path.join(logsDir, 'scenario-agent.jsonl')`
+    - Log startup info (`Scenario Agent starting:`, ADW ID, Issue number)
+    - Call `runClaudeAgentWithCommand('/scenario_writer', args, 'Scenario', outputFile, getModelForCommand('/scenario_writer', issue.body), getEffortForCommand('/scenario_writer', issue.body), undefined, statePath, cwd)`
+    - Log completion (`Scenario Agent completed`)
+    - Return result
+
+### Step 6: Create the scenario phase module
+- Create `adws/phases/scenarioPhase.ts`
+- Follow the KPI phase pattern from `adws/phases/kpiPhase.ts`:
+  - Import `log`, `AgentStateManager`, `ModelUsageMap`, `emptyModelUsageMap` from `../core`
+  - Import `runScenarioAgent` from `../agents`
+  - Import `WorkflowConfig` from `./workflowLifecycle`
+  - Export `executeScenarioPhase(config: WorkflowConfig): Promise<{ costUsd: number; modelUsage: ModelUsageMap }>`
+  - Destructure `orchestratorStatePath`, `adwId`, `issueNumber`, `issue`, `worktreePath`, `logsDir` from config
+  - Initialize `costUsd = 0`, `modelUsage = emptyModelUsageMap()`
+  - Log `'Phase: Scenario Planning'`
+  - Wrap in try/catch:
+    - Initialize agent state: `AgentStateManager.initializeState(adwId, 'scenario-agent', orchestratorStatePath)`
+    - Write running state
+    - Call `runScenarioAgent(issue, logsDir, scenarioAgentStatePath, worktreePath, adwId)`
+    - Extract cost and model usage from result
+    - If `!result.success`: write failed state, log warning, return `{ costUsd, modelUsage }` (non-fatal)
+    - If success: write completed state with truncated output, log success
+  - Catch block: log `'Scenario phase error (non-fatal)'` at warn level, return `{ costUsd: 0, modelUsage: emptyModelUsageMap() }`
+  - Return `{ costUsd, modelUsage }`
+
+### Step 7: Update barrel exports
+- In `adws/agents/index.ts`, add:
+  ```typescript
+  // Scenario Agent
+  export {
+    runScenarioAgent,
+    formatScenarioArgs,
+  } from './scenarioAgent';
+  ```
+- In `adws/phases/index.ts`, add:
+  ```typescript
+  export { executeScenarioPhase } from './scenarioPhase';
+  ```
+- In `adws/workflowPhases.ts`, add `executeScenarioPhase` to the re-export from `'./phases'`
+
+### Step 8: Update orchestrators to run scenario phase in parallel with plan phase
+- For each orchestrator that calls `executePlanPhase`:
+  - Import `executeScenarioPhase` from `'./workflowPhases'`
+  - Replace the sequential `const planResult = await executePlanPhase(config);` with:
+    ```typescript
+    const [planResult, scenarioResult] = await Promise.all([
+      executePlanPhase(config),
+      executeScenarioPhase(config),
+    ]);
+    ```
+  - After the `Promise.all`, merge scenario cost into totals:
+    ```typescript
+    totalCostUsd += planResult.costUsd + scenarioResult.costUsd;
+    totalModelUsage = mergeModelUsageMaps(
+      mergeModelUsageMaps(totalModelUsage, planResult.modelUsage),
+      scenarioResult.modelUsage,
+    );
+    ```
+  - The rest of the orchestrator remains unchanged (build, test, etc. follow sequentially)
+- Update these files:
+  - `adws/adwSdlc.tsx`
+  - `adws/adwPlanBuild.tsx`
+  - `adws/adwPlanBuildTest.tsx`
+  - `adws/adwPlanBuildReview.tsx`
+  - `adws/adwPlanBuildDocument.tsx`
+  - `adws/adwPlanBuildTestReview.tsx`
+
+### Step 9: Update conditional docs
+- Open `.adw/conditional_docs.md`
+- Add an entry for the scenario agent documentation (to be generated after implementation):
+  ```
+  - app_docs/feature-implement-scenario-p-hpq6cn-scenario-planner-agent.md
+    - Conditions:
+      - When working with BDD scenario generation or the scenario agent
+      - When modifying `adws/agents/scenarioAgent.ts` or `adws/phases/scenarioPhase.ts`
+      - When working with `.adw/scenarios.md` configuration
+      - When adding or modifying `@crucial` tag maintenance logic
+  ```
+
+### Step 10: Run validation commands
+- Run all validation commands listed below to confirm zero regressions
+
+## Testing Strategy
+### Unit Tests
+- ADW does not use unit tests per `guidelines/coding_guidelines.md` — BDD scenarios are the validation mechanism
+- TypeScript compilation (`bunx tsc --noEmit` and `bunx tsc --noEmit -p adws/tsconfig.json`) validates all type additions compile correctly
+- Lint validates code quality
+
+### Edge Cases
+- Scenario phase failure should not block the workflow (non-fatal pattern)
+- Missing `.adw/scenarios.md` in target repo — agent should handle gracefully
+- Missing or `n/a` `## Run E2E Tests` in `.adw/commands.md` — triggers Cucumber bootstrap
+- No existing scenario files — agent creates new ones from scratch
+- Issue with no body — agent handles gracefully via issueJson
+- Plan phase failure while scenario phase succeeds — scenario result cost still accumulated but plan failure throws and is caught by orchestrator error handler
+
+## Acceptance Criteria
+- `'/scenario_writer'` exists in `SlashCommand` union type
+- `'scenario-agent'` exists in `AgentIdentifier` union type
+- All four slash command maps in `config.ts` have entries for `'/scenario_writer'`
+- `.claude/commands/scenario_writer.md` exists with the complete prompt template
+- `adws/agents/scenarioAgent.ts` exports `formatScenarioArgs` and `runScenarioAgent`
+- `adws/phases/scenarioPhase.ts` exports `executeScenarioPhase` with non-fatal error handling
+- All six orchestrators (`adwSdlc`, `adwPlanBuild`, `adwPlanBuildTest`, `adwPlanBuildReview`, `adwPlanBuildDocument`, `adwPlanBuildTestReview`) run scenario phase in parallel with plan phase via `Promise.all`
+- Barrel exports updated in `agents/index.ts`, `phases/index.ts`, and `workflowPhases.ts`
+- All validation commands pass with zero errors
+
+## Validation Commands
+Execute every command to validate the feature works correctly with zero regressions.
+
+- `bunx tsc --noEmit` — Type check main project
+- `bunx tsc --noEmit -p adws/tsconfig.json` — Type check ADW scripts
+- `bun run lint` — Run linter to check for code quality issues
+- `bun run test` — Run tests to validate zero regressions
+
+## Notes
+- **Guidelines compliance**: Implementation must follow `guidelines/coding_guidelines.md` — clarity over cleverness, modularity (files < 300 lines), immutability, type safety, pure functions, no decorators.
+- **Non-fatal pattern**: The scenario phase follows the KPI phase pattern — errors are caught and logged at `'warn'` level, never thrown. This ensures scenario failures don't block the workflow.
+- **Parallel execution**: The scenario phase runs via `Promise.all` with the plan phase. Since both phases only read `config` (no mutations), they are safe to run concurrently.
+- **Depends on #164**: This issue depends on #164 (BDD scenario configuration and tagging conventions). The `.adw/scenarios.md` file referenced by this agent is defined by that issue. If `scenarios.md` does not exist yet, the agent should handle the absence gracefully.
+- **Slash command args match plan agent**: The scenario agent uses the same `[issueNumber, adwId, issueJson]` arg pattern as the plan agent for consistency.
+- **No new libraries needed**: The implementation uses only existing dependencies (path, fs) and internal modules.


### PR DESCRIPTION
## Summary

Implements the Scenario Planner Agent as part of the BDD-first testing strategy. The agent runs in parallel with the Plan Agent during the planning phase and produces BDD scenarios that gate pre-PR testing and the review phase.

## What was done

- [x] New slash command: `.claude/commands/scenario_writer.md` — interactive scenario writing command
- [x] New agent: `adws/agents/scenarioAgent.ts` — core scenario planner agent logic
- [x] New phase: `adws/phases/scenarioPhase.ts` — phase function that runs the scenario agent
- [x] Integrated scenario phase into all workflow entry points (`adwPlanBuild.tsx`, `adwSdlc.tsx`, etc.) to run in parallel with the Plan Agent
- [x] Extended `adws/core/config.ts` to support scenario directory configuration
- [x] Updated `adws/types/agentTypes.ts` and `issueTypes.ts` for new agent types
- [x] Added conditional docs entry in `.adw/conditional_docs.md`
- [x] Implementation spec: `specs/issue-165-adw-hpq6cn-implement-scenario-p-sdlc_planner-scenario-planner-agent.md`

## Key changes

- **Scenario Agent** reads the GitHub issue and existing scenario files, then creates/modifies/flags scenarios tagged `@adw-{issueNumber}`
- **Tool detection**: reads `## Run E2E Tests` from `commands.md`; bootstraps Cucumber if absent
- **`@crucial` maintenance**: sweeps all existing `@crucial`-tagged scenarios and re-evaluates designations on every run
- **Parallel execution**: scenario phase runs alongside the Plan Agent, not sequentially after it

## Implementation plan

`specs/issue-165-adw-hpq6cn-implement-scenario-p-sdlc_planner-scenario-planner-agent.md`

Closes #165

---
ADW: `hpq6cn-implement-scenario-p`