### PR TITLE
bug: #217 - Fix PR review worktree creation

### DIFF
--- a/adws/vcs/worktreeCreation.ts
+++ b/adws/vcs/worktreeCreation.ts
@@ -104,7 +104,15 @@ export function createWorktree(branchName: string, baseBranch?: string, baseRepo
         execSync(`git rev-parse --verify "origin/${branchName}"`, gitOpts);
         branchExists = true;
       } catch {
-        branchExists = false;
+        // Remote ref not found locally, try fetching from origin
+        try {
+          execSync(`git fetch origin "${branchName}"`, gitOpts);
+          execSync(`git rev-parse --verify "origin/${branchName}"`, gitOpts);
+          branchExists = true;
+          log(`Fetched branch '${branchName}' from origin`, 'info');
+        } catch {
+          branchExists = false;
+        }
       }
     }
 

--- a/features/pr_review_worktree_creation.feature
+++ b/features/pr_review_worktree_creation.feature
@@ -17,8 +17,7 @@ Feature: PR review creates worktree for branch that exists only on the remote
   @adw-217 @regression
   Scenario: createWorktree fetches from remote when branch is not in remote-tracking refs
     Given "adws/vcs/worktreeCreation.ts" is read
-    Then createWorktree or ensureWorktree performs a git fetch for the target branch
-    before attempting git worktree add
+    Then createWorktree or ensureWorktree performs a git fetch for the target branch before attempting git worktree add
 
   @adw-217 @regression
   Scenario: PR review worktree is created for a branch that exists on remote but not locally

--- a/features/pr_review_worktree_creation.feature
+++ b/features/pr_review_worktree_creation.feature
@@ -1,0 +1,58 @@
+@adw-217
+Feature: PR review creates worktree for branch that exists only on the remote
+
+  When adwPrReview.tsx starts, it calls ensureWorktree(prDetails.headBranch) with
+  no base branch. If the branch exists on GitHub but has not been fetched into local
+  remote-tracking refs (origin/<branch>), createWorktree throws
+  "Branch does not exist and no base branch was provided", crashing the PR review
+  workflow before any review work begins.
+
+  The fix must fetch the branch from the remote before attempting worktree creation
+  so that createWorktree can locate the branch even when the local repo has stale
+  or missing remote-tracking refs.
+
+  Background:
+    Given the ADW codebase is checked out
+
+  @adw-217 @regression
+  Scenario: createWorktree fetches from remote when branch is not in remote-tracking refs
+    Given "adws/vcs/worktreeCreation.ts" is read
+    Then createWorktree or ensureWorktree performs a git fetch for the target branch
+    before attempting git worktree add
+
+  @adw-217 @regression
+  Scenario: PR review worktree is created for a branch that exists on remote but not locally
+    Given a PR exists for branch "chore-issue-28-update-command-md"
+    And the branch does not exist as a local branch in the ADW repository
+    And the branch has not been fetched so "origin/chore-issue-28-update-command-md" does not resolve
+    When initializePRReviewWorkflow is called for that PR
+    Then a worktree is successfully created for "chore-issue-28-update-command-md"
+    And the workflow does not crash with "Branch does not exist and no base branch was provided"
+
+  @adw-217 @regression
+  Scenario: createWorktree handles branch present only in remote-tracking refs after fetch
+    Given the branch "feat-99-abc-my-feature" does not exist as a local branch
+    And after fetching, "origin/feat-99-abc-my-feature" resolves to a valid commit
+    When createWorktree is called for "feat-99-abc-my-feature" with no base branch
+    Then git worktree add creates the worktree tracking the remote branch
+    And the worktree path is returned without error
+
+  @adw-217 @regression
+  Scenario: TypeScript type-check passes after the remote-fetch fix
+    Given the ADW codebase is checked out
+    Then the ADW TypeScript type-check passes
+
+  @adw-217
+  Scenario: ensureWorktree still reuses an existing worktree when the branch is already checked out
+    Given a worktree already exists for branch "chore-issue-28-update-command-md"
+    When ensureWorktree is called for "chore-issue-28-update-command-md"
+    Then the existing worktree path is returned
+    And no new worktree is created
+    And no git fetch is performed for an already-present worktree
+
+  @adw-217
+  Scenario: ensureWorktree still works when the branch exists locally before the fetch
+    Given the branch "feat-42-xyz-something" exists as a local branch
+    When ensureWorktree is called for "feat-42-xyz-something"
+    Then a worktree is created using the existing local branch
+    And the worktree path is returned without error

--- a/features/step_definitions/prReviewWorktreeFetchSteps.ts
+++ b/features/step_definitions/prReviewWorktreeFetchSteps.ts
@@ -1,0 +1,180 @@
+import { Given, When, Then } from '@cucumber/cucumber';
+import { readFileSync } from 'fs';
+import { join } from 'path';
+import assert from 'assert';
+import { sharedCtx } from './commonSteps.ts';
+
+const ROOT = process.cwd();
+
+function loadWorktreeCreation(): void {
+  const filePath = 'adws/vcs/worktreeCreation.ts';
+  sharedCtx.fileContent = readFileSync(join(ROOT, filePath), 'utf-8');
+  sharedCtx.filePath = filePath;
+}
+
+// ── Context-only Given/When steps ─────────────────────────────────────────────
+
+Given('a PR exists for branch {string}', function (_branch: string) {
+  // Context only — branch existence validated via code inspection
+});
+
+Given('the branch does not exist as a local branch in the ADW repository', function () {
+  // Context only — precondition described in scenario prose
+});
+
+Given('the branch has not been fetched so {string} does not resolve', function (_ref: string) {
+  // Context only — precondition described in scenario prose
+});
+
+Given('the branch {string} does not exist as a local branch', function (_branch: string) {
+  // Context only — precondition described in scenario prose
+});
+
+Given('after fetching, {string} resolves to a valid commit', function (_ref: string) {
+  // Context only — precondition described in scenario prose
+});
+
+Given('a worktree already exists for branch {string}', function (_branch: string) {
+  // Context only — precondition described in scenario prose
+});
+
+Given('the branch {string} exists as a local branch', function (_branch: string) {
+  // Context only — precondition described in scenario prose
+});
+
+When('initializePRReviewWorkflow is called for that PR', function () {
+  loadWorktreeCreation();
+});
+
+When('createWorktree is called for {string} with no base branch', function (_branch: string) {
+  loadWorktreeCreation();
+});
+
+When('ensureWorktree is called for {string}', function (_branch: string) {
+  loadWorktreeCreation();
+});
+
+// ── Key regression assertions ─────────────────────────────────────────────────
+
+Then(
+  'createWorktree or ensureWorktree performs a git fetch for the target branch before attempting git worktree add',
+  function () {
+    const content = sharedCtx.fileContent;
+
+    const fetchIdx = content.indexOf('git fetch origin');
+    assert.ok(
+      fetchIdx !== -1,
+      'Expected worktreeCreation.ts to contain "git fetch origin" as a fallback fetch',
+    );
+
+    const worktreeAddIdx = content.indexOf('git worktree add');
+    assert.ok(
+      worktreeAddIdx !== -1,
+      'Expected worktreeCreation.ts to contain "git worktree add"',
+    );
+
+    assert.ok(
+      fetchIdx < worktreeAddIdx,
+      'Expected "git fetch origin" to appear before "git worktree add" in worktreeCreation.ts',
+    );
+  },
+);
+
+Then('a worktree is successfully created for {string}', function (_branch: string) {
+  const content = sharedCtx.fileContent;
+
+  assert.ok(
+    content.includes('git fetch origin'),
+    'Expected worktreeCreation.ts to include a git fetch fallback so the worktree can be created',
+  );
+  assert.ok(
+    content.includes('git worktree add'),
+    'Expected worktreeCreation.ts to call git worktree add for branch creation',
+  );
+});
+
+Then(
+  'the workflow does not crash with {string}',
+  function (_errorMessage: string) {
+    const content = sharedCtx.fileContent;
+
+    // The fetch fallback must be in the catch block that previously set branchExists = false,
+    // so it now attempts a fetch before giving up.
+    assert.ok(
+      content.includes('git fetch origin'),
+      'Expected worktreeCreation.ts to attempt git fetch before concluding branch does not exist',
+    );
+  },
+);
+
+Then('git worktree add creates the worktree tracking the remote branch', function () {
+  const content = sharedCtx.fileContent;
+
+  assert.ok(
+    content.includes('git worktree add "${worktreePath}" "${branchName}"'),
+    'Expected worktreeCreation.ts to call git worktree add with worktreePath and branchName for existing branches',
+  );
+});
+
+Then('the worktree path is returned without error', function () {
+  // Pass-through — validated by the absence of error-throwing in the Then steps above
+});
+
+Then('the existing worktree path is returned', function () {
+  const content = sharedCtx.fileContent;
+
+  assert.ok(
+    content.includes('getWorktreeForBranch'),
+    'Expected ensureWorktree to call getWorktreeForBranch to find existing worktrees',
+  );
+  assert.ok(
+    content.includes('Worktree for branch') && content.includes('already exists'),
+    'Expected ensureWorktree to log and return the existing worktree path',
+  );
+});
+
+Then('no new worktree is created', function () {
+  // Pass-through — validated by the existing-path early return in ensureWorktree
+});
+
+Then('no git fetch is performed for an already-present worktree', function () {
+  const content = sharedCtx.fileContent;
+
+  // ensureWorktree returns early when existingPath is found, before calling createWorktree
+  // (which contains the fetch logic). Verify the early-return guard exists in ensureWorktree.
+  assert.ok(
+    content.includes('if (existingPath)'),
+    'Expected ensureWorktree to guard on existingPath and return early before calling createWorktree',
+  );
+
+  // The fetch logic must be inside createWorktree, not inside ensureWorktree.
+  // Verify the fetch is scoped to the branch-existence check block.
+  assert.ok(
+    content.includes('git fetch origin'),
+    'Expected the fetch fallback to exist inside createWorktree',
+  );
+
+  // ensureWorktree should not directly call git fetch — it delegates to createWorktree
+  const ensureWorktreeFnStart = content.indexOf('export function ensureWorktree(');
+  assert.ok(ensureWorktreeFnStart !== -1, 'Expected ensureWorktree function to be present');
+
+  const ensureWorktreeBody = content.slice(ensureWorktreeFnStart);
+  assert.ok(
+    !ensureWorktreeBody.includes('git fetch'),
+    'Expected ensureWorktree to not directly call git fetch (fetch is delegated to createWorktree)',
+  );
+});
+
+Then('a worktree is created using the existing local branch', function () {
+  const content = sharedCtx.fileContent;
+
+  // Local branch is found by the first rev-parse check; worktree add is called directly
+  assert.ok(
+    content.includes('git rev-parse --verify "${branchName}"'),
+    'Expected createWorktree to check for local branch existence via git rev-parse',
+  );
+  assert.ok(
+    content.includes('git worktree add "${worktreePath}" "${branchName}"'),
+    'Expected createWorktree to call git worktree add for a locally-present branch',
+  );
+});

--- a/specs/issue-217-adw-7nw4nz-bug-in-target-repo-sdlc_planner-fix-pr-review-worktree-fetch.md
+++ b/specs/issue-217-adw-7nw4nz-bug-in-target-repo-sdlc_planner-fix-pr-review-worktree-fetch.md
@@ -1,0 +1,102 @@
+# Bug: PR review worktree creation fails when branch only exists on remote
+
+## Metadata
+issueNumber: `217`
+adwId: `7nw4nz-bug-in-target-repo`
+issueJson: `{"number":217,"title":"Bug in target repo","body":"...worktreeCreation.ts:144 throw new Error...Branch 'chore-issue-28-update-command-md' does not exist and no base branch was provided...","state":"OPEN","author":"paysdoc","labels":[],"createdAt":"2026-03-17T13:57:20Z","comments":[],"actionableComment":null}`
+
+## Bug Description
+When the PR review workflow (`adwPrReview.tsx`) is triggered for a PR whose head branch only exists on the remote (not yet fetched locally), worktree creation fails with:
+
+```
+Error: Failed to create worktree for branch 'chore-issue-28-update-command-md': Error: Branch 'chore-issue-28-update-command-md' does not exist and no base branch was provided
+```
+
+**Expected behavior**: The PR review workflow should fetch the branch from the remote and create a worktree for it, since the branch is the head of an open PR and must exist on GitHub.
+
+**Actual behavior**: `createWorktree` checks local refs and stale remote tracking refs, finds neither, and throws because no `baseBranch` fallback was provided by the caller (`prReviewPhase.ts`).
+
+## Problem Statement
+`createWorktree()` in `worktreeCreation.ts` checks `git rev-parse --verify "origin/${branchName}"` to see if the branch exists on the remote, but this only checks locally-cached remote tracking refs. If `git fetch` hasn't been run for that specific branch, the tracking ref doesn't exist locally, causing both the local and remote checks to fail. The PR review workflow at `prReviewPhase.ts:92` calls `ensureWorktree(prDetails.headBranch)` without a `baseBranch` — which is correct (the branch already exists on GitHub, we don't want to create a new one) — but `createWorktree` has no fallback fetch mechanism.
+
+## Solution Statement
+Add a `git fetch origin "${branchName}"` attempt in `createWorktree()` when both the local and stale remote ref checks fail. After fetching, re-check `origin/${branchName}`. If the fetch succeeds and the ref now exists, proceed normally with worktree creation. This is a surgical fix in `createWorktree` that benefits all callers, not just the PR review flow.
+
+## Steps to Reproduce
+1. Have a target repository with a PR whose head branch (`chore-issue-28-update-command-md`) has not been fetched locally
+2. Trigger the PR review workflow: `bunx tsx adws/adwPrReview.tsx <pr-number>`
+3. The workflow calls `initializePRReviewWorkflow` → `ensureWorktree(prDetails.headBranch)` → `createWorktree(branchName)` with no `baseBranch`
+4. `createWorktree` fails because:
+   - `git rev-parse --verify "chore-issue-28-update-command-md"` fails (no local branch)
+   - `git rev-parse --verify "origin/chore-issue-28-update-command-md"` fails (stale tracking refs)
+   - No `baseBranch` provided, so the error is thrown
+
+## Root Cause Analysis
+The root cause is a missing `git fetch` step in `createWorktree()`. The function assumes that if a branch exists on the remote, `origin/${branchName}` will already be available in the local refs. This assumption breaks when:
+
+1. The target repo was cloned with minimal fetch depth or the branch was pushed to the remote after the last fetch
+2. The cron/webhook trigger spawns a fresh process that inherits a stale git state
+3. The PR review workflow is the first operation targeting this specific branch
+
+The normal workflow (`initializeWorkflow` in `workflowInit.ts`) avoids this by always passing `defaultBranch` as the `baseBranch` parameter to `ensureWorktree`, which creates a new branch from the base. But in the PR review case, the branch already exists and should be checked out — creating a new branch from a base would be wrong.
+
+## Relevant Files
+Use these files to fix the bug:
+
+- `adws/vcs/worktreeCreation.ts` — Contains `createWorktree()` where the fix needs to be applied. The branch existence check at lines 96-109 needs a fetch fallback before concluding the branch doesn't exist.
+- `adws/phases/prReviewPhase.ts` — The caller at line 92 that triggers the bug. No changes needed here since the fix is in `createWorktree`.
+- `guidelines/coding_guidelines.md` — Coding guidelines to follow during implementation.
+
+## Step by Step Tasks
+
+### 1. Add fetch fallback to `createWorktree` in `adws/vcs/worktreeCreation.ts`
+
+- In the `createWorktree` function, after the remote ref check (`git rev-parse --verify "origin/${branchName}"`) fails at lines 103-108, add a fetch attempt before setting `branchExists = false`
+- The logic should be:
+  1. Try `git fetch origin "${branchName}"` using the same `gitOpts`
+  2. If fetch succeeds, re-check `git rev-parse --verify "origin/${branchName}"`
+  3. If the re-check succeeds, set `branchExists = true`
+  4. If either the fetch or re-check fails, set `branchExists = false` (current behavior)
+- Add a log message when the fetch succeeds: `log(\`Fetched branch '${branchName}' from origin\`, 'info')`
+- The modified code in the inner catch block (lines 105-108) should look like:
+
+```typescript
+catch {
+  // Remote ref not found locally, try fetching from origin
+  try {
+    execSync(`git fetch origin "${branchName}"`, gitOpts);
+    execSync(`git rev-parse --verify "origin/${branchName}"`, gitOpts);
+    branchExists = true;
+    log(`Fetched branch '${branchName}' from origin`, 'info');
+  } catch {
+    branchExists = false;
+  }
+}
+```
+
+### 2. Add BDD scenario for PR review worktree creation with unfetched branch
+
+- Create a new feature file `features/pr_review_worktree_fetch.feature` with a scenario that validates:
+  - Given a branch exists only on the remote (not in local refs)
+  - When `createWorktree` is called for that branch without a `baseBranch`
+  - Then `createWorktree` fetches the branch from origin and creates the worktree successfully
+- Create step definitions in `features/step_definitions/prReviewWorktreeFetchSteps.ts`
+- Tag the scenario with `@adw-217` and `@regression`
+
+### 3. Run validation commands
+
+- Run all validation commands listed below to ensure the fix compiles, passes linting, and introduces no regressions.
+
+## Validation Commands
+Execute every command to validate the bug is fixed with zero regressions.
+
+- `bun run lint` — Run linter to check for code quality issues
+- `bunx tsc --noEmit` — Type check the root project
+- `bunx tsc --noEmit -p adws/tsconfig.json` — Type check the adws project
+- `bunx cucumber-js --tags "@adw-217"` — Run the new BDD scenario for this fix
+- `bunx cucumber-js --tags "@regression"` — Run all regression scenarios to ensure no regressions
+
+## Notes
+- This is a minimal fix in `createWorktree` that benefits all callers, not just the PR review flow. Any code path that calls `createWorktree` for an existing remote branch that hasn't been fetched locally will now self-heal.
+- The `git fetch origin "${branchName}"` is a targeted fetch (single branch), not a full `git fetch`, so it's fast and doesn't pull unnecessary data.
+- The coding guidelines in `guidelines/coding_guidelines.md` must be strictly followed: meaningful error messages, type safety, and pure function preferences.


### PR DESCRIPTION
## Summary

Fixes a crash in the PR review workflow where creating a worktree for an existing remote branch fails because the branch doesn't exist locally and no base branch is provided.

- **Issue**: When `adwPrReview` runs and the target branch only exists on the remote, `ensureWorktree` throws `Branch 'X' does not exist and no base branch was provided`
- **Root cause**: `worktreeCreation.ts` did not fetch the remote branch before attempting to create a local worktree from it

## Plan

See [specs/issue-217-adw-7nw4nz-bug-in-target-repo-sdlc_planner-fix-pr-review-worktree-fetch.md](specs/issue-217-adw-7nw4nz-bug-in-target-repo-sdlc_planner-fix-pr-review-worktree-fetch.md)

## Changes

- `adws/vcs/worktreeCreation.ts`: Added `git fetch origin <branch>` before creating a worktree when the branch doesn't exist locally, so remote-only branches are available
- `features/pr_review_worktree_creation.feature`: BDD scenarios covering the fetch-before-create behaviour
- `features/step_definitions/prReviewWorktreeFetchSteps.ts`: Step definitions for the new feature scenarios

## Checklist

- [x] Root cause identified
- [x] Fix applied in `worktreeCreation.ts`
- [x] BDD feature file added
- [x] Step definitions added
- [x] Spec document committed

Closes #217

---
ADW tracking ID: `7nw4nz-bug-in-target-repo`