### PR TITLE
bug: #223 - Fix wrong repository being targeted in PR review

### DIFF
--- a/.adw/conditional_docs.md
+++ b/.adw/conditional_docs.md
@@ -189,3 +189,11 @@
     - When troubleshooting missing `## Run Scenarios by Tag` or `## Run Regression Scenarios` in generated `commands.md`
     - When working with `/adw_init` and E2E tool detection in step 7
     - When `projectConfig.ts` `runScenariosByTag` or `runRegressionScenarios` are falling back to defaults unexpectedly
+
+- app_docs/feature-ie8l08-fix-pr-review-target-repo.md
+  - Conditions:
+    - When working with `initializePRReviewWorkflow` in `adws/phases/prReviewPhase.ts`
+    - When troubleshooting PR review workflows targeting the wrong repository (ADW repo instead of target repo)
+    - When modifying `adwPrReview.tsx` target-repo argument handling
+    - When `ensureWorktree` is called without `baseRepoPath` in the PR review path
+    - When investigating the "wrong repository" class of bugs (#23, #33, #52, #56, #62, #119, #217, #223)

--- a/adws/adwPrReview.tsx
+++ b/adws/adwPrReview.tsx
@@ -43,7 +43,7 @@ async function main(): Promise<void> {
     process.exit(1);
   }
 
-  const config = await initializePRReviewWorkflow(prNumber, null, repoInfo, repoId);
+  const config = await initializePRReviewWorkflow(prNumber, null, repoInfo, repoId, targetRepo ?? undefined);
 
   let totalCostUsd = 0;
   let totalModelUsage: ModelUsageMap = {};

--- a/adws/phases/prReviewPhase.ts
+++ b/adws/phases/prReviewPhase.ts
@@ -4,7 +4,7 @@
 
 import * as fs from 'fs';
 import * as path from 'path';
-import { log, setLogAdwId, ensureLogsDirectory, generateAdwId, type PRDetails, type PRReviewComment, AgentStateManager, type AgentState, type ModelUsageMap, allocateRandomPort, emptyModelUsageMap, OrchestratorId } from '../core';
+import { log, setLogAdwId, ensureLogsDirectory, generateAdwId, type PRDetails, type PRReviewComment, AgentStateManager, type AgentState, type ModelUsageMap, allocateRandomPort, emptyModelUsageMap, OrchestratorId, type TargetRepoInfo, ensureTargetRepoWorkspace } from '../core';
 import { fetchPRDetails, getUnaddressedComments, type PRReviewWorkflowContext, getRepoInfo, type RepoInfo, activateGitHubAppAuth } from '../github';
 import { ensureWorktree } from '../vcs';
 import type { RepoContext, RepoIdentifier } from '../providers/types';
@@ -42,7 +42,7 @@ export interface PRReviewWorkflowConfig {
  * @param prNumber - The PR number to review
  * @param adwId - Optional ADW workflow ID (generated if not provided)
  */
-export async function initializePRReviewWorkflow(prNumber: number, adwId: string | null, repoInfo?: RepoInfo, repoId?: RepoIdentifier): Promise<PRReviewWorkflowConfig> {
+export async function initializePRReviewWorkflow(prNumber: number, adwId: string | null, repoInfo?: RepoInfo, repoId?: RepoIdentifier, targetRepo?: TargetRepoInfo): Promise<PRReviewWorkflowConfig> {
   const resolvedRepoInfo = repoInfo ?? getRepoInfo();
   // Activate GitHub App auth to generate a fresh token for this process.
   // Ensures child processes spawned by triggers don't rely on stale inherited GH_TOKEN.
@@ -89,7 +89,13 @@ export async function initializePRReviewWorkflow(prNumber: number, adwId: string
     reviewComments: unaddressedComments.length,
     branchName: prDetails.headBranch,
   };
-  const worktreePath = ensureWorktree(prDetails.headBranch);
+  let targetRepoWorkspacePath: string | undefined;
+  if (targetRepo) {
+    log(`Setting up target repo workspace for ${targetRepo.owner}/${targetRepo.repo}...`, 'info');
+    targetRepoWorkspacePath = ensureTargetRepoWorkspace(targetRepo);
+    log(`Target repo workspace: ${targetRepoWorkspacePath}`, 'success');
+  }
+  const worktreePath = ensureWorktree(prDetails.headBranch, undefined, targetRepoWorkspacePath);
   log(`Worktree path: ${worktreePath}`, 'info');
 
   // Allocate a random port for the dedicated dev server instance

--- a/app_docs/feature-ie8l08-fix-pr-review-target-repo.md
+++ b/app_docs/feature-ie8l08-fix-pr-review-target-repo.md
@@ -1,0 +1,76 @@
+# Fix: PR Review Workflow Targets Correct Repository
+
+**ADW ID:** ie8l08-wrong-repository-bei
+**Date:** 2026-03-17
+**Specification:** specs/issue-223-adw-ie8l08-wrong-repository-bei-sdlc_planner-fix-pr-review-target-repo.md
+
+## Overview
+
+When `adwPrReview.tsx` processed a PR from a target repository (e.g., `paysdoc/vestmatic`), all git operations (branch lookup, worktree creation) were incorrectly executed against the ADW repository instead of the target repository. This fix threads the `targetRepo` parameter through `adwPrReview.tsx` into `initializePRReviewWorkflow`, which now resolves the target repo workspace path and passes it as `baseRepoPath` to `ensureWorktree`.
+
+## What Was Built
+
+- `targetRepo?: TargetRepoInfo` parameter added to `initializePRReviewWorkflow` signature
+- Target repo workspace resolution inside `initializePRReviewWorkflow` using `ensureTargetRepoWorkspace`
+- `baseRepoPath` forwarded to `ensureWorktree` so git commands run against the correct repo
+- `adwPrReview.tsx` updated to pass the full `targetRepo` object to `initializePRReviewWorkflow`
+- BDD regression scenarios (`@adw-223`) added to `features/wrong_repository_target.feature`
+- Step definitions added in `features/step_definitions/wrongRepositoryTargetSteps.ts`
+
+## Technical Implementation
+
+### Files Modified
+
+- `adws/phases/prReviewPhase.ts`: Added `targetRepo?: TargetRepoInfo` parameter, imported `ensureTargetRepoWorkspace` and `TargetRepoInfo` from `../core`, added workspace resolution block before `ensureWorktree`, passed `targetRepoWorkspacePath` as third argument to `ensureWorktree`
+- `adws/adwPrReview.tsx`: Updated `initializePRReviewWorkflow` call to pass `targetRepo ?? undefined` as the fifth argument
+
+### Files Added
+
+- `features/wrong_repository_target.feature`: New BDD feature file with `@adw-223 @regression` scenarios covering `initializePRReviewWorkflow`, `ensureWorktree`, and the `adwPrReview.tsx` entry-point
+- `features/step_definitions/wrongRepositoryTargetSteps.ts`: Step definitions that verify source-level presence of `ensureTargetRepoWorkspace` import/call, `baseRepoPath` argument, and `targetRepo` pass-through
+
+### Key Changes
+
+- `initializePRReviewWorkflow` now accepts an optional fifth parameter `targetRepo?: TargetRepoInfo`
+- When `targetRepo` is provided, `ensureTargetRepoWorkspace(targetRepo)` is called to clone/pull and return the workspace path
+- `ensureWorktree(prDetails.headBranch, undefined, targetRepoWorkspacePath)` — `baseRepoPath` is now populated for target-repo PRs
+- Pattern mirrors the existing fix in `workflowInit.ts` (lines 140–168)
+- This closes the 7th recurrence of the "wrong repository" bug class (issues #23, #33, #52, #56, #62, #119, #217)
+
+## How to Use
+
+This fix is transparent — no configuration changes are required. When the cron trigger calls `adwPrReview.tsx` with `--target-repo owner/repo --clone-url <url>`, the resolved workspace is now automatically forwarded into the PR review workflow.
+
+1. Ensure `--target-repo` and `--clone-url` flags are present in the `adwPrReview.tsx` invocation (already set by the cron trigger)
+2. `adwPrReview.tsx` parses these into a `TargetRepoInfo` object and passes it to `initializePRReviewWorkflow`
+3. `initializePRReviewWorkspace` resolves the workspace, then creates the worktree inside the target repo
+
+## Configuration
+
+No new environment variables or configuration files required. The existing `--target-repo` and `--clone-url` CLI arguments are sufficient.
+
+## Testing
+
+```bash
+# Run regression scenarios specific to this fix
+bunx cucumber-js --tags "@adw-223"
+
+# Verify no regressions in existing PR review worktree scenarios
+bunx cucumber-js --tags "@adw-217"
+
+# Full regression suite
+bunx cucumber-js --tags "@regression"
+
+# TypeScript type checks
+bunx tsc --noEmit
+bunx tsc --noEmit -p adws/tsconfig.json
+
+# Linter
+bun run lint
+```
+
+## Notes
+
+- Surgical fix: only 2 source files changed (`prReviewPhase.ts`, `adwPrReview.tsx`)
+- The `ensureWorktree` and `ensureTargetRepoWorkspace` functions already supported this use-case — no changes needed there
+- BDD regression scenarios are static source-inspection tests (no runtime side-effects) and will prevent this specific execution path from regressing

--- a/features/step_definitions/wrongRepositoryTargetSteps.ts
+++ b/features/step_definitions/wrongRepositoryTargetSteps.ts
@@ -1,0 +1,197 @@
+import { Given, When, Then } from '@cucumber/cucumber';
+import { readFileSync } from 'fs';
+import { join } from 'path';
+import assert from 'assert';
+import { sharedCtx } from './commonSteps.ts';
+
+const ROOT = process.cwd();
+
+function loadPrReviewPhase(): void {
+  const filePath = 'adws/phases/prReviewPhase.ts';
+  sharedCtx.fileContent = readFileSync(join(ROOT, filePath), 'utf-8');
+  sharedCtx.filePath = filePath;
+}
+
+function loadAdwPrReview(): void {
+  const filePath = 'adws/adwPrReview.tsx';
+  sharedCtx.fileContent = readFileSync(join(ROOT, filePath), 'utf-8');
+  sharedCtx.filePath = filePath;
+}
+
+// ── Context-only Given/When steps ─────────────────────────────────────────────
+
+Given('a PR exists for branch {string} on the vestmatic repository', function (_branch: string) {
+  // Context only — precondition described in scenario prose
+});
+
+Given('the branch does not exist in the ADW repository\'s git history', function () {
+  // Context only — precondition described in scenario prose
+});
+
+Given('adwPrReview.tsx is invoked with {string}', function (_args: string) {
+  loadAdwPrReview();
+});
+
+Given('adwPrReview.tsx is invoked without --target-repo arguments', function () {
+  loadAdwPrReview();
+});
+
+When('initializePRReviewWorkflow runs for PR #{int}', function (_prNumber: number) {
+  loadPrReviewPhase();
+});
+
+When('initializePRReviewWorkflow runs without a targetRepo', function () {
+  loadPrReviewPhase();
+});
+
+// ── Key regression assertions ──────────────────────────────────────────────────
+
+Then('adwPrReview.tsx calls initializePRReviewWorkflow with the targetRepo argument', function () {
+  loadAdwPrReview();
+  const content = sharedCtx.fileContent;
+
+  // The call to initializePRReviewWorkflow must include targetRepo (5th argument or
+  // as a named/positional parameter beyond repoInfo and repoId).
+  // The function should NOT discard targetRepo after parseTargetRepoArgs().
+  assert.ok(
+    content.includes('initializePRReviewWorkflow'),
+    'Expected adwPrReview.tsx to call initializePRReviewWorkflow',
+  );
+
+  // parseTargetRepoArgs must be called to extract targetRepo with cloneUrl
+  assert.ok(
+    content.includes('parseTargetRepoArgs'),
+    'Expected adwPrReview.tsx to call parseTargetRepoArgs to extract --target-repo args',
+  );
+
+  // targetRepo must be forwarded to initializePRReviewWorkflow, not silently discarded.
+  // The call must reference targetRepo in the same expression as initializePRReviewWorkflow.
+  const initCallIdx = content.indexOf('initializePRReviewWorkflow(');
+  assert.ok(initCallIdx !== -1, 'Expected initializePRReviewWorkflow( call site in adwPrReview.tsx');
+
+  // Extract the call expression (roughly up to the closing paren, within ~300 chars)
+  const callSlice = content.slice(initCallIdx, initCallIdx + 300);
+
+  assert.ok(
+    callSlice.includes('targetRepo'),
+    'Expected the initializePRReviewWorkflow() call in adwPrReview.tsx to pass targetRepo as an argument',
+  );
+});
+
+Then('the initializePRReviewWorkflow function signature accepts a targetRepo parameter', function () {
+  loadPrReviewPhase();
+  const content = sharedCtx.fileContent;
+
+  // The function signature must declare a targetRepo parameter
+  const fnSignatureIdx = content.indexOf('function initializePRReviewWorkflow(');
+  assert.ok(fnSignatureIdx !== -1, 'Expected initializePRReviewWorkflow function definition in prReviewPhase.ts');
+
+  // Look at the function declaration (up to 400 chars covers the parameter list)
+  const signatureSlice = content.slice(fnSignatureIdx, fnSignatureIdx + 400);
+
+  assert.ok(
+    signatureSlice.includes('targetRepo') || signatureSlice.includes('TargetRepoInfo'),
+    'Expected initializePRReviewWorkflow signature to include a targetRepo parameter (TargetRepoInfo)',
+  );
+});
+
+Then('initializePRReviewWorkflow imports and calls ensureTargetRepoWorkspace', function () {
+  loadPrReviewPhase();
+  const content = sharedCtx.fileContent;
+
+  assert.ok(
+    content.includes('ensureTargetRepoWorkspace'),
+    'Expected prReviewPhase.ts to import and call ensureTargetRepoWorkspace for target repo workspace setup',
+  );
+
+  // It must be called (not just imported), so look for a call pattern
+  assert.ok(
+    content.includes('ensureTargetRepoWorkspace('),
+    'Expected prReviewPhase.ts to call ensureTargetRepoWorkspace() (not just reference it)',
+  );
+});
+
+Then('ensureWorktree is called with a baseRepoPath derived from the target repo workspace', function () {
+  loadPrReviewPhase();
+  const content = sharedCtx.fileContent;
+
+  // ensureWorktree must be called with at least 3 arguments — the 3rd is baseRepoPath.
+  // A call with only 1 argument (just branchName) indicates the regression.
+  const ensureWorktreeCallIdx = content.indexOf('ensureWorktree(');
+  assert.ok(ensureWorktreeCallIdx !== -1, 'Expected ensureWorktree( call in prReviewPhase.ts');
+
+  // Look at the call (up to 200 chars for the argument list)
+  const callSlice = content.slice(ensureWorktreeCallIdx, ensureWorktreeCallIdx + 200);
+
+  // The call must reference a workspace path variable — not just prDetails.headBranch alone.
+  // Valid patterns: ensureWorktree(branch, undefined, workspacePath) or ensureWorktree(branch, baseBranch, workspacePath)
+  const hasBaseRepoPath =
+    callSlice.includes('targetRepoWorkspacePath') ||
+    callSlice.includes('workspacePath') ||
+    callSlice.includes('baseRepoPath') ||
+    callSlice.includes('targetRepo.workspacePath') ||
+    callSlice.includes('getTargetRepoWorkspacePath');
+
+  assert.ok(
+    hasBaseRepoPath,
+    'Expected ensureWorktree() in prReviewPhase.ts to receive a baseRepoPath argument ' +
+    '(targetRepoWorkspacePath or similar). Without it, git operations run in the ADW ' +
+    'directory instead of the target repo workspace.',
+  );
+});
+
+Then('the worktree is created inside the vestmatic workspace path', function () {
+  const content = sharedCtx.fileContent;
+
+  // The workspace path must be derived from the target repo, not the ADW process directory.
+  // ensureTargetRepoWorkspace or getTargetRepoWorkspacePath must be used.
+  const usesTargetWorkspace =
+    content.includes('ensureTargetRepoWorkspace') ||
+    content.includes('getTargetRepoWorkspacePath') ||
+    content.includes('targetRepoWorkspacePath');
+
+  assert.ok(
+    usesTargetWorkspace,
+    'Expected prReviewPhase.ts to derive the worktree base path from the target repo workspace ' +
+    '(ensureTargetRepoWorkspace / getTargetRepoWorkspacePath), not from process.cwd()',
+  );
+});
+
+Then('the workflow does not fail with {string}', function (_errorMessage: string) {
+  const content = sharedCtx.fileContent;
+
+  // Regression guard: ensureWorktree must receive the target repo workspace path
+  // so that branch lookup succeeds in the correct git repo.
+  const ensureWorktreeCallIdx = content.indexOf('ensureWorktree(');
+  assert.ok(ensureWorktreeCallIdx !== -1, 'Expected ensureWorktree( call in prReviewPhase.ts');
+
+  const callSlice = content.slice(ensureWorktreeCallIdx, ensureWorktreeCallIdx + 200);
+  const hasBaseRepoPath =
+    callSlice.includes('targetRepoWorkspacePath') ||
+    callSlice.includes('workspacePath') ||
+    callSlice.includes('baseRepoPath') ||
+    callSlice.includes('targetRepo.workspacePath') ||
+    callSlice.includes('getTargetRepoWorkspacePath');
+
+  assert.ok(
+    hasBaseRepoPath,
+    'Expected ensureWorktree() to receive a baseRepoPath so branch lookup runs in the correct repo',
+  );
+});
+
+Then('ensureWorktree is called without a baseRepoPath', function () {
+  const content = sharedCtx.fileContent;
+
+  // When no --target-repo is provided, ensureWorktree should use the ADW directory (default).
+  // This is the no-op / backward-compatible path.
+  assert.ok(
+    content.includes('ensureWorktree('),
+    'Expected ensureWorktree( to be present in prReviewPhase.ts',
+  );
+  // Pass-through: the fallback behaviour is preserved when targetRepo is absent
+});
+
+Then('worktree operations remain scoped to the ADW repository directory', function () {
+  // Pass-through — the absence of targetRepo means ensureWorktree uses process.cwd() (ADW dir),
+  // which is correct for ADW's own PRs. Validated implicitly by the guarded ensureTargetRepoWorkspace call.
+});

--- a/features/wrong_repository_target.feature
+++ b/features/wrong_repository_target.feature
@@ -1,0 +1,55 @@
+@adw-223
+Feature: PR review targets the correct repository
+
+  When adwPrReview.tsx is triggered for a PR on a target repository (e.g., vestmatic),
+  it must create the worktree in the target repository's workspace
+  (~/.adw/repos/<owner>/<repo>/), not in the ADW repository directory.
+
+  The root cause of the regression: adwPrReview.tsx extracts a targetRepo (with cloneUrl)
+  from --target-repo CLI args but only forwards repoInfo (owner/repo, no cloneUrl) to
+  initializePRReviewWorkflow. As a result, ensureWorktree is called without baseRepoPath,
+  so all git operations run in the ADW process directory instead of the target repo workspace.
+
+  Background:
+    Given the ADW codebase is checked out
+
+  @adw-223 @regression
+  Scenario: adwPrReview passes targetRepo (with cloneUrl) to initializePRReviewWorkflow
+    Given "adws/adwPrReview.tsx" is read
+    Then adwPrReview.tsx calls initializePRReviewWorkflow with the targetRepo argument
+
+  @adw-223 @regression
+  Scenario: initializePRReviewWorkflow accepts a targetRepo parameter
+    Given "adws/phases/prReviewPhase.ts" is read
+    Then the initializePRReviewWorkflow function signature accepts a targetRepo parameter
+
+  @adw-223 @regression
+  Scenario: initializePRReviewWorkflow calls ensureTargetRepoWorkspace when targetRepo is provided
+    Given "adws/phases/prReviewPhase.ts" is read
+    Then initializePRReviewWorkflow imports and calls ensureTargetRepoWorkspace
+
+  @adw-223 @regression
+  Scenario: ensureWorktree is called with the target repo workspace path as baseRepoPath
+    Given "adws/phases/prReviewPhase.ts" is read
+    Then ensureWorktree is called with a baseRepoPath derived from the target repo workspace
+
+  @adw-223 @regression
+  Scenario: ADW TypeScript type-check passes after the wrong-repo fix
+    Given the ADW codebase is checked out
+    Then the ADW TypeScript type-check passes
+
+  @adw-223
+  Scenario: PR review for a target repo branch does not fail with "Branch does not exist" in the ADW repo
+    Given a PR exists for branch "chore-issue-30-update-adw-settings" on the vestmatic repository
+    And the branch does not exist in the ADW repository's git history
+    And adwPrReview.tsx is invoked with "--target-repo paysdoc/vestmatic"
+    When initializePRReviewWorkflow runs for PR #31
+    Then the worktree is created inside the vestmatic workspace path
+    And the workflow does not fail with "Branch does not exist and no base branch was provided"
+
+  @adw-223
+  Scenario: When no --target-repo is provided, worktree falls back to the ADW directory
+    Given adwPrReview.tsx is invoked without --target-repo arguments
+    When initializePRReviewWorkflow runs without a targetRepo
+    Then ensureWorktree is called without a baseRepoPath
+    And worktree operations remain scoped to the ADW repository directory

--- a/specs/issue-223-adw-ie8l08-wrong-repository-bei-sdlc_planner-fix-pr-review-target-repo.md
+++ b/specs/issue-223-adw-ie8l08-wrong-repository-bei-sdlc_planner-fix-pr-review-target-repo.md
@@ -1,0 +1,130 @@
+# Bug: PR review workflow targets wrong repository for worktree creation
+
+## Metadata
+issueNumber: `223`
+adwId: `ie8l08-wrong-repository-bei`
+issueJson: `{"number":223,"title":"Wrong repository being targeted","body":"The Pr Review is trying to access the wrong repository. It is supposed to be vestmatic but it is looking in AI Developer Workflow.","state":"OPEN","author":"paysdoc","labels":[],"createdAt":"2026-03-17T16:58:18Z"}`
+
+## Bug Description
+When `adwPrReview.tsx` processes a PR from a target repository (e.g., vestmatic), it calls `initializePRReviewWorkflow` which calls `ensureWorktree(prDetails.headBranch)` **without passing the target repository workspace path**. This causes all git commands (branch lookup, worktree creation) to execute against the ADW repository instead of the target repository.
+
+**Symptoms:**
+- `git log "chore-issue-30-update-adw-settings"` fails with "ambiguous argument" because the branch doesn't exist in the ADW repo
+- `ensureWorktree` fails with "Branch does not exist and no base branch was provided"
+- The worktree is attempted at `AI_Dev_Workflow/.worktrees/` instead of the target repo's `.worktrees/`
+
+**Expected behavior:** When processing a PR for vestmatic, all git operations should execute against the vestmatic workspace (e.g., `~/.adw/repos/paysdoc/vestmatic/`).
+
+**Actual behavior:** Git operations execute against the ADW repository's working directory.
+
+## Problem Statement
+`initializePRReviewWorkflow` in `prReviewPhase.ts` does not resolve or thread through the target repository workspace path. While `adwPrReview.tsx` parses `--target-repo` args into `repoInfo` and `repoId`, the `TargetRepoInfo` (with `cloneUrl`) is discarded, and no workspace path is ever computed. The `ensureWorktree` call on line 92 receives no `baseRepoPath`, so all git commands default to the current process directory (ADW repo).
+
+## Solution Statement
+1. Add `targetRepo?: TargetRepoInfo` parameter to `initializePRReviewWorkflow`
+2. When `targetRepo` is provided, call `ensureTargetRepoWorkspace(targetRepo)` to clone/pull the target repo and get its workspace path
+3. Pass the workspace path as `baseRepoPath` to `ensureWorktree`
+4. Pass the full `targetRepo` object from `adwPrReview.tsx` to `initializePRReviewWorkflow`
+
+This mirrors the pattern already established in `workflowInit.ts` (lines 140-168).
+
+## Steps to Reproduce
+1. A PR exists on `paysdoc/vestmatic` (e.g., PR #31 with branch `chore-issue-30-update-adw-settings`)
+2. The cron trigger spawns `adwPrReview.tsx 31 --target-repo paysdoc/vestmatic --clone-url <url>`
+3. `adwPrReview.tsx` parses `--target-repo` but only passes `repoInfo` (owner/repo) to `initializePRReviewWorkflow`
+4. `initializePRReviewWorkflow` calls `ensureWorktree(prDetails.headBranch)` without `baseRepoPath`
+5. Git operations execute against ADW repo → branch not found → crash
+
+## Root Cause Analysis
+This is a recurring class of bugs (see issues #52, #56, #33, #23, #62, #217) where functions operating on external target repos default to the ADW repository's working directory.
+
+**Why it's back:** When `prReviewPhase.ts` was written or last refactored, the `ensureWorktree` call was not updated to receive the target repo workspace path. The regular workflow init (`workflowInit.ts`) was fixed in prior issues to correctly thread `targetRepoWorkspacePath` through to `ensureWorktree` (line 168), but the PR review init path was missed.
+
+**Prior fixes addressed:**
+- Issue #56: Added `baseRepoPath` parameter to worktree functions
+- Issue #52: Threaded `repoInfo` to classifier
+- Issue #217: Added `git fetch` fallback in `createWorktree`
+
+None of these fixes addressed `initializePRReviewWorkflow`'s `ensureWorktree` call specifically.
+
+## Relevant Files
+Use these files to fix the bug:
+
+- `adws/phases/prReviewPhase.ts` — Contains `initializePRReviewWorkflow` with the broken `ensureWorktree` call (line 92). **Primary fix location.**
+- `adws/adwPrReview.tsx` — Entry point that parses `--target-repo` args. Currently discards the full `TargetRepoInfo` and only passes `repoInfo` (owner/repo). Needs to pass `targetRepo` through.
+- `adws/vcs/worktreeCreation.ts` — `ensureWorktree` already supports `baseRepoPath` parameter. No changes needed.
+- `adws/core/targetRepoManager.ts` — `ensureTargetRepoWorkspace` already handles cloning/pulling. Needs to be imported in `prReviewPhase.ts`.
+- `adws/phases/workflowInit.ts` — Reference implementation showing correct target repo workspace handling (lines 140-168).
+- `guidelines/coding_guidelines.md` — Coding guidelines to follow.
+- `features/pr_review_worktree_creation.feature` — Existing BDD feature for PR review worktree creation. Will add new regression scenarios here.
+- `features/step_definitions/prReviewWorktreeFetchSteps.ts` — Existing step definitions. Will add new steps for target repo regression.
+
+## Step by Step Tasks
+
+### 1. Fix `initializePRReviewWorkflow` to accept and use target repo info
+
+- Open `adws/phases/prReviewPhase.ts`
+- Import `ensureTargetRepoWorkspace` from `../core` and `TargetRepoInfo` from `../types/issueTypes`
+- Add `targetRepo?: TargetRepoInfo` parameter to the `initializePRReviewWorkflow` function signature
+- Before the `ensureWorktree` call (line 92), add target repo workspace resolution:
+  ```typescript
+  let targetRepoWorkspacePath: string | undefined;
+  if (targetRepo) {
+    log(`Setting up target repo workspace for ${targetRepo.owner}/${targetRepo.repo}...`, 'info');
+    targetRepoWorkspacePath = ensureTargetRepoWorkspace(targetRepo);
+    log(`Target repo workspace: ${targetRepoWorkspacePath}`, 'success');
+  }
+  ```
+- Change the `ensureWorktree` call to pass the workspace path:
+  ```typescript
+  const worktreePath = ensureWorktree(prDetails.headBranch, undefined, targetRepoWorkspacePath);
+  ```
+
+### 2. Update `adwPrReview.tsx` to pass `targetRepo` to `initializePRReviewWorkflow`
+
+- Open `adws/adwPrReview.tsx`
+- Change the `initializePRReviewWorkflow` call (line 46) to pass the full `targetRepo`:
+  ```typescript
+  const config = await initializePRReviewWorkflow(prNumber, null, repoInfo, repoId, targetRepo ?? undefined);
+  ```
+
+### 3. Add regression BDD scenarios
+
+- Open `features/pr_review_worktree_creation.feature`
+- Add new `@adw-223 @regression` scenarios that verify:
+  1. `initializePRReviewWorkflow` calls `ensureTargetRepoWorkspace` when a target repo is provided
+  2. `ensureWorktree` is called with `baseRepoPath` (not bare) when processing a target repo PR
+  3. The `adwPrReview.tsx` entry point passes the `targetRepo` parameter through to `initializePRReviewWorkflow`
+
+### 4. Add step definitions for new regression scenarios
+
+- Open `features/step_definitions/prReviewWorktreeFetchSteps.ts`
+- Add step definitions that verify:
+  1. `prReviewPhase.ts` imports `ensureTargetRepoWorkspace`
+  2. `prReviewPhase.ts` calls `ensureTargetRepoWorkspace` when `targetRepo` is provided
+  3. `ensureWorktree` is called with a third argument (baseRepoPath) derived from the target repo workspace
+  4. `adwPrReview.tsx` passes `targetRepo` to `initializePRReviewWorkflow`
+
+### 5. Run validation commands
+
+- Run `bunx tsc --noEmit` and `bunx tsc --noEmit -p adws/tsconfig.json` to verify type safety
+- Run `bun run lint` to verify code quality
+- Run `bunx cucumber-js --tags "@adw-223"` to verify new regression scenarios pass
+- Run `bunx cucumber-js --tags "@adw-217"` to verify existing PR review worktree scenarios still pass
+- Run `bunx cucumber-js --tags "@regression"` to verify no regressions across all BDD scenarios
+
+## Validation Commands
+Execute every command to validate the bug is fixed with zero regressions.
+
+- `bunx tsc --noEmit` — Root TypeScript type check
+- `bunx tsc --noEmit -p adws/tsconfig.json` — ADW TypeScript type check
+- `bun run lint` — Linter check
+- `bunx cucumber-js --tags "@adw-223"` — Run new regression scenarios for this fix
+- `bunx cucumber-js --tags "@adw-217"` — Run existing PR review worktree scenarios (no regressions)
+- `bunx cucumber-js --tags "@regression"` — Run all regression scenarios
+
+## Notes
+- This is a **surgical fix** — only 2 source files need changes (`prReviewPhase.ts` and `adwPrReview.tsx`), plus regression tests
+- The fix mirrors the proven pattern in `workflowInit.ts` (lines 140-168) which already handles target repos correctly
+- This is the 7th instance of the "wrong repository" class of bugs (issues #23, #33, #52, #56, #62, #119, #217). The regression BDD scenarios should prevent this specific path from breaking again.
+- Follow `guidelines/coding_guidelines.md` for all changes


### PR DESCRIPTION
## Summary

The PR review workflow was targeting the wrong repository (AI_Dev_Workflow instead of vestmatic). This fix ensures the `targetRepo` is correctly passed through to the PR review workflow.

- Fixes incorrect repository targeting in `adwPrReview.tsx` and `prReviewPhase.ts`
- Adds E2E feature test (`wrong_repository_target.feature`) to prevent regression
- Adds step definitions for the new feature test

## Plan

[ie8l08-wrong-repository-bei](specs/issue-223-adw-ie8l08-wrong-repository-bei-sdlc_planner-fix-pr-review-target-repo.md)

## Changes

- `adws/adwPrReview.tsx` — pass `targetRepo` to PR review workflow initialization
- `adws/phases/prReviewPhase.ts` — accept and use `targetRepo` parameter correctly
- `features/wrong_repository_target.feature` — regression test scenario
- `features/step_definitions/wrongRepositoryTargetSteps.ts` — step definitions for regression tests

## Checklist

- [x] Root cause identified: `targetRepo` was not being passed to the PR review workflow
- [x] Fix applied to `adwPrReview.tsx` and `prReviewPhase.ts`
- [x] Regression tests added via BDD feature file
- [x] Step definitions implemented

Closes #223

---
ADW: ie8l08-wrong-repository-bei