### PR TITLE
feat: #168 - Refactor review phase: replace code-diff proof with @crucial BDD scenario execution

### DIFF
--- a/.adw/review_proof.md
+++ b/.adw/review_proof.md
@@ -3,32 +3,40 @@
 This file defines the proof requirements for the ADW (AI Dev Workflow) project.
 The `/review` command reads this file to determine what evidence to produce and how to attach it to a pull request.
 
+> **Note:** When a `scenarioProofPath` argument is passed to `/review`, the scenario execution results take precedence over this file. This file applies when no scenario proof path is provided.
+
 ## Proof Type
 
-ADW is a CLI/automation tool with no UI. Proof consists of:
+ADW is a CLI/automation tool with no UI. Primary proof is `@crucial` BDD scenario execution results. Supplementary proof consists of:
 
-1. **Code-diff verification** - Confirm the git diff matches the spec requirements. Summarize which spec items are addressed and which files were changed.
-2. **Test output summaries** - Run the project's test suite (`bun run test`) and summarize pass/fail results. Include the number of test suites and individual tests that passed.
-3. **Type check verification** - Run `bunx tsc --noEmit` and `bunx tsc --noEmit -p adws/tsconfig.json`. Report whether type checking passed cleanly.
-4. **Lint verification** - Run `bun run lint` and report whether linting passed cleanly.
-5. **Spec compliance checklist** - For each acceptance criterion in the spec, state whether it is met or not with a brief justification.
+1. **@crucial scenario execution** - The primary proof. Results are provided via a scenario proof file (path passed as the `scenarioProofPath` argument to `/review`). Read and classify results: `@crucial` failures = `blocker`, `@adw-{issueNumber}` non-crucial failures = `tech-debt`.
+2. **Type check verification** - Run `bunx tsc --noEmit` and `bunx tsc --noEmit -p adws/tsconfig.json`. Report whether type checking passed cleanly.
+3. **Lint verification** - Run `bun run lint` and report whether linting passed cleanly.
+4. **Spec compliance checklist** - For each acceptance criterion in the spec, state whether it is met or not with a brief justification.
 
 ## Proof Format
 
 Structure proof as text summaries within the review JSON output:
-- Use the `reviewSummary` field for a concise 2-4 sentence overview
-- Use the `reviewIssues` array to document any discrepancies between spec and implementation
-- Use the `screenshots` array for paths to any generated proof artifacts (e.g., test output logs saved to the reviewImage_dir)
+- Use the `reviewSummary` field for a concise 2-4 sentence overview describing scenario pass/fail results
+- Use the `reviewIssues` array to document any discrepancies (classified per the rules above)
+- Use the `screenshots` array for paths to proof artifacts (scenario proof file path, test output logs, etc.)
 
 ## Proof Attachment
 
 Proof is attached to the PR via the review JSON output fields:
 - `reviewSummary` - Human-readable summary for the PR comment
-- `screenshots` - Array of absolute paths to proof artifacts in the `reviewImage_dir`
+- `screenshots` - Array of absolute paths to proof artifacts (scenario proof file, logs, etc.)
 - `reviewIssues` - Structured list of any issues found during review
+
+## Classification Rules
+
+- `@crucial` scenario failures → `issueSeverity: 'blocker'`
+- `@adw-{issueNumber}` non-crucial failures → `issueSeverity: 'tech-debt'`
+- Type-check or lint failures → `issueSeverity: 'blocker'` (prevents release)
 
 ## What NOT to Do
 
 - Do NOT take browser screenshots (there is no UI to screenshot)
 - Do NOT attempt to start a dev server or navigate to a URL
-- Do NOT skip the spec compliance checklist
+- Do NOT use code-diff as primary proof — scenario execution results are authoritative
+- Do NOT run `bun run test` (unit tests are disabled for this project per `.adw/project.md`)

--- a/.claude/commands/conditional_docs.md
+++ b/.claude/commands/conditional_docs.md
@@ -113,3 +113,11 @@ This prompt helps you determine what documentation you should read based on the 
     - When working with `.adw/scenarios.md` configuration or scenario directory setup
     - When adding or modifying `@crucial` tag maintenance logic
     - When implementing a new non-fatal workflow phase following the scenario or KPI phase pattern
+
+- app_docs/feature-9emriw-bdd-scenario-review-proof.md
+  - Conditions:
+    - When working with the review proof mechanism or `crucialScenarioProof.ts`
+    - When modifying `reviewRetry.ts` or `ReviewRetryOptions` scenario-related fields
+    - When adding or changing `@crucial` / `@adw-{issueNumber}` scenario classification in review
+    - When configuring `runCrucialScenarios` or `runScenariosByTag` commands in `.adw/commands.md`
+    - When troubleshooting review proof fallback behaviour for repos without `.adw/scenarios.md`

--- a/.claude/commands/review.md
+++ b/.claude/commands/review.md
@@ -8,11 +8,14 @@ adwId: $1
 specFile: $2
 agentName: $3 if provided, otherwise use 'reviewAgent'
 applicationUrl: $4 if provided, otherwise use http://localhost:3000
+scenarioProofPath: $5 if provided, otherwise empty
 reviewImage_dir: `<absolute path to codebase>/agents/<adwId>/<agentName>/reviewImg/`
 
 ## Proof Requirements
 
-Read the file `.adw/review_proof.md` from the current working directory.
+**If `scenarioProofPath` is provided and the file exists**: Read the scenario proof file at `scenarioProofPath`. Use the BDD scenario execution results as the **primary proof** for this review. Classify `@crucial` failures as `blocker` issues. Classify non-crucial `@adw-{issueNumber}` failures as `tech-debt` issues. The `reviewSummary` should describe scenario pass/fail results. Still run type-check and lint as supplementary checks.
+
+**If `scenarioProofPath` is NOT provided**: Read the file `.adw/review_proof.md` from the current working directory.
 
 - **If the file exists and is non-empty**: Follow its instructions for what proof to produce and how to attach it. The file specifies the proof type (screenshots, test output, code-diff verification, etc.), the format, and how it gets attached to the PR. Override the default screenshot-based proof instructions below with whatever `.adw/review_proof.md` specifies.
 - **If the file does not exist or is empty**: Fall back to the default proof behavior described in the Instructions section below (screenshot-based UI validation).
@@ -24,7 +27,19 @@ Read the file `.adw/review_proof.md` from the current working directory.
 - Run `git diff origin/<default>` to see all changes made in current branch. Continue even if there are no changes related to the spec file.
 - Find the spec file by looking for spec/*.md files in the diff that match the current branch name
 - Read the identified spec file to understand requirements
-- IMPORTANT: Produce proof according to the `Proof Requirements` section above. If `.adw/review_proof.md` was loaded, follow its instructions. Otherwise, use the default UI validation approach below:
+- IMPORTANT: Produce proof according to the `Proof Requirements` section above:
+  - **If `scenarioProofPath` is provided**:
+    - Read the scenario proof markdown file at `scenarioProofPath`
+    - Check the `## @crucial Scenarios` section status:
+      - If **FAILED**: create a `reviewIssue` with `issueSeverity: 'blocker'`, `issueDescription` summarising the @crucial failures, `issueResolution` advising investigation of the scenario proof file, and `screenshotPath` set to `scenarioProofPath`
+    - Check the `## @adw-{issueNumber} Scenarios` section status (where `{issueNumber}` is derived from the spec file name or branch name):
+      - If **FAILED**: create a `reviewIssue` with `issueSeverity: 'tech-debt'` describing the non-crucial failures
+    - Run type-check and lint as supplementary checks:
+      - Run `bunx tsc --noEmit` and report any type errors as additional `reviewIssues`
+      - Run `bun run lint` and report any lint errors as additional `reviewIssues`
+    - Set `screenshots` to include `scenarioProofPath` as a proof artifact (plus any supplementary artifacts)
+    - `reviewSummary` should describe: how many @crucial scenarios passed/failed and how many @adw-{issueNumber} scenarios passed/failed
+  - **If `scenarioProofPath` is NOT provided**: follow `.adw/review_proof.md` instructions (if present) or use the default UI validation approach below:
   - If the work can be validated by UI validation then (if not skip the section):
     - Look for corresponding e2e test files in ./claude/commands/e2e-examples/test*.md that mirror the feature name
     - Use e2e test files only as navigation guides for screenshot locations, not for other purposes
@@ -67,7 +82,7 @@ Use the `applicationUrl` when navigating to the application for screenshots.
 - `success` should be `true` if there are NO BLOCKING issues (implementation matches spec for critical functionality)
 - `success` should be `false` ONLY if there are BLOCKING issues that prevent the work from being released
 - `reviewIssues` can contain issues of any severity (skippable, tech-debt, or blocker)
-- `screenshots` should ALWAYS contain paths to proof artifacts showcasing the review evidence, regardless of success status. Use full absolute paths. These can be screenshots, test output logs, or any other proof artifacts as specified by `.adw/review_proof.md`.
+- `screenshots` should ALWAYS contain paths to proof artifacts showcasing the review evidence, regardless of success status. Use full absolute paths. These can be screenshots, test output logs, scenario proof files, or any other proof artifacts as specified by `.adw/review_proof.md` or the scenario proof path.
 - This allows subsequent agents to quickly identify and resolve blocking errors while documenting all issues
 
 ### Output Structure

--- a/adws/agents/bddScenarioRunner.ts
+++ b/adws/agents/bddScenarioRunner.ts
@@ -1,8 +1,8 @@
 /**
  * BDD scenario subprocess executor.
  *
- * Runs the tag-filtered scenario command (e.g. `@adw-{issueNumber}`) as a
- * subprocess, captures output, and returns a structured result.
+ * Runs tag-filtered scenario commands as a subprocess, captures output,
+ * and returns a structured result.
  * Analogous to testDiscovery.ts for Playwright.
  */
 
@@ -44,6 +44,60 @@ export function runBddScenarios(
   }
 
   const resolvedCommand = command.replace(/\{issueNumber\}/g, String(issueNumber));
+  const workDir = cwd ?? process.cwd();
+
+  return new Promise((resolve) => {
+    const proc = spawn(resolvedCommand, [], {
+      cwd: workDir,
+      stdio: ['ignore', 'pipe', 'pipe'],
+      shell: true,
+    });
+
+    let stdout = '';
+    let stderr = '';
+
+    proc.stdout.on('data', (data: Buffer) => {
+      stdout += data.toString();
+    });
+
+    proc.stderr.on('data', (data: Buffer) => {
+      stderr += data.toString();
+    });
+
+    proc.on('close', (exitCode) => {
+      resolve({
+        allPassed: exitCode === 0,
+        stdout,
+        stderr,
+        exitCode,
+      });
+    });
+  });
+}
+
+/**
+ * Runs BDD scenarios filtered by an arbitrary tag as a subprocess.
+ *
+ * - If `tagCommand` is `'N/A'` or empty, returns a passing result immediately
+ *   (no scenarios configured — skip gracefully).
+ * - Replaces `{tag}` in the command template with the actual tag value.
+ * - Returns `allPassed: true` when the process exits with code 0.
+ *
+ * @param tagCommand - The run-by-tag command template (e.g. `cucumber-js --tags "@{tag}"`),
+ *   or a full command without `{tag}` placeholder (e.g. `cucumber-js --tags "@crucial"`).
+ * @param tag - The tag value to substitute for `{tag}` (e.g. `crucial`, `adw-168`).
+ * @param cwd - Optional working directory (defaults to `process.cwd()`).
+ */
+export function runScenariosByTag(
+  tagCommand: string,
+  tag: string,
+  cwd?: string,
+): Promise<BddScenarioResult> {
+  if (!tagCommand || tagCommand.trim() === 'N/A') {
+    return Promise.resolve({ allPassed: true, stdout: '', stderr: '', exitCode: 0 });
+  }
+
+  const resolvedCommand = tagCommand.replace(/\{tag\}/g, tag);
   const workDir = cwd ?? process.cwd();
 
   return new Promise((resolve) => {

--- a/adws/agents/crucialScenarioProof.ts
+++ b/adws/agents/crucialScenarioProof.ts
@@ -1,0 +1,143 @@
+/**
+ * Crucial scenario proof orchestrator.
+ *
+ * Runs @crucial and @adw-{issueNumber} BDD scenarios, writes combined results
+ * to a proof markdown file, and returns a structured outcome for the review retry loop.
+ */
+
+import * as fs from 'fs';
+import * as path from 'path';
+import { runScenariosByTag } from './bddScenarioRunner';
+
+/** Maximum characters of scenario output retained in the proof file. */
+const MAX_OUTPUT_LENGTH = 10_000;
+
+/**
+ * Structured result from running crucial and issue-specific scenario proofs.
+ */
+export interface ScenarioProofResult {
+  /** Whether all @crucial scenarios passed (exit code 0). */
+  crucialPassed: boolean;
+  /** Stdout from the @crucial run (truncated if over 10,000 chars). */
+  crucialOutput: string;
+  /** Exit code from the @crucial run. */
+  crucialExitCode: number | null;
+  /** Whether the @adw-{issueNumber} scenarios passed (exit code 0). */
+  issueScenariosPassed: boolean;
+  /** Stdout from the issue-specific run (truncated if over 10,000 chars). */
+  issueScenarioOutput: string;
+  /** Exit code from the issue-specific run. */
+  issueScenarioExitCode: number | null;
+  /** Absolute path to the written scenario proof markdown file. */
+  resultsFilePath: string;
+}
+
+/**
+ * Returns true when scenario proof should be run.
+ * Returns false when .adw/scenarios.md content is absent or empty — callers
+ * should fall back to code-diff proof behaviour in that case.
+ */
+export function shouldRunScenarioProof(scenariosMd: string): boolean {
+  return scenariosMd.trim().length > 0;
+}
+
+function truncate(output: string): string {
+  if (output.length <= MAX_OUTPUT_LENGTH) return output;
+  return `${output.slice(0, MAX_OUTPUT_LENGTH)}\n\n[...output truncated at ${MAX_OUTPUT_LENGTH} characters...]`;
+}
+
+function buildProofMarkdown(
+  issueNumber: number,
+  crucialOutput: string,
+  crucialExitCode: number | null,
+  crucialPassed: boolean,
+  issueOutput: string,
+  issueExitCode: number | null,
+  issueScenariosPassed: boolean,
+): string {
+  const crucialStatus = crucialPassed ? '✅ PASSED' : '❌ FAILED';
+  const issueStatus = issueScenariosPassed ? '✅ PASSED' : '❌ FAILED';
+
+  return [
+    '# Scenario Proof',
+    '',
+    `Generated at: ${new Date().toISOString()}`,
+    '',
+    '## @crucial Scenarios',
+    '',
+    `**Status:** ${crucialStatus}`,
+    `**Exit Code:** ${crucialExitCode ?? 'null'}`,
+    '',
+    '### Output',
+    '',
+    '```',
+    crucialOutput || '(no output)',
+    '```',
+    '',
+    `## @adw-${issueNumber} Scenarios`,
+    '',
+    `**Status:** ${issueStatus}`,
+    `**Exit Code:** ${issueExitCode ?? 'null'}`,
+    '',
+    '### Output',
+    '',
+    '```',
+    issueOutput || '(no output)',
+    '```',
+  ].join('\n');
+}
+
+/**
+ * Runs @crucial and @adw-{issueNumber} BDD scenarios, writes combined results
+ * to a proof markdown file, and returns a structured ScenarioProofResult.
+ *
+ * @param options.scenariosMd - Raw content of .adw/scenarios.md (used for guard check only).
+ * @param options.runByTagCommand - Command template with `{tag}` placeholder for issue scenarios.
+ * @param options.runCrucialCommand - Command (or template) to run @crucial scenarios.
+ * @param options.issueNumber - Current issue number for @adw-{issueNumber} tag filtering.
+ * @param options.proofDir - Directory in which to write `scenario_proof.md`.
+ * @param options.cwd - Optional working directory for scenario subprocesses.
+ */
+export async function runCrucialScenarioProof(options: {
+  scenariosMd: string;
+  runByTagCommand: string;
+  runCrucialCommand: string;
+  issueNumber: number;
+  proofDir: string;
+  cwd?: string;
+}): Promise<ScenarioProofResult> {
+  const { runByTagCommand, runCrucialCommand, issueNumber, proofDir, cwd } = options;
+
+  // Run @crucial scenarios — use runCrucialCommand directly (may contain {tag} or full command)
+  const crucialResult = await runScenariosByTag(runCrucialCommand, 'crucial', cwd);
+  const crucialOutput = truncate(crucialResult.stdout);
+
+  // Run @adw-{issueNumber} scenarios via the tag-based command template
+  const issueTag = `adw-${issueNumber}`;
+  const issueResult = await runScenariosByTag(runByTagCommand, issueTag, cwd);
+  const issueOutput = truncate(issueResult.stdout);
+
+  // Write proof file — create directory if it doesn't exist
+  fs.mkdirSync(proofDir, { recursive: true });
+  const resultsFilePath = path.resolve(proofDir, 'scenario_proof.md');
+  const proofContent = buildProofMarkdown(
+    issueNumber,
+    crucialOutput,
+    crucialResult.exitCode,
+    crucialResult.allPassed,
+    issueOutput,
+    issueResult.exitCode,
+    issueResult.allPassed,
+  );
+  fs.writeFileSync(resultsFilePath, proofContent, 'utf-8');
+
+  return {
+    crucialPassed: crucialResult.allPassed,
+    crucialOutput,
+    crucialExitCode: crucialResult.exitCode,
+    issueScenariosPassed: issueResult.allPassed,
+    issueScenarioOutput: issueOutput,
+    issueScenarioExitCode: issueResult.exitCode,
+    resultsFilePath,
+  };
+}

--- a/adws/agents/index.ts
+++ b/adws/agents/index.ts
@@ -55,8 +55,16 @@ export {
 // BDD Scenario Runner
 export {
   runBddScenarios,
+  runScenariosByTag,
   type BddScenarioResult,
 } from './bddScenarioRunner';
+
+// Crucial Scenario Proof
+export {
+  runCrucialScenarioProof,
+  shouldRunScenarioProof,
+  type ScenarioProofResult,
+} from './crucialScenarioProof';
 
 // Test Retry (shared test retry logic)
 export {

--- a/adws/agents/reviewAgent.ts
+++ b/adws/agents/reviewAgent.ts
@@ -51,7 +51,12 @@ export function formatReviewArgs(
   specFile: string,
   agentName: string,
   applicationUrl?: string,
+  scenarioProofPath?: string,
 ): string[] {
+  if (scenarioProofPath) {
+    // $5 requires $4 to be present — use empty string for applicationUrl if absent
+    return [adwId, specFile, agentName, applicationUrl ?? '', scenarioProofPath];
+  }
   return applicationUrl
     ? [adwId, specFile, agentName, applicationUrl]
     : [adwId, specFile, agentName];
@@ -79,12 +84,13 @@ export async function runReviewAgent(
   applicationUrl?: string,
   issueBody?: string,
   agentIndex?: number,
+  scenarioProofPath?: string,
 ): Promise<ReviewAgentResult> {
   const agentName = agentIndex !== undefined ? `review_agent_${agentIndex}` : 'review_agent';
   const logFileName = agentIndex !== undefined ? `review-agent-${agentIndex}.jsonl` : 'review-agent.jsonl';
   const outputFile = path.join(logsDir, logFileName);
 
-  const args = formatReviewArgs(adwId, specFile, agentName, applicationUrl);
+  const args = formatReviewArgs(adwId, specFile, agentName, applicationUrl, scenarioProofPath);
 
   const result = await runClaudeAgentWithCommand(
     '/review',

--- a/adws/agents/reviewRetry.ts
+++ b/adws/agents/reviewRetry.ts
@@ -3,12 +3,14 @@
  * Iterates: 3 parallel review agents -> merge results -> patch blockers -> commit+push -> re-review.
  */
 
+import * as path from 'path';
 import { log, AgentStateManager, type IssueClassSlashCommand, type ModelUsageMap, emptyModelUsageMap, type AgentIdentifier } from '../core';
 import { initAgentState, trackCost, type AgentRunResult } from '../core/retryOrchestrator';
 import { runReviewAgent, type ReviewIssue, type ReviewAgentResult } from './reviewAgent';
 import { runPatchAgent } from './patchAgent';
 import { runCommitAgent } from './gitAgent';
 import { pushBranch } from '../vcs';
+import { shouldRunScenarioProof, runCrucialScenarioProof, type ScenarioProofResult } from './crucialScenarioProof';
 
 /** Number of parallel review agents per iteration. */
 export const REVIEW_AGENT_COUNT = 3;
@@ -29,6 +31,8 @@ export interface ReviewRetryResult {
   reviewSummary?: string;
   allScreenshots: string[];
   allSummaries: string[];
+  /** Scenario proof from the final iteration, if scenario proof was run. */
+  scenarioProof?: ScenarioProofResult;
 }
 
 export interface ReviewRetryOptions {
@@ -47,6 +51,14 @@ export interface ReviewRetryOptions {
   applicationUrl?: string;
   /** Optional issue body for fast/cheap model selection */
   issueBody?: string;
+  /** Issue number for @adw-{issueNumber} scenario tag filtering. */
+  issueNumber: number;
+  /** Raw content of .adw/scenarios.md — empty string when absent (disables scenario proof). */
+  scenariosMd: string;
+  /** Command to run @crucial scenarios (from .adw/commands.md). */
+  runCrucialCommand: string;
+  /** Command template with {tag} placeholder for tag-filtered scenarios. */
+  runByTagCommand: string;
 }
 
 /**
@@ -87,13 +99,15 @@ export function mergeReviewResults(results: readonly ReviewAgentResult[]): Merge
 
 /**
  * Runs multiple review agents in parallel with automatic retry logic on failure.
- * On each attempt: launches 3 review agents concurrently, merges results,
- * patches any blocker issues with a single patch agent, commits, pushes, and re-reviews.
+ * On each attempt: optionally runs @crucial BDD scenarios first, then launches
+ * 3 review agents concurrently, merges results, patches any blocker issues with
+ * a single patch agent, commits, pushes, and re-reviews.
  */
 export async function runReviewWithRetry(opts: ReviewRetryOptions): Promise<ReviewRetryResult> {
   const {
     adwId, specFile, logsDir, orchestratorStatePath: statePath,
-    maxRetries, branchName, issueType, issueContext, onReviewFailed, onPatchingIssue, cwd, applicationUrl, issueBody,
+    maxRetries, branchName, issueType, issueContext, onReviewFailed, onPatchingIssue, cwd,
+    applicationUrl, issueBody, issueNumber, scenariosMd, runCrucialCommand, runByTagCommand,
   } = opts;
 
   let retryCount = 0;
@@ -101,17 +115,68 @@ export async function runReviewWithRetry(opts: ReviewRetryOptions): Promise<Revi
   const costState = { costUsd: 0, modelUsage: emptyModelUsageMap() };
   const allScreenshots: string[] = [];
   const allSummaries: string[] = [];
+  let lastScenarioProof: ScenarioProofResult | undefined;
 
   while (retryCount < maxRetries) {
     log(`Running review (attempt ${retryCount + 1}/${maxRetries}) with ${REVIEW_AGENT_COUNT} parallel agents...`, 'info');
     AgentStateManager.appendLog(statePath, `Review attempt ${retryCount + 1}/${maxRetries} (${REVIEW_AGENT_COUNT} agents)`);
+
+    // Run scenario proof once per iteration before launching review agents
+    let scenarioProof: ScenarioProofResult | undefined;
+    if (shouldRunScenarioProof(scenariosMd)) {
+      log('Running @crucial and issue BDD scenarios for proof...', 'info');
+      AgentStateManager.appendLog(statePath, 'Running BDD scenario proof');
+
+      const proofDir = path.join(logsDir, 'scenario_proof');
+      scenarioProof = await runCrucialScenarioProof({
+        scenariosMd,
+        runByTagCommand,
+        runCrucialCommand,
+        issueNumber,
+        proofDir,
+        cwd,
+      });
+      lastScenarioProof = scenarioProof;
+
+      const crucialStatus = scenarioProof.crucialPassed ? 'passed' : 'FAILED';
+      log(`@crucial scenarios: ${crucialStatus}`, scenarioProof.crucialPassed ? 'success' : 'error');
+      AgentStateManager.appendLog(statePath, `@crucial scenarios: ${crucialStatus}`);
+      allScreenshots.push(scenarioProof.resultsFilePath);
+
+      // On the final attempt, if @crucial scenarios still fail — return immediately with blockers
+      const isLastAttempt = retryCount === maxRetries - 1;
+      if (!scenarioProof.crucialPassed && isLastAttempt) {
+        log('@crucial scenarios failed on final attempt — returning blocker immediately', 'error');
+        AgentStateManager.appendLog(statePath, '@crucial scenarios failed on final attempt');
+        const blockerIssue: ReviewIssue = {
+          reviewIssueNumber: 1,
+          screenshotPath: scenarioProof.resultsFilePath,
+          issueDescription: '@crucial BDD scenarios failed — see scenario proof file for details',
+          issueResolution: 'Fix the failing @crucial BDD scenarios before re-running the review',
+          issueSeverity: 'blocker',
+        };
+        const reviewSummary = allSummaries.find(s => s.length > 0);
+        return {
+          passed: false,
+          costUsd: costState.costUsd,
+          totalRetries: retryCount,
+          blockerIssues: [blockerIssue],
+          modelUsage: costState.modelUsage,
+          reviewSummary,
+          allScreenshots,
+          allSummaries,
+          scenarioProof,
+        };
+      }
+    }
 
     // Launch REVIEW_AGENT_COUNT review agents in parallel
     const agentIndices = Array.from({ length: REVIEW_AGENT_COUNT }, (_, i) => i + 1);
     const reviewResults: ReviewAgentResult[] = await Promise.all(
       agentIndices.map(index =>
         runReviewAgent(
-          adwId, specFile, logsDir, initAgentState(statePath, `review-agent-${index}` as AgentIdentifier), cwd, applicationUrl, issueBody, index,
+          adwId, specFile, logsDir, initAgentState(statePath, `review-agent-${index}` as AgentIdentifier),
+          cwd, applicationUrl, issueBody, index, scenarioProof?.resultsFilePath,
         )
       )
     );
@@ -135,7 +200,7 @@ export async function runReviewWithRetry(opts: ReviewRetryOptions): Promise<Revi
       return {
         passed: true, costUsd: costState.costUsd, totalRetries: retryCount,
         blockerIssues: [], modelUsage: costState.modelUsage,
-        reviewSummary, allScreenshots, allSummaries,
+        reviewSummary, allScreenshots, allSummaries, scenarioProof: lastScenarioProof,
       };
     }
 
@@ -175,6 +240,6 @@ export async function runReviewWithRetry(opts: ReviewRetryOptions): Promise<Revi
   return {
     passed: false, costUsd: costState.costUsd, totalRetries: retryCount,
     blockerIssues: lastBlockerIssues, modelUsage: costState.modelUsage,
-    reviewSummary, allScreenshots, allSummaries,
+    reviewSummary, allScreenshots, allSummaries, scenarioProof: lastScenarioProof,
   };
 }

--- a/adws/phases/workflowCompletion.ts
+++ b/adws/phases/workflowCompletion.ts
@@ -115,6 +115,10 @@ export async function executeReviewPhase(config: WorkflowConfig): Promise<{
     cwd: worktreePath,
     applicationUrl,
     issueBody: issue.body,
+    issueNumber,
+    scenariosMd: config.projectConfig.scenariosMd,
+    runCrucialCommand: config.projectConfig.commands.runCrucialScenarios,
+    runByTagCommand: config.projectConfig.commands.runScenariosByTag,
   });
 
   if (reviewResult.passed) {

--- a/app_docs/feature-9emriw-bdd-scenario-review-proof.md
+++ b/app_docs/feature-9emriw-bdd-scenario-review-proof.md
@@ -1,0 +1,75 @@
+# BDD Scenario Review Proof
+
+**ADW ID:** 9emriw-refactor-review-phas
+**Date:** 2026-03-13
+**Specification:** specs/issue-168-adw-9emriw-refactor-review-phas-sdlc_planner-bdd-scenario-review-proof.md
+
+## Overview
+
+Replaces the code-diff-based review proof with `@crucial` BDD scenario execution as the primary proof mechanism. Review agents now classify `@crucial` failures as blockers and current-issue (`@adw-{issueNumber}`) non-crucial failures as tech-debt. When `.adw/scenarios.md` is absent, the system falls back transparently to the existing code-diff proof behaviour.
+
+## What Was Built
+
+- `crucialScenarioProof.ts` — New orchestrator that runs `@crucial` and `@adw-{issueNumber}` scenarios, writes a structured `scenario_proof.md` file, and returns a typed `ScenarioProofResult`
+- `runScenariosByTag` — New generic tag-based scenario runner in `bddScenarioRunner.ts` (replaces issue-number-specific logic with a `{tag}` placeholder)
+- Review retry integration — `runReviewWithRetry` now runs scenario proof once per iteration before launching the 3 parallel review agents
+- Scenario proof path forwarded to each review agent via `reviewAgent.ts` so the `/review` command can read and classify results
+- `workflowCompletion.ts` updated to supply `issueNumber`, `scenariosMd`, `runCrucialCommand`, and `runByTagCommand` to the retry loop
+- `.claude/commands/review.md` updated with scenario-aware proof instructions and fallback logic
+- `.adw/review_proof.md` rewritten to describe the scenario-based proof format
+- `features/review_phase.feature` — New BDD feature file covering review phase scenarios
+
+## Technical Implementation
+
+### Files Modified
+
+- `adws/agents/crucialScenarioProof.ts`: New file — `ScenarioProofResult` interface, `shouldRunScenarioProof()`, `runCrucialScenarioProof()` orchestrator
+- `adws/agents/bddScenarioRunner.ts`: Added `runScenariosByTag(tagCommand, tag, cwd?)` — generic tag-based subprocess runner with graceful skip for `'N/A'` commands
+- `adws/agents/reviewAgent.ts`: Added optional `scenarioProofPath?` to `runReviewAgent` and `formatReviewArgs`; passes it as `$5` to the `/review` command
+- `adws/agents/reviewRetry.ts`: Added `issueNumber`, `scenariosMd`, `runCrucialCommand`, `runByTagCommand` to `ReviewRetryOptions`; integrated scenario proof loop before parallel agents; added `scenarioProof?` to `ReviewRetryResult`
+- `adws/agents/index.ts`: Exports `runScenariosByTag`, `runCrucialScenarioProof`, `shouldRunScenarioProof`, `ScenarioProofResult`
+- `adws/phases/workflowCompletion.ts`: Passes four new fields from `WorkflowConfig.projectConfig` to `runReviewWithRetry`
+- `.claude/commands/review.md`: Added `$5` variable (`scenarioProofPath`); scenario-aware proof section with fallback
+- `.adw/review_proof.md`: Rewritten — scenario execution is primary proof; code-diff is fallback only
+- `features/review_phase.feature`: BDD feature file for review phase acceptance scenarios
+
+### Key Changes
+
+- **Scenario proof runs once per iteration** before the 3 parallel review agents, writing results to `agents/{adwId}/scenario_proof/scenario_proof.md`
+- **Early-exit on final attempt**: if `@crucial` scenarios fail on the last retry, a `blocker` `ReviewIssue` is returned immediately without launching review agents
+- **Graceful fallback**: `shouldRunScenarioProof(scenariosMd)` returns `false` when `scenariosMd` is empty — review falls back to existing code-diff behaviour with no code changes required in target repos
+- **Output truncation**: scenario stdout is capped at 10,000 characters in the proof file to prevent memory issues
+- **Shared proof file**: all 3 review agents receive the same `resultsFilePath`, ensuring consistent classification without redundant scenario re-runs
+
+## How to Use
+
+1. Ensure `.adw/scenarios.md` exists in the target repo with non-empty content (presence enables scenario proof)
+2. Ensure `.adw/commands.md` defines `runCrucialScenarios` and `runScenariosByTag` commands
+3. Run the `/review` command as usual — the workflow automatically detects `scenarios.md` and runs `@crucial` scenarios first
+4. Review agents receive the scenario proof path as `$5` and classify results:
+   - `@crucial` failures → `blocker` issues
+   - `@adw-{issueNumber}` non-crucial failures → `tech-debt` issues
+5. The scenario proof file is written to `agents/{adwId}/scenario_proof/scenario_proof.md` and attached as a proof artifact in the PR review
+
+## Configuration
+
+| Setting | Location | Description |
+|---|---|---|
+| `runCrucialScenarios` | `.adw/commands.md` | Command to run `@crucial` scenarios (e.g. `cucumber-js --tags "@crucial"`) |
+| `runScenariosByTag` | `.adw/commands.md` | Command template with `{tag}` placeholder (e.g. `cucumber-js --tags "@{tag}"`) |
+| `scenariosMd` | `.adw/scenarios.md` | Non-empty content enables scenario proof; empty/absent triggers fallback |
+
+## Testing
+
+- Run `bun run lint` — linting must pass with no errors
+- Run `bunx tsc --noEmit` — root-level type checking must pass
+- Run `bunx tsc --noEmit -p adws/tsconfig.json` — adws type checking must pass
+- Run `bun run build` — build must succeed
+- BDD acceptance: `features/review_phase.feature` covers the review phase scenarios tagged `@adw-168`
+
+## Notes
+
+- The three parallel review agents all read the **same** scenario proof file — scenarios are not re-run per agent
+- The patch-and-retry mechanism continues to work: if `@crucial` fail, the patch agent fixes the code and scenarios re-run on the next iteration
+- Repos without `.adw/scenarios.md` continue to work unchanged — no migration required
+- Depends on issue #165 (Scenario Planner Agent with `@crucial` tag maintenance) and #167 (BDD test infrastructure)

--- a/features/review_phase.feature
+++ b/features/review_phase.feature
@@ -1,0 +1,73 @@
+@adw-168
+Feature: Review phase uses BDD scenario execution as proof
+
+  The review phase replaces code-diff analysis with @crucial BDD scenario execution.
+  Crucial scenario failures are blockers; non-crucial failures from the current issue
+  are reported as tech-debt. When .adw/scenarios.md is absent, the review falls back
+  to the original code-diff proof behaviour.
+
+  Background:
+    Given the ADW workflow is configured for a target repository
+    And the target repository has ".adw/scenarios.md" present
+    And the scenarios command is configured as "cucumber-js --tags \"@crucial\""
+
+  @adw-168 @crucial
+  Scenario: Review runs all @crucial scenarios when scenarios.md exists
+    Given the target repository has ".adw/scenarios.md" defining the scenarios directory
+    And there are scenarios tagged "@crucial" in the features directory
+    When the review phase executes
+    Then the review phase runs the crucial scenario command from ".adw/scenarios.md"
+    And the review proof contains the scenario execution output
+    And the review proof does not contain a code-diff analysis
+
+  @adw-168 @crucial
+  Scenario: @crucial scenario failures are reported as blocker issues
+    Given the target repository has "@crucial" tagged scenarios
+    And at least one "@crucial" scenario fails
+    When the review phase executes
+    Then the failed "@crucial" scenarios are reported as blocker issues
+    And the review is marked as not passed
+    And the patch agent is invoked to fix the blockers
+
+  @adw-168 @crucial
+  Scenario: All @crucial scenarios passing means the review passes
+    Given the target repository has "@crucial" tagged scenarios
+    And all "@crucial" scenarios pass
+    When the review phase executes
+    Then the review is marked as passed
+    And no blocker issues are reported for crucial scenarios
+
+  @adw-168
+  Scenario: Non-crucial failures from the current issue are reported as tech-debt
+    Given the target repository has scenarios tagged "@adw-168" that are not tagged "@crucial"
+    And at least one "@adw-168" non-crucial scenario fails
+    And all "@crucial" scenarios pass
+    When the review phase executes
+    Then the review is marked as passed
+    And the non-crucial "@adw-168" failures are reported as tech-debt
+    And no blocker issues are raised for the non-crucial failures
+
+  @adw-168
+  Scenario: Review summary describes scenario results not code diff
+    Given the target repository has ".adw/scenarios.md" present
+    When the review phase completes
+    Then the review summary contains scenario pass/fail counts
+    And the review summary does not describe git diff changes
+    And the proof attached to the PR reflects scenario execution output
+
+  @adw-168 @crucial
+  Scenario: Review falls back to code-diff proof when scenarios.md is absent
+    Given the target repository does NOT have ".adw/scenarios.md"
+    When the review phase executes
+    Then the review phase uses code-diff analysis as proof
+    And the review proof contains code-diff verification results
+    And the review proof contains test output summaries
+    And the review proof contains type-check and lint results
+
+  @adw-168
+  Scenario: review_proof.md specifies scenario-based proof for ADW project
+    Given the ADW project's ".adw/review_proof.md" is present
+    When the review_proof.md file is read
+    Then it specifies "@crucial scenario execution" as the proof type
+    And it does not reference "bun run test" output as primary proof
+    And it does not reference "code-diff verification" as primary proof

--- a/specs/issue-168-adw-9emriw-refactor-review-phas-sdlc_planner-bdd-scenario-review-proof.md
+++ b/specs/issue-168-adw-9emriw-refactor-review-phas-sdlc_planner-bdd-scenario-review-proof.md
@@ -1,0 +1,190 @@
+# Feature: Replace code-diff review proof with @crucial BDD scenario execution
+
+## Metadata
+issueNumber: `168`
+adwId: `9emriw-refactor-review-phas`
+issueJson: `{"number":168,"title":"Refactor review phase: replace code-diff proof with @crucial BDD scenario execution","body":"## Context\n\nThe review phase currently produces proof via code-diff analysis, lint/type checks, and screenshots. This is replaced by executing all \\`@crucial\\`-tagged BDD scenarios. Crucial scenario failures are blockers; the review passes if all crucial scenarios pass. Non-crucial failures from the current issue's scenarios are reported as tech-debt.\n\n## Depends on\n\n- #165 (Scenario Planner Agent — \\`@crucial\\` tags must exist and be maintained)\n- #167 (BDD test infrastructure and pipeline order in place)\n\n## Requirements\n\n### Review behaviour change\n\n- \\`/review\\` command executes all \\`@crucial\\` scenarios using the command from \\`.adw/scenarios.md\\`\n- Scenario execution results replace code-diff analysis as the primary proof\n- \\`@crucial\\` failures = blocker issues\n- Failures from \\`@adw-{issueNumber}\\` scenarios (current issue, non-crucial) = tech-debt\n- Review summary describes scenario results, not code diff\n\n### \\`review_proof.md\\` update (ADW project)\n\n- Updated to reflect scenario-based proof\n- Removes references to \\`bun run test\\` output and code-diff verification\n- Specifies that proof = \\`@crucial\\` scenario execution results\n\n### Backward compatibility\n\n- If \\`.adw/scenarios.md\\` does not exist in the target repo: fall back to current code-diff proof behaviour\n- This ensures projects that have not yet adopted BDD continue to work\n\n## Acceptance Criteria\n\n- Review phase runs \\`@crucial\\` scenarios and reports pass/fail\n- \\`@crucial\\` failures are reported as blockers\n- Current-issue scenario failures (non-crucial) are reported as tech-debt\n- Review proof posted to PR is scenario output, not code diff\n- Fallback to code-diff proof when \\`scenarios.md\\` is absent\n- ADW's own \\`review_proof.md\\` is updated to reflect the new approach","state":"OPEN","author":"paysdoc","labels":["enhancement"],"createdAt":"2026-03-13T07:02:35Z","comments":[{"author":"paysdoc","createdAt":"2026-03-13T16:12:41Z","body":"## Take action\n"}],"actionableComment":null}`
+
+## Feature Description
+The review phase currently produces proof via code-diff analysis, test output summaries, lint/type-check verification, and spec compliance checklists. This feature replaces that proof mechanism with BDD scenario execution: all `@crucial`-tagged scenarios are executed, and their pass/fail results become the primary review proof. `@crucial` failures are blockers that prevent the PR from passing review. Non-crucial failures from the current issue's `@adw-{issueNumber}` scenarios are reported as tech-debt. Backward compatibility is maintained — repos without `.adw/scenarios.md` fall back to the existing code-diff proof behaviour.
+
+## User Story
+As an ADW workflow operator
+I want the review phase to use `@crucial` BDD scenario execution as its primary proof mechanism
+So that review proof reflects actual runtime behaviour rather than static code-diff analysis
+
+## Problem Statement
+The current review proof mechanism relies on code-diff analysis, test output summaries, and lint/type checks. These are static verification methods that don't demonstrate that the application actually works as specified. BDD scenarios test real behaviour, and `@crucial` scenarios form a regression safety net. Using scenario execution as proof provides stronger, more meaningful verification that the implementation meets requirements.
+
+## Solution Statement
+Run `@crucial` BDD scenarios **once** (via subprocess) at the start of each review iteration, before launching the 3 parallel review agents. Also run `@adw-{issueNumber}` scenarios for the current issue. Save the combined scenario output to a results file. Each review agent then reads those scenario results and classifies them: `@crucial` failures become `blocker` review issues, `@adw-{issueNumber}` non-crucial failures become `tech-debt` review issues. The review summary describes scenario results instead of code diffs. When `.adw/scenarios.md` is absent, the system falls back to the existing code-diff proof behaviour.
+
+## Relevant Files
+Use these files to implement the feature:
+
+- `guidelines/coding_guidelines.md` — Coding standards to follow during implementation
+- `adws/agents/reviewRetry.ts` — Multi-agent review retry loop; needs scenario execution step added before parallel review agents
+- `adws/agents/reviewAgent.ts` — Review agent runner; needs to pass scenario results file path to the `/review` command
+- `adws/agents/bddScenarioRunner.ts` — Existing BDD subprocess executor; needs new functions to run `@crucial` and tag-filtered scenarios returning structured results
+- `adws/agents/index.ts` — Agent module barrel; needs to export new scenario runner functions
+- `adws/phases/workflowCompletion.ts` — Review phase orchestration; needs to pass `issueNumber` and `projectConfig` to `runReviewWithRetry`
+- `adws/phases/workflowInit.ts` — `WorkflowConfig` type definition (read-only reference)
+- `adws/core/projectConfig.ts` — `ProjectConfig` type with `ScenariosConfig` and `scenariosMd` (read-only reference)
+- `.claude/commands/review.md` — Review slash command prompt; needs scenario-aware proof instructions with fallback
+- `.adw/review_proof.md` — ADW project proof requirements; needs rewrite for scenario-based proof
+- `.adw/scenarios.md` — BDD scenario configuration (read-only reference for command templates)
+- `.adw/commands.md` — Project commands including `runCrucialScenarios` and `runScenariosByTag` (read-only reference)
+- `app_docs/feature-fix-review-process-8aatht-multi-agent-review-external-proof.md` — Documentation of multi-agent review architecture (read for context)
+- `app_docs/feature-1773386463517-mvb88d-bdd-scenario-config.md` — Documentation of BDD scenario config (read for context)
+
+### New Files
+- `adws/agents/crucialScenarioProof.ts` — Orchestrates running `@crucial` and `@adw-{issueNumber}` scenarios, saves results to a file, returns structured outcome for the review retry loop
+
+## Implementation Plan
+### Phase 1: Foundation
+Extend the BDD scenario runner to support running scenarios by arbitrary tags (not just `@adw-{issueNumber}`) and create the crucial-scenario proof orchestrator that runs both `@crucial` and `@adw-{issueNumber}` scenarios, classifies results, and writes them to a results file.
+
+### Phase 2: Core Implementation
+Integrate the crucial-scenario proof step into the review retry loop (`reviewRetry.ts`). Run scenarios once per review iteration before the 3 parallel review agents launch. Pass the scenario results file path to each review agent. Update the `/review` slash command to read scenario results and produce scenario-based proof. Update `ReviewRetryOptions` to carry `issueNumber` and `projectConfig`.
+
+### Phase 3: Integration
+Update `.adw/review_proof.md` to describe the new scenario-based proof format. Update `executeReviewPhase` in `workflowCompletion.ts` to pass the additional config needed. Ensure backward compatibility: when `scenariosMd` is empty, skip scenario execution and fall back to the existing code-diff proof behaviour.
+
+## Step by Step Tasks
+
+### Step 1: Read context documentation
+- Read `app_docs/feature-fix-review-process-8aatht-multi-agent-review-external-proof.md` for multi-agent review architecture context
+- Read `app_docs/feature-1773386463517-mvb88d-bdd-scenario-config.md` for BDD scenario configuration context
+- Read `guidelines/coding_guidelines.md` for coding standards
+
+### Step 2: Extend `bddScenarioRunner.ts` with a generic tag runner
+- Add a new function `runScenariosByTag(tagCommand: string, tag: string, cwd?: string): Promise<BddScenarioResult>` that:
+  - Takes the run-by-tag command template (e.g. `cucumber-js --tags "@{tag}"`)
+  - Replaces `{tag}` with the provided tag
+  - Runs it as a subprocess and returns `BddScenarioResult`
+  - Returns a passing result when the command is `'N/A'` or empty (graceful skip)
+- This generalises the existing `runBddScenarios` which is specific to `{issueNumber}` replacement
+- Export the new function from `adws/agents/index.ts`
+
+### Step 3: Create `crucialScenarioProof.ts`
+- Create `adws/agents/crucialScenarioProof.ts` with:
+  - Interface `ScenarioProofResult`:
+    - `crucialPassed: boolean` — all `@crucial` scenarios passed
+    - `crucialOutput: string` — stdout from `@crucial` run
+    - `crucialExitCode: number | null`
+    - `issueScenariosPassed: boolean` — `@adw-{issueNumber}` scenarios passed
+    - `issueScenarioOutput: string` — stdout from issue-specific run
+    - `issueScenarioExitCode: number | null`
+    - `resultsFilePath: string` — path to the written results file
+  - Function `runCrucialScenarioProof(options)` that:
+    - Accepts `{ scenariosMd: string, runByTagCommand: string, runCrucialCommand: string, issueNumber: number, proofDir: string, cwd?: string }`
+    - Runs `@crucial` scenarios using `runCrucialCommand` (from `.adw/commands.md`) via `runScenariosByTag` or directly via `runBddScenarios`-style subprocess
+    - Runs `@adw-{issueNumber}` scenarios using `runByTagCommand` with tag `adw-{issueNumber}`
+    - Writes combined results to `{proofDir}/scenario_proof.md` as a structured markdown file with sections for each run
+    - Returns `ScenarioProofResult`
+  - Function `shouldRunScenarioProof(scenariosMd: string): boolean` — returns `true` when `.adw/scenarios.md` content is non-empty
+- Export from `adws/agents/index.ts`
+
+### Step 4: Update `ReviewRetryOptions` and `runReviewWithRetry`
+- In `adws/agents/reviewRetry.ts`:
+  - Add to `ReviewRetryOptions`:
+    - `issueNumber: number`
+    - `scenariosMd: string` — raw content of `.adw/scenarios.md`
+    - `runCrucialCommand: string` — command to run `@crucial` scenarios
+    - `runByTagCommand: string` — command template with `{tag}` placeholder
+  - In `runReviewWithRetry`, at the top of each iteration (before launching parallel review agents):
+    - Check `shouldRunScenarioProof(scenariosMd)`
+    - If true: call `runCrucialScenarioProof(...)` with proofDir set to `agents/{adwId}/scenario_proof/`
+    - Store the `ScenarioProofResult` for this iteration
+    - If `@crucial` scenarios fail AND this is the last retry attempt: return with blockers immediately (scenarios are the source of truth)
+  - Pass the `resultsFilePath` from `ScenarioProofResult` to each `runReviewAgent` call (add it as a new optional parameter)
+  - Add `ScenarioProofResult` to `ReviewRetryResult` so the review phase can access scenario outcomes
+
+### Step 5: Update `reviewAgent.ts` to pass scenario proof path
+- In `adws/agents/reviewAgent.ts`:
+  - Add an optional `scenarioProofPath?: string` parameter to `runReviewAgent`
+  - Add it to `formatReviewArgs` — if provided, pass it as an additional argument after `applicationUrl`
+  - This makes the scenario results file available to the `/review` slash command
+
+### Step 6: Update `.claude/commands/review.md` for scenario-based proof
+- Add a new variable: `scenarioProofPath: $5 if provided, otherwise empty`
+- In the `Proof Requirements` section, add scenario-aware logic:
+  - **If `scenarioProofPath` is provided and the file exists**: Read the scenario proof file. Use the scenario execution results as the primary proof. Classify `@crucial` failures as `blocker` issues. Classify non-crucial `@adw-{issueNumber}` failures as `tech-debt` issues. The `reviewSummary` should describe scenario pass/fail results.
+  - **If `scenarioProofPath` is NOT provided**: Fall back to `.adw/review_proof.md` instructions (existing behaviour)
+- Update the Instructions section to prioritise scenario proof when available:
+  - Read the scenario proof markdown file
+  - For each `@crucial` failure: create a `reviewIssue` with `issueSeverity: 'blocker'`, `issueDescription` describing the failing scenario, and `issueResolution` suggesting investigation
+  - For each `@adw-{issueNumber}` non-crucial failure: create a `reviewIssue` with `issueSeverity: 'tech-debt'`
+  - Still run type-check and lint as supplementary proof (these remain useful)
+  - `reviewSummary` should describe: how many `@crucial` scenarios passed/failed, how many `@adw-{issueNumber}` scenarios passed/failed
+  - `screenshots` array should contain the path to the scenario proof file as a proof artifact
+- Maintain the existing fallback: if no scenario proof is provided, use the current `.adw/review_proof.md` instructions
+
+### Step 7: Update `.adw/review_proof.md`
+- Rewrite to describe scenario-based proof:
+  - **Proof Type**: Primary proof is `@crucial` BDD scenario execution results. Supplementary checks: type-check (`bunx tsc --noEmit` and `bunx tsc --noEmit -p adws/tsconfig.json`) and lint (`bun run lint`)
+  - **Proof Format**: Scenario execution output is provided via a scenario proof file (path passed as argument). Review agents read and classify results.
+  - **Classification rules**: `@crucial` failures = `blocker`, `@adw-{issueNumber}` non-crucial failures = `tech-debt`
+  - **What NOT to Do**: Do NOT take browser screenshots. Do NOT start a dev server. Do NOT use code-diff as primary proof (scenario results are authoritative).
+- Keep the proof attachment format (JSON output structure) the same
+
+### Step 8: Update `executeReviewPhase` in `workflowCompletion.ts`
+- Pass the additional fields to `runReviewWithRetry`:
+  - `issueNumber: config.issueNumber`
+  - `scenariosMd: config.projectConfig.scenariosMd`
+  - `runCrucialCommand: config.projectConfig.commands.runCrucialScenarios`
+  - `runByTagCommand: config.projectConfig.commands.runScenariosByTag`
+- The `WorkflowConfig` already carries `projectConfig` with all needed fields, so no type changes needed
+
+### Step 9: Export new types and functions from barrel files
+- Update `adws/agents/index.ts` to export:
+  - `runScenariosByTag` from `./bddScenarioRunner`
+  - `runCrucialScenarioProof`, `shouldRunScenarioProof`, `ScenarioProofResult` from `./crucialScenarioProof`
+
+### Step 10: Validate
+- Run `bun run lint` to check for code quality issues
+- Run `bunx tsc --noEmit` to verify no type errors
+- Run `bunx tsc --noEmit -p adws/tsconfig.json` to verify adws type checking
+- Run `bun run build` to verify no build errors
+
+## Testing Strategy
+### Unit Tests
+Unit tests are disabled for this project (per `.adw/project.md`). Validation relies on type-checking, linting, and BDD scenarios.
+
+### Edge Cases
+- `.adw/scenarios.md` is absent → `scenariosMd` is empty string → `shouldRunScenarioProof` returns false → falls back to code-diff proof
+- `@crucial` scenario command is `'N/A'` → `runScenariosByTag` returns passing result (graceful skip)
+- No `@adw-{issueNumber}` scenarios exist → subprocess returns 0 (no scenarios matched) → treated as passing
+- Both `@crucial` and `@adw-{issueNumber}` pass → review proof shows all green, `reviewIssues` is empty
+- `@crucial` fails but `@adw-{issueNumber}` passes → blocker issues only
+- `@crucial` passes but `@adw-{issueNumber}` fails → tech-debt issues only, review still passes (non-blocking)
+- Review retry loop: `@crucial` fail → patch agent fixes code → re-run scenarios → pass on retry
+- Scenario proof file directory doesn't exist → create it before writing
+- Scenario command produces very large output → truncate in proof file to prevent memory issues
+
+## Acceptance Criteria
+- Review phase runs `@crucial` scenarios once per iteration and reports pass/fail
+- `@crucial` failures are reported as `blocker` review issues
+- Current-issue scenario failures (non-crucial `@adw-{issueNumber}`) are reported as `tech-debt` review issues
+- Review proof posted to PR is based on scenario output, not code diff
+- Fallback to code-diff proof when `.adw/scenarios.md` is absent (empty `scenariosMd`)
+- ADW's own `.adw/review_proof.md` is updated to reflect the new scenario-based approach
+- Type checking passes with no errors
+- Linting passes with no errors
+- Build completes successfully
+
+## Validation Commands
+Execute every command to validate the feature works correctly with zero regressions.
+
+- `bun run lint` — Run linter to check for code quality issues
+- `bunx tsc --noEmit` — Verify root-level type checking passes
+- `bunx tsc --noEmit -p adws/tsconfig.json` — Verify adws-specific type checking passes
+- `bun run build` — Build the application to verify no build errors
+
+## Notes
+- The `guidelines/coding_guidelines.md` file must be followed strictly. Key points: prefer pure functions, isolate side effects, use TypeScript strict mode, prefer declarative patterns, keep files under 300 lines.
+- The existing `runBddScenarios` function in `bddScenarioRunner.ts` uses `{issueNumber}` replacement. The new `runScenariosByTag` function uses `{tag}` replacement for generality — these are complementary, not conflicting.
+- The review retry loop's patch-and-retry mechanism continues to work: if `@crucial` scenarios fail, the patch agent can attempt to fix the code, then scenarios re-run on the next iteration.
+- The 3 parallel review agents all see the **same** scenario results (run once, shared via file), ensuring consistent proof across agents without wasting resources re-running scenarios 3 times.
+- Scenario output can be large. The proof file should include stdout (truncated if over 10,000 characters) and the exit code for each run.
+- This feature depends on #165 (Scenario Planner Agent) and #167 (BDD test infrastructure). Both are already merged.


### PR DESCRIPTION
## Summary

Replaces the code-diff analysis proof in the review phase with execution of `@crucial`-tagged BDD scenarios. Crucial failures are blockers; non-crucial failures from the current issue's scenarios are reported as tech-debt. Falls back to code-diff proof if `.adw/scenarios.md` is absent.

## Plan

[`specs/issue-168-adw-9emriw-refactor-review-phas-sdlc_planner-bdd-scenario-review-proof.md`](specs/issue-168-adw-9emriw-refactor-review-phas-sdlc_planner-bdd-scenario-review-proof.md)

## Changes

- **`adws/agents/crucialScenarioProof.ts`** — new agent that runs `@crucial` BDD scenarios and formats pass/fail proof
- **`adws/agents/bddScenarioRunner.ts`** — extended to support filtering and running crucial scenarios
- **`adws/agents/reviewAgent.ts`** — updated to invoke crucial scenario proof instead of code-diff analysis
- **`adws/agents/reviewRetry.ts`** — updated retry logic to handle scenario-based failures
- **`adws/agents/index.ts`** — exports new `crucialScenarioProof` agent
- **`.claude/commands/review.md`** — updated review command to describe scenario-based proof flow
- **`.adw/review_proof.md`** — updated to reflect scenario-based proof; removes `bun run test` and code-diff references
- **`adws/phases/workflowCompletion.ts`** — minor update to surface scenario results in completion summary
- **`features/review_phase.feature`** — BDD feature file for the review phase scenario proof behaviour

## Checklist

- [x] Review phase runs `@crucial` scenarios and reports pass/fail
- [x] `@crucial` failures are reported as blockers
- [x] Current-issue scenario failures (non-crucial) are reported as tech-debt
- [x] Review proof posted to PR is scenario output, not code diff
- [x] Fallback to code-diff proof when `scenarios.md` is absent
- [x] ADW's own `review_proof.md` updated to reflect new approach

Closes #168

ADW tracking ID: `9emriw-refactor-review-phas`