### PR TITLE
bug: #196 - push adw_kpis

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,7 @@ bun run test:watch    # Run tests in watch mode
 │   ├── commit_cost.md
 │   ├── conditional_docs.md
 │   ├── document.md
+│   ├── extract_dependencies.md
 │   ├── feature.md
 │   ├── find_issue_dependencies.md
 │   ├── generate_branch_name.md
@@ -135,6 +136,7 @@ adws/                   # ADW workflow system
 │   ├── buildAgent.ts
 │   ├── claudeAgent.ts
 │   ├── crucialScenarioProof.ts  # Crucial scenario proof for reviews
+│   ├── dependencyExtractionAgent.ts  # LLM-based issue dependency extraction
 │   ├── documentAgent.ts
 │   ├── gitAgent.ts
 │   ├── index.ts

--- a/adws/phases/kpiPhase.ts
+++ b/adws/phases/kpiPhase.ts
@@ -14,6 +14,7 @@ import {
   getPlanFilePath,
   runKpiAgent,
 } from '../agents';
+import { commitAndPushKpiFile } from '../vcs';
 import type { WorkflowConfig } from './workflowLifecycle';
 
 /**
@@ -86,6 +87,8 @@ export async function executeKpiPhase(
         true,
       ),
     });
+
+    commitAndPushKpiFile();
 
     AgentStateManager.appendLog(orchestratorStatePath, 'KPI tracking completed');
     log('KPI phase completed', 'success');

--- a/adws/vcs/commitOperations.ts
+++ b/adws/vcs/commitOperations.ts
@@ -127,3 +127,40 @@ export function commitAndPushCostFiles(options: CommitCostFilesOptions = {}): bo
     return false;
   }
 }
+
+/**
+ * Stages, commits, and pushes the agentic KPI file.
+ * Returns true if changes were committed, false if no changes or on failure.
+ */
+export function commitAndPushKpiFile(cwd?: string): boolean {
+  try {
+    const status = execSync(
+      'git status --porcelain -- "app_docs/agentic_kpis.md"',
+      { encoding: 'utf-8', cwd },
+    ).trim();
+
+    if (!status) {
+      log(`No KPI file changes to commit`, 'info');
+      return false;
+    }
+
+    execSync('git add "app_docs/agentic_kpis.md"', { stdio: 'pipe', cwd });
+    execSync('git commit -m "kpis: update agentic_kpis"', { stdio: 'pipe', cwd });
+
+    const branch = getCurrentBranch(cwd);
+
+    if (!branch) {
+      throw new Error('Cannot push KPI file: no current branch detected (detached HEAD)');
+    }
+
+    execSync(`git fetch origin "${branch}"`, { stdio: 'pipe', cwd });
+    execSync(`git rebase --autostash "origin/${branch}"`, { stdio: 'pipe', cwd });
+    execSync(`git push origin "${branch}"`, { stdio: 'pipe', cwd });
+
+    log(`Committed and pushed agentic_kpis.md`, 'success');
+    return true;
+  } catch (error) {
+    log(`Failed to commit KPI file: ${error}`, 'error');
+    return false;
+  }
+}

--- a/adws/vcs/index.ts
+++ b/adws/vcs/index.ts
@@ -27,6 +27,7 @@ export {
   pushBranch,
   pullLatestCostBranch,
   commitAndPushCostFiles,
+  commitAndPushKpiFile,
   type CommitCostFilesOptions,
 } from './commitOperations';
 

--- a/features/push_adw_kpis.feature
+++ b/features/push_adw_kpis.feature
@@ -1,0 +1,56 @@
+@adw-jm6pnw-push-adw-kpis
+Feature: KPI phase commits and pushes the updated agentic_kpis.md file
+
+  After the KPI agent writes updates to `app_docs/agentic_kpis.md`, the changes
+  must be committed and pushed to the remote branch. Without a push, the KPI
+  tracking data is lost when the worktree is cleaned up.
+
+  Background:
+    Given the ADW workflow has completed at least the plan and build phases
+    And the KPI agent has successfully written updates to "app_docs/agentic_kpis.md"
+
+  @adw-jm6pnw-push-adw-kpis @crucial
+  Scenario: KPI phase commits the updated agentic_kpis.md after agent completion
+    Given the KPI agent has written changes to "app_docs/agentic_kpis.md"
+    And the file has uncommitted changes in the working tree
+    When the KPI phase finishes executing the agent
+    Then a git commit is created that includes "app_docs/agentic_kpis.md"
+    And the commit message references KPI tracking
+
+  @adw-jm6pnw-push-adw-kpis @crucial
+  Scenario: KPI phase pushes the commit to the remote branch
+    Given the KPI agent has written and committed changes to "app_docs/agentic_kpis.md"
+    When the KPI phase push step executes
+    Then the commit is pushed to the remote tracking branch
+    And "app_docs/agentic_kpis.md" is visible on the remote branch
+
+  @adw-jm6pnw-push-adw-kpis @crucial
+  Scenario: agentic_kpis.md is present in remote branch after full SDLC run
+    Given an ADW SDLC workflow (plan + build + test + review + document + KPI) has completed
+    When the remote branch is inspected
+    Then "app_docs/agentic_kpis.md" exists in the remote branch
+    And the file contains the ADW run entry for the current adwId
+
+  @adw-jm6pnw-push-adw-kpis
+  Scenario: KPI commit and push failure is non-fatal and does not block workflow completion
+    Given the KPI agent has written changes to "app_docs/agentic_kpis.md"
+    And the git push command fails (e.g. network error or permission denied)
+    When the KPI phase attempts to commit and push
+    Then the error is caught and logged as a warning
+    And the workflow continues to the completion step without throwing
+    And the workflow completes successfully despite the push failure
+
+  @adw-jm6pnw-push-adw-kpis
+  Scenario: No commit is created when KPI agent produces no changes
+    Given the KPI agent runs but "app_docs/agentic_kpis.md" already reflects the current run
+    And there are no uncommitted changes to "app_docs/agentic_kpis.md"
+    When the KPI phase commit step executes
+    Then no new git commit is created
+    And the push step is skipped
+
+  @adw-jm6pnw-push-adw-kpis
+  Scenario: No commit is created when the KPI agent itself fails
+    Given the KPI agent fails to produce output
+    When the KPI phase completes with a failed agent result
+    Then no commit or push is attempted for "app_docs/agentic_kpis.md"
+    And the KPI phase still returns without throwing (non-fatal)

--- a/specs/issue-196-adw-jm6pnw-push-adw-kpis-sdlc_planner-push-kpi-file.md
+++ b/specs/issue-196-adw-jm6pnw-push-adw-kpis-sdlc_planner-push-kpi-file.md
@@ -1,0 +1,77 @@
+# Bug: agentic_kpis.md updated but never pushed
+
+## Metadata
+issueNumber: `196`
+adwId: `jm6pnw-push-adw-kpis`
+issueJson: `{"number":196,"title":"push adw_kpis","body":"/bug \n\nThe agentic_kpis.md file is updated but never pushed","state":"OPEN","author":"paysdoc","labels":[],"createdAt":"2026-03-16T11:25:00Z","comments":[],"actionableComment":null}`
+
+## Bug Description
+The KPI phase (`adws/phases/kpiPhase.ts`) runs the KPI agent which updates `app_docs/agentic_kpis.md` in the ADW repo root, but the phase never commits or pushes the changes. The file is updated locally and then the changes are lost when the worktree is cleaned up or the workflow ends.
+
+**Expected behavior:** After the KPI agent successfully updates `app_docs/agentic_kpis.md`, the changes should be committed and pushed to the remote so KPI data is persisted.
+
+**Actual behavior:** The file is updated on disk but never committed or pushed. The feature docs explicitly note: "No git operations in KPI phase: unlike the document phase, `executeKpiPhase` never commits or pushes."
+
+## Problem Statement
+The `executeKpiPhase` function in `adws/phases/kpiPhase.ts` lacks commit and push operations after the KPI agent updates `app_docs/agentic_kpis.md`. The document phase (`documentPhase.ts`) correctly commits and pushes its output, but the KPI phase was implemented without these git operations.
+
+## Solution Statement
+Add a `commitAndPushKpiFile` function to `adws/vcs/commitOperations.ts` following the existing `commitAndPushCostFiles` pattern, and call it from `kpiPhase.ts` after the KPI agent succeeds. The function will stage only `app_docs/agentic_kpis.md`, commit with a KPI-specific message, fetch/rebase to avoid conflicts, and push to the current branch.
+
+## Steps to Reproduce
+1. Run the full SDLC orchestrator: `bunx tsx adws/adwSdlc.tsx <issueNumber>`
+2. Observe that `app_docs/agentic_kpis.md` is updated locally by the KPI agent
+3. Check `git status` — the file has uncommitted changes
+4. The workflow completes without committing or pushing the KPI file
+5. The KPI data is lost
+
+## Root Cause Analysis
+When the KPI tracking feature was implemented (issue #148, ADW ID `8ar0fo`), the design intentionally omitted git operations from `executeKpiPhase`. The feature docs state: "No git operations in KPI phase: unlike the document phase, executeKpiPhase never commits or pushes. The updated app_docs/agentic_kpis.md lives in the ADW repo and is committed separately (e.g. via /commit_cost or a manual commit)."
+
+However, there is no automatic mechanism that commits and pushes `app_docs/agentic_kpis.md`. The `/commit_cost` command only handles files under `projects/`, not `app_docs/`. Manual commits are unreliable in an automated workflow. The result is that KPI data is always lost.
+
+## Relevant Files
+Use these files to fix the bug:
+
+- `adws/phases/kpiPhase.ts` — The KPI phase that needs commit+push after the agent succeeds
+- `adws/vcs/commitOperations.ts` — Contains `commitAndPushCostFiles` pattern to follow; add `commitAndPushKpiFile` here
+- `adws/vcs/index.ts` — Export barrel; needs to export the new function
+- `guidelines/coding_guidelines.md` — Coding guidelines to follow
+
+## Step by Step Tasks
+
+### Step 1: Add `commitAndPushKpiFile` to `commitOperations.ts`
+- Add a new exported function `commitAndPushKpiFile(cwd?: string): boolean` to `adws/vcs/commitOperations.ts`
+- Follow the exact pattern of `commitAndPushCostFiles`:
+  1. `git status --porcelain -- "app_docs/agentic_kpis.md"` to check for changes
+  2. `git add "app_docs/agentic_kpis.md"` to stage only the KPI file
+  3. `git commit -m "kpis: update agentic_kpis"` to commit
+  4. `getCurrentBranch(cwd)` to get the current branch
+  5. `git fetch origin "<branch>"` to sync
+  6. `git rebase --autostash "origin/<branch>"` to rebase
+  7. `git push origin "<branch>"` to push
+- Return `true` if committed+pushed, `false` if no changes or on failure
+- Wrap in try/catch, log errors with `log()`, return `false` on failure (non-fatal, matching the KPI phase's non-fatal design)
+
+### Step 2: Export `commitAndPushKpiFile` from `adws/vcs/index.ts`
+- Add `commitAndPushKpiFile` to the commit operations export block in `adws/vcs/index.ts`
+
+### Step 3: Call `commitAndPushKpiFile` in `kpiPhase.ts` after agent success
+- Import `commitAndPushKpiFile` from `'../vcs'` in `adws/phases/kpiPhase.ts`
+- After the KPI agent returns successfully (after the `AgentStateManager.writeState` success block at ~line 88), call `commitAndPushKpiFile()` with no `cwd` argument (the KPI agent writes to the ADW repo root)
+- This call is already inside the try/catch that makes the phase non-fatal, so push failures won't block the workflow
+
+### Step 4: Run validation commands
+
+## Validation Commands
+Execute every command to validate the bug is fixed with zero regressions.
+
+- `bunx tsc --noEmit -p adws/tsconfig.json` — TypeScript compilation check
+- `bun run lint` — Lint check for code quality
+- `bun run test` — Run tests to validate zero regressions
+
+## Notes
+- The fix follows the existing `commitAndPushCostFiles` pattern in `commitOperations.ts` for consistency.
+- The `commitAndPushKpiFile` call is inside the existing try/catch in `executeKpiPhase`, preserving the non-fatal design — push failures are logged but never block the workflow.
+- The function stages only `app_docs/agentic_kpis.md`, not all changes, to avoid accidentally committing unrelated files.
+- No new libraries are required.


### PR DESCRIPTION
## Summary

Fixes an issue where `agentic_kpis.md` was being updated during the KPI phase but never committed and pushed to the remote repository.

**Plan:** `jm6pnw-push-adw-kpis`

Closes #196

**ADW Tracking ID:** jm6pnw-push-adw-kpis

## Checklist

- [x] Added `commitAndPushFile` utility in `adws/vcs/commitOperations.ts`
- [x] Exported new utility from `adws/vcs/index.ts`
- [x] Updated `kpiPhase.ts` to commit and push `agentic_kpis.md` after generation
- [x] Added feature spec `features/push_adw_kpis.feature`
- [x] Added implementation plan spec

## Key Changes

- **`adws/vcs/commitOperations.ts`**: New `commitAndPushFile` function that stages, commits, and pushes a specific file
- **`adws/vcs/index.ts`**: Exports the new `commitAndPushFile` utility
- **`adws/phases/kpiPhase.ts`**: Calls `commitAndPushFile` after writing `agentic_kpis.md` so KPI data is persisted remotely