### PR TITLE
bug: #233 - Fix issue number resolution in PR review workflow and serialise cost CSVs

### DIFF
--- a/.adw/conditional_docs.md
+++ b/.adw/conditional_docs.md
@@ -220,3 +220,12 @@
     - When modifying or reviewing the model tier assigned to `/scenario_writer`
     - When adding a new slash command and deciding which model tier to assign
     - When troubleshooting scenario writer producing lower-quality output or using unexpected model
+
+- app_docs/feature-y000tl-fix-issue-number-res-pr-review-issue-number.md
+  - Conditions:
+    - When working with `fetchPRDetails()` or issue number extraction in `adws/github/prApi.ts`
+    - When modifying `extractIssueNumberFromBranch()` in `adws/triggers/webhookHandlers.ts`
+    - When working with `PRReviewWorkflowConfig` or `initializePRReviewWorkflow()` in `adws/phases/prReviewPhase.ts`
+    - When modifying cost CSV writing in `completePRReviewWorkflow()` or `adws/core/costCsvWriter.ts`
+    - When troubleshooting `Could not resolve to an Issue with the number of 0` errors in PR review workflows
+    - When investigating `0-*.csv` cost files or serialised PR review CSV naming

--- a/README.md
+++ b/README.md
@@ -269,10 +269,6 @@ adws/                   # ADW workflow system
 ├── healthCheckChecks.ts
 ├── workflowPhases.ts   # Workflow phase re-exports
 ├── index.ts
-├── healthCheck.tsx
-├── healthCheckChecks.ts
-├── workflowPhases.ts
-├── index.ts
 ├── tsconfig.json
 └── README.md
 app_docs/               # Generated feature documentation

--- a/adws/core/costCsvWriter.ts
+++ b/adws/core/costCsvWriter.ts
@@ -108,6 +108,33 @@ export function parseIssueCostTotal(csvContent: string): number {
   return isNaN(value) ? 0 : value;
 }
 
+/**
+ * Returns the next available serialised CSV path for a PR review cost file.
+ * PR review runs may occur multiple times for the same issue, so each run
+ * gets a unique serial suffix (e.g., `30-update-adw-settings-1.csv`, `-2.csv`).
+ */
+export function getNextSerialCsvPath(repoRoot: string, repoName: string, issueNumber: number, issueTitle: string): string {
+  const basePath = getIssueCsvPath(repoName, issueNumber, issueTitle);
+  const baseName = basePath.replace(/\.csv$/, '');
+  const baseFilename = path.basename(baseName);
+  const projectDir = path.join(repoRoot, 'projects', repoName);
+
+  let maxSerial = 0;
+  if (fs.existsSync(projectDir)) {
+    const escapedBase = baseFilename.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+    const serialPattern = new RegExp(`^${escapedBase}-(\\d+)\\.csv$`);
+    for (const file of fs.readdirSync(projectDir)) {
+      const match = file.match(serialPattern);
+      if (match) {
+        const serial = parseInt(match[1], 10);
+        if (serial > maxSerial) maxSerial = serial;
+      }
+    }
+  }
+
+  return `${baseName}-${maxSerial + 1}.csv`;
+}
+
 /** Writes a per-issue cost CSV file. */
 export function writeIssueCostCsv(
   repoRoot: string,

--- a/adws/core/index.ts
+++ b/adws/core/index.ts
@@ -101,6 +101,7 @@ export type { ProjectCostRow } from './costCsvWriter';
 export {
   getIssueCsvPath,
   getProjectCsvPath,
+  getNextSerialCsvPath,
   formatIssueCostCsv,
   formatProjectCostCsv,
   parseProjectCostCsv,

--- a/adws/github/prApi.ts
+++ b/adws/github/prApi.ts
@@ -5,6 +5,7 @@
 import { execSync } from 'child_process';
 import { PRDetails, PRReviewComment, PRListItem, log } from '../core';
 import { type RepoInfo } from './githubApi';
+import { extractIssueNumberFromBranch } from '../triggers/webhookHandlers';
 
 
 interface RawPRDetails {
@@ -63,9 +64,11 @@ export function fetchPRDetails(prNumber: number, repoInfo: RepoInfo): PRDetails 
     );
     const raw = JSON.parse(json) as RawPRDetails;
 
-    // Extract issue number from PR body (e.g., "Implements #12")
+    // Extract issue number from PR body (e.g., "Implements #12"), falling back to branch name
     const issueMatch = raw.body?.match(/Implements #(\d+)/);
-    const issueNumber = issueMatch ? parseInt(issueMatch[1], 10) : null;
+    const issueNumber = issueMatch
+      ? parseInt(issueMatch[1], 10)
+      : extractIssueNumberFromBranch(raw.headRefName);
 
     return {
       number: raw.number,

--- a/adws/github/workflowCommentsIssue.ts
+++ b/adws/github/workflowCommentsIssue.ts
@@ -9,7 +9,7 @@ import type { ReviewIssue } from '../agents/reviewAgent';
 
 /** Context information for issue workflow comments. */
 export interface WorkflowContext {
-  issueNumber: number;
+  issueNumber: number | null;
   adwId: string;
   branchName?: string;
   issueType?: IssueClassSlashCommand;

--- a/adws/phases/prReviewCompletion.ts
+++ b/adws/phases/prReviewCompletion.ts
@@ -5,7 +5,9 @@
  * pushing branches, posting completion comments, and error handling.
  */
 
-import { log, AgentStateManager, COST_REPORT_CURRENCIES, type ModelUsageMap, buildCostBreakdown, mergeModelUsageMaps, emptyModelUsageMap, persistTokenCounts, writeIssueCostCsv, rebuildProjectCostCsv, OrchestratorId, computeEurRate } from '../core';
+import * as fs from 'fs';
+import * as path from 'path';
+import { log, AgentStateManager, COST_REPORT_CURRENCIES, type ModelUsageMap, buildCostBreakdown, mergeModelUsageMaps, emptyModelUsageMap, persistTokenCounts, getNextSerialCsvPath, formatIssueCostCsv, rebuildProjectCostCsv, OrchestratorId, computeEurRate } from '../core';
 import { BoardStatus } from '../providers/types';
 import { pushBranch, inferIssueTypeFromBranch } from '../vcs';
 import { postPRStageComment } from './phaseCommentHelpers';
@@ -111,15 +113,22 @@ export async function completePRReviewWorkflow(config: PRReviewWorkflowConfig, m
     ctx.costBreakdown = costBreakdown;
 
     // Write cost data to CSV files
-    try {
-      const repoName = config.repoContext!.repoId.repo;
-      const adwRepoRoot = process.cwd();
-      const eurRate = computeEurRate(costBreakdown);
+    if (config.issueNumber) {
+      try {
+        const repoName = config.repoContext!.repoId.repo;
+        const adwRepoRoot = process.cwd();
+        const eurRate = computeEurRate(costBreakdown);
 
-      writeIssueCostCsv(adwRepoRoot, repoName, config.issueNumber, config.prDetails.title, costBreakdown);
-      rebuildProjectCostCsv(adwRepoRoot, repoName, eurRate);
-    } catch (csvError) {
-      log(`Failed to write cost CSV files: ${csvError}`, 'error');
+        const serialRelativePath = getNextSerialCsvPath(adwRepoRoot, repoName, config.issueNumber, config.prDetails.title);
+        const serialFullPath = path.join(adwRepoRoot, serialRelativePath);
+        fs.mkdirSync(path.dirname(serialFullPath), { recursive: true });
+        fs.writeFileSync(serialFullPath, formatIssueCostCsv(costBreakdown), 'utf-8');
+        log(`PR review cost CSV written: ${serialRelativePath}`, 'success');
+
+        rebuildProjectCostCsv(adwRepoRoot, repoName, eurRate);
+      } catch (csvError) {
+        log(`Failed to write cost CSV files: ${csvError}`, 'error');
+      }
     }
   }
 
@@ -133,7 +142,9 @@ export async function completePRReviewWorkflow(config: PRReviewWorkflowConfig, m
   if (repoContext) {
     postPRStageComment(repoContext, prNumber, 'pr_review_pushed', ctx);
     postPRStageComment(repoContext, prNumber, 'pr_review_completed', ctx);
-    await repoContext.issueTracker.moveToStatus(config.issueNumber, BoardStatus.Review);
+    if (config.issueNumber) {
+      await repoContext.issueTracker.moveToStatus(config.issueNumber, BoardStatus.Review);
+    }
   }
 
   AgentStateManager.writeState(orchestratorStatePath, {

--- a/adws/phases/prReviewPhase.ts
+++ b/adws/phases/prReviewPhase.ts
@@ -23,7 +23,7 @@ import { postPRStageComment } from './phaseCommentHelpers';
  */
 export interface PRReviewWorkflowConfig {
   prNumber: number;
-  issueNumber: number;
+  issueNumber: number | null;
   adwId: string;
   prDetails: PRDetails;
   unaddressedComments: PRReviewComment[];
@@ -68,7 +68,7 @@ export async function initializePRReviewWorkflow(prNumber: number, adwId: string
   }
   log(`Found ${unaddressedComments.length} unaddressed review comment(s)`, 'info');
   const logsDir = ensureLogsDirectory(resolvedAdwId);
-  const issueNumber = prDetails.issueNumber || 0;
+  const issueNumber = prDetails.issueNumber;
   const orchestratorStatePath = AgentStateManager.initializeState(resolvedAdwId, OrchestratorId.PrReview);
   log(`State: ${orchestratorStatePath}`, 'info');
   const initialState: Partial<AgentState> = {

--- a/adws/triggers/webhookHandlers.ts
+++ b/adws/triggers/webhookHandlers.ts
@@ -47,16 +47,22 @@ export function extractIssueNumberFromPRBody(body: string | null): number | null
 }
 
 /**
- * Extracts issue number from a branch name using the "issue-N" pattern.
- * Handles both slash-separated (feature/issue-42-slug) and hyphen-separated (bugfix-issue-42-slug) styles.
- * Returns null if no issue pattern is found or input is falsy.
+ * Extracts issue number from a branch name.
+ * Tries the legacy "issue-N" pattern first (e.g., feature/issue-42-slug),
+ * then falls back to the ADW branch format {type}-{issueNumber}-{adwId}-{slug}
+ * (e.g., bugfix-233-y000tl-fix-issue).
+ * Returns null if neither pattern matches or input is falsy.
  */
 export function extractIssueNumberFromBranch(branchName: string | null | undefined): number | null {
   if (!branchName) {
     return null;
   }
-  const match = branchName.match(/issue-(\d+)/);
-  return match ? parseInt(match[1], 10) : null;
+  const legacyMatch = branchName.match(/issue-(\d+)/);
+  if (legacyMatch) {
+    return parseInt(legacyMatch[1], 10);
+  }
+  const adwMatch = branchName.match(/^(?:feat|feature|bug|bugfix|chore|fix|hotfix)-(\d+)-/);
+  return adwMatch ? parseInt(adwMatch[1], 10) : null;
 }
 
 /**

--- a/adws/types/agentTypes.ts
+++ b/adws/types/agentTypes.ts
@@ -135,7 +135,7 @@ export interface AgentState {
   /** Unique ADW session identifier */
   adwId: string;
   /** GitHub issue number being addressed */
-  issueNumber: number;
+  issueNumber: number | null;
   /** Git branch name for the feature/fix */
   branchName?: string;
   /** Path to the implementation plan file */

--- a/app_docs/feature-y000tl-fix-issue-number-res-pr-review-issue-number.md
+++ b/app_docs/feature-y000tl-fix-issue-number-res-pr-review-issue-number.md
@@ -1,0 +1,70 @@
+# Fix PR Review Issue Number Resolution and Serialised Cost CSVs
+
+**ADW ID:** y000tl-fix-issue-number-res
+**Date:** 2026-03-18
+**Specification:** specs/issue-233-adw-y000tl-fix-issue-number-res-sdlc_planner-fix-pr-review-issue-number.md
+
+## Overview
+
+When the PR review workflow completed for PRs without an `Implements #N` link in the body, the issue number defaulted to `0`, causing GitHub API errors (`Could not resolve to an Issue with the number of 0`) and producing cost CSV files named `0-*.csv`. This fix adds a branch-name fallback for issue number extraction, makes the issue number nullable throughout the PR review config, guards downstream consumers, and introduces serialised cost CSV naming so multiple PR review runs for the same issue produce distinct files.
+
+## What Was Built
+
+- Branch-name fallback in `extractIssueNumberFromBranch()` matching the ADW branch format `{type}-{issueNumber}-{adwId}-{slug}`
+- Branch-name fallback wired into `fetchPRDetails()` when the PR body has no `Implements #N` link
+- `PRReviewWorkflowConfig.issueNumber` changed from `number` to `number | null`, removing the `|| 0` coercion
+- Guards on `moveToStatus()` and cost CSV writing in `completePRReviewWorkflow()` that skip when `issueNumber` is `null`
+- New `getNextSerialCsvPath()` function that appends a serial suffix (`-1`, `-2`, …) to PR review cost CSV filenames to prevent overwriting
+
+## Technical Implementation
+
+### Files Modified
+
+- `adws/triggers/webhookHandlers.ts`: Updated `extractIssueNumberFromBranch()` to try the legacy `issue-(\d+)` pattern first, then fall back to the ADW format regex `/^(?:feat|feature|bug|bugfix|chore|fix|hotfix)-(\d+)-/`
+- `adws/github/prApi.ts`: Imported `extractIssueNumberFromBranch` and used it as a fallback in `fetchPRDetails()` when the PR body regex yields no match
+- `adws/phases/prReviewPhase.ts`: Changed `PRReviewWorkflowConfig.issueNumber` to `number | null`; removed `|| 0` from `initializePRReviewWorkflow()`
+- `adws/phases/prReviewCompletion.ts`: Wrapped cost CSV write and `moveToStatus()` calls with `if (config.issueNumber)`; switched from `writeIssueCostCsv()` to serialised path via `getNextSerialCsvPath()` + `fs.writeFileSync()`
+- `adws/core/costCsvWriter.ts`: Added `getNextSerialCsvPath()` function that scans the project directory for existing serial suffixes and returns the next available path
+- `adws/core/index.ts`: Exported `getNextSerialCsvPath` and `formatIssueCostCsv` from the core barrel
+
+### Key Changes
+
+- `extractIssueNumberFromBranch()` now resolves issue numbers from ADW-format branch names (e.g., `bugfix-233-y000tl-fix-issue` → `233`), making it usable in both webhook handlers and `fetchPRDetails()`
+- `PRReviewWorkflowConfig.issueNumber` is `number | null` throughout; the `|| 0` coercion that hid the null is gone
+- `completePRReviewWorkflow()` skips project board updates and CSV writes when no issue number is available, preventing the `#0` API error
+- `getNextSerialCsvPath()` returns `{baseName}-1.csv` on first run, incrementing for subsequent runs — `rebuildProjectCostCsv()` handles these naturally because it splits on the first `-` to extract the issue number prefix
+- The fix is backward-compatible: the legacy `issue-(\d+)` branch pattern is still tried first
+
+## How to Use
+
+The fix is transparent — no configuration changes are required.
+
+1. Create a PR whose branch name follows the ADW format `{type}-{issueNumber}-{adwId}-{slug}` (e.g., `bugfix-233-y000tl-fix-issue`).
+2. Trigger the PR review workflow (via `adwPrReview.tsx` or the cron trigger).
+3. The issue number is now resolved from the branch name automatically when the PR body has no `Implements #N` link.
+4. On completion, the cost CSV is written as `projects/{repo}/{issueNumber}-{slug}-1.csv` (incrementing to `-2.csv`, `-3.csv` on subsequent runs).
+5. If no issue number can be resolved at all, the workflow skips the project board move and cost CSV write instead of erroring.
+
+## Configuration
+
+No new configuration options. Existing `.adw/` project config is unchanged.
+
+## Testing
+
+Run the regression BDD suite:
+
+```sh
+bunx cucumber-js --tags "@regression"
+```
+
+The new feature file `features/fix_pr_review_issue_number.feature` covers:
+- Issue number extraction from ADW-format branch names
+- Null propagation when neither PR body nor branch name yields an issue number
+- Serialised CSV naming (`-1`, `-2` suffixes)
+- Guards that skip board moves and CSV writes for `null` issue numbers
+
+## Notes
+
+- The 13 `0-*.csv` files already present in `projects/AI_Dev_Workflow/` are artefacts of past failed runs; they should be manually removed or ignored.
+- `rebuildProjectCostCsv()` already handles serialised filenames correctly because it splits on the first `-` to extract the issue number prefix — no changes were needed there.
+- No circular dependency is introduced: `prApi.ts` is in `github/` and imports from `triggers/webhookHandlers.ts`; neither module imports from the other's package.

--- a/features/fix_pr_review_issue_number.feature
+++ b/features/fix_pr_review_issue_number.feature
@@ -1,0 +1,82 @@
+@adw-233
+Feature: Fix issue number resolution in PR review workflow and serialise cost CSVs
+
+  When the PR review workflow completes, the issue number must be resolved
+  reliably. If the PR body lacks an "Implements #N" link, extraction falls
+  back to the ADW branch-name format. When no issue number can be resolved,
+  downstream consumers (project board moves, cost CSVs) are safely skipped.
+  PR review cost CSVs use a serialised naming scheme so multiple review
+  iterations for the same issue are grouped and sortable.
+
+  Background:
+    Given the ADW codebase is checked out
+
+  # ── 1: Branch-name fallback for issue number extraction ────────────────────
+
+  @adw-233 @regression
+  Scenario: extractIssueNumberFromBranch matches ADW branch format
+    Given "adws/triggers/webhookHandlers.ts" is read
+    Then extractIssueNumberFromBranch matches ADW-style branches like "feature-42-abcd1234-slug"
+
+  @adw-233 @regression
+  Scenario: extractIssueNumberFromBranch still matches legacy issue-N pattern
+    Given "adws/triggers/webhookHandlers.ts" is read
+    Then extractIssueNumberFromBranch matches legacy branches like "feature/issue-42-slug"
+
+  @adw-233 @regression
+  Scenario: extractIssueNumberFromBranch returns null for non-matching branches
+    Given "adws/triggers/webhookHandlers.ts" is read
+    Then extractIssueNumberFromBranch returns null for "main"
+
+  @adw-233 @regression
+  Scenario: fetchPRDetails falls back to branch name when PR body has no issue link
+    Given "adws/github/prApi.ts" is read
+    Then fetchPRDetails references a branch-name extraction fallback for issueNumber
+
+  # ── 2: Make issue number nullable in PR review config ──────────────────────
+
+  @adw-233 @regression
+  Scenario: PRReviewWorkflowConfig.issueNumber allows null
+    Given "adws/phases/prReviewPhase.ts" is read
+    Then the PRReviewWorkflowConfig issueNumber field accepts null
+
+  @adw-233 @regression
+  Scenario: initializePRReviewWorkflow does not default issueNumber to zero
+    Given "adws/phases/prReviewPhase.ts" is read
+    Then initializePRReviewWorkflow does not contain "issueNumber || 0"
+
+  # ── 3: Guard downstream consumers ─────────────────────────────────────────
+
+  @adw-233 @regression
+  Scenario: completePRReviewWorkflow guards moveToStatus with issueNumber check
+    Given "adws/phases/prReviewCompletion.ts" is read
+    Then moveToStatus is only called when issueNumber is truthy in completePRReviewWorkflow
+
+  @adw-233 @regression
+  Scenario: completePRReviewWorkflow guards cost CSV write with issueNumber check
+    Given "adws/phases/prReviewCompletion.ts" is read
+    Then cost CSV writing is guarded by an issueNumber check in completePRReviewWorkflow
+
+  # ── 4: Serialised cost CSV naming for PR reviews ──────────────────────────
+
+  @adw-233 @regression
+  Scenario: costCsvWriter exports a function to resolve serialised cost CSV path
+    Given "adws/core/costCsvWriter.ts" is read
+    Then the file contains a function for resolving serialised cost CSV paths
+
+  @adw-233 @regression
+  Scenario: Serialised cost CSV path appends a serial number suffix
+    Given "adws/core/costCsvWriter.ts" is read
+    Then the serialised CSV path function appends a numeric serial suffix
+
+  @adw-233 @regression
+  Scenario: rebuildProjectCostCsv correctly parses serialised filenames
+    Given "adws/core/costCsvWriter.ts" is read
+    Then rebuildProjectCostCsv extracts issue number from the first dash-separated segment
+
+  # ── Cross-cutting: Type-check passes ───────────────────────────────────────
+
+  @adw-233 @regression
+  Scenario: TypeScript type-check passes after PR review issue number fix
+    Given the ADW codebase is checked out
+    Then the ADW TypeScript type-check passes

--- a/features/step_definitions/fixPrReviewIssueNumberSteps.ts
+++ b/features/step_definitions/fixPrReviewIssueNumberSteps.ts
@@ -1,0 +1,204 @@
+import { Then } from '@cucumber/cucumber';
+import assert from 'assert';
+import { sharedCtx } from './commonSteps.ts';
+
+// ── 1: Branch-name fallback ────────────────────────────────────────────────
+
+Then(
+  'extractIssueNumberFromBranch matches ADW-style branches like {string}',
+  function (_example: string) {
+    const content = sharedCtx.fileContent;
+    const funcStart = content.indexOf('function extractIssueNumberFromBranch');
+    assert.ok(funcStart !== -1, 'Expected extractIssueNumberFromBranch function');
+    const funcBody = content.slice(funcStart, funcStart + 600);
+    // The function should contain a regex that matches ADW branch format:
+    // {type}-{issueNumber}-{adwId}-{slug} e.g. feature-42-abcd1234-slug
+    const hasAdwPattern =
+      funcBody.includes('feat|feature|bug|bugfix|chore|fix|hotfix') ||
+      funcBody.includes('feat|bug|chore|fix|feature|bugfix|hotfix') ||
+      // Alternatively a more general pattern that captures digits after a type prefix
+      (funcBody.match(/\^?\(?(?:feat|feature|bug|bugfix|chore|fix|hotfix)/) !== null);
+    assert.ok(
+      hasAdwPattern,
+      'Expected extractIssueNumberFromBranch to contain a regex matching ADW branch type prefixes (feat|feature|bug|bugfix|chore|fix|hotfix)',
+    );
+  },
+);
+
+Then(
+  'extractIssueNumberFromBranch matches legacy branches like {string}',
+  function (_example: string) {
+    const content = sharedCtx.fileContent;
+    const funcStart = content.indexOf('function extractIssueNumberFromBranch');
+    assert.ok(funcStart !== -1, 'Expected extractIssueNumberFromBranch function');
+    const funcBody = content.slice(funcStart, funcStart + 600);
+    assert.ok(
+      funcBody.includes('issue-(\\d+)') || funcBody.includes('issue-'),
+      'Expected extractIssueNumberFromBranch to still match the legacy "issue-N" pattern',
+    );
+  },
+);
+
+Then(
+  'extractIssueNumberFromBranch returns null for {string}',
+  function (_branch: string) {
+    const content = sharedCtx.fileContent;
+    const funcStart = content.indexOf('function extractIssueNumberFromBranch');
+    assert.ok(funcStart !== -1, 'Expected extractIssueNumberFromBranch function');
+    const funcBody = content.slice(funcStart, funcStart + 600);
+    // Verify the function returns null when no match is found
+    assert.ok(
+      funcBody.includes('return null'),
+      'Expected extractIssueNumberFromBranch to return null for non-matching inputs',
+    );
+  },
+);
+
+Then(
+  'fetchPRDetails references a branch-name extraction fallback for issueNumber',
+  function () {
+    const content = sharedCtx.fileContent;
+    const funcStart = content.indexOf('function fetchPRDetails');
+    assert.ok(funcStart !== -1, 'Expected fetchPRDetails function in prApi.ts');
+    const funcBody = content.slice(funcStart, funcStart + 1200);
+    // After the body-based extraction, there should be a fallback using branch name
+    const hasBranchFallback =
+      funcBody.includes('headRefName') || funcBody.includes('headBranch');
+    const hasExtractCall =
+      funcBody.includes('extractIssueNumber') ||
+      funcBody.includes('issue') && funcBody.includes('branch');
+    assert.ok(
+      hasBranchFallback && hasExtractCall,
+      'Expected fetchPRDetails to fall back to branch-name extraction when PR body has no issue link',
+    );
+  },
+);
+
+// ── 2: Nullable issue number ───────────────────────────────────────────────
+
+Then('the PRReviewWorkflowConfig issueNumber field accepts null', function () {
+  const content = sharedCtx.fileContent;
+  const interfaceStart = content.indexOf('interface PRReviewWorkflowConfig');
+  assert.ok(interfaceStart !== -1, 'Expected PRReviewWorkflowConfig interface');
+  // Find the closing brace of the interface
+  const interfaceBody = content.slice(interfaceStart, interfaceStart + 600);
+  const issueNumberLine = interfaceBody.split('\n').find(l => l.includes('issueNumber'));
+  assert.ok(issueNumberLine, 'Expected issueNumber field in PRReviewWorkflowConfig');
+  assert.ok(
+    issueNumberLine.includes('null'),
+    `Expected issueNumber to accept null, got: ${issueNumberLine.trim()}`,
+  );
+});
+
+Then(
+  'initializePRReviewWorkflow does not contain {string}',
+  function (forbidden: string) {
+    const content = sharedCtx.fileContent;
+    const funcStart = content.indexOf('function initializePRReviewWorkflow');
+    assert.ok(funcStart !== -1, 'Expected initializePRReviewWorkflow function');
+    const funcBody = content.slice(funcStart, funcStart + 2000);
+    assert.ok(
+      !funcBody.includes(forbidden),
+      `Expected initializePRReviewWorkflow NOT to contain "${forbidden}"`,
+    );
+  },
+);
+
+// ── 3: Guard downstream consumers ──────────────────────────────────────────
+
+Then(
+  'moveToStatus is only called when issueNumber is truthy in completePRReviewWorkflow',
+  function () {
+    const content = sharedCtx.fileContent;
+    const funcStart = content.indexOf('function completePRReviewWorkflow');
+    assert.ok(funcStart !== -1, 'Expected completePRReviewWorkflow function');
+    const funcBody = content.slice(funcStart, funcStart + 2000);
+    // moveToStatus should be preceded by a guard on issueNumber
+    const moveIdx = funcBody.indexOf('moveToStatus');
+    assert.ok(moveIdx !== -1, 'Expected moveToStatus call in completePRReviewWorkflow');
+    // Look for an issueNumber guard in the surrounding context (within 300 chars before)
+    const surroundingBefore = funcBody.slice(Math.max(0, moveIdx - 300), moveIdx);
+    assert.ok(
+      surroundingBefore.includes('issueNumber') ||
+      surroundingBefore.includes('config.issueNumber'),
+      'Expected moveToStatus to be guarded by an issueNumber check',
+    );
+  },
+);
+
+Then(
+  'cost CSV writing is guarded by an issueNumber check in completePRReviewWorkflow',
+  function () {
+    const content = sharedCtx.fileContent;
+    const funcStart = content.indexOf('function completePRReviewWorkflow');
+    assert.ok(funcStart !== -1, 'Expected completePRReviewWorkflow function');
+    const funcBody = content.slice(funcStart, funcStart + 2000);
+    // Cost CSV writing (writeIssueCostCsv or serialised variant) should be guarded
+    const csvWriteIdx = funcBody.indexOf('CostCsv') !== -1
+      ? funcBody.indexOf('CostCsv')
+      : funcBody.indexOf('costCsv');
+    assert.ok(csvWriteIdx !== -1, 'Expected a cost CSV write call in completePRReviewWorkflow');
+    const surroundingBefore = funcBody.slice(Math.max(0, csvWriteIdx - 300), csvWriteIdx);
+    assert.ok(
+      surroundingBefore.includes('issueNumber') ||
+      surroundingBefore.includes('config.issueNumber'),
+      'Expected cost CSV writing to be guarded by an issueNumber check',
+    );
+  },
+);
+
+// ── 4: Serialised cost CSV naming ──────────────────────────────────────────
+
+Then(
+  'the file contains a function for resolving serialised cost CSV paths',
+  function () {
+    const content = sharedCtx.fileContent;
+    // Look for a function related to serialised/serial cost CSV path resolution
+    const hasSerialisedFn =
+      content.includes('Serial') ||
+      content.includes('serial') ||
+      content.includes('nextSerial') ||
+      content.includes('getSerialised') ||
+      content.includes('getSerialized');
+    assert.ok(
+      hasSerialisedFn,
+      'Expected costCsvWriter.ts to contain a function for resolving serialised cost CSV paths',
+    );
+  },
+);
+
+Then(
+  'the serialised CSV path function appends a numeric serial suffix',
+  function () {
+    const content = sharedCtx.fileContent;
+    // The serialised naming function should produce paths like {number}-{slug}-{serial}.csv
+    // Look for the pattern of appending a serial/number suffix
+    const hasSerialSuffix =
+      (content.includes('-${') && content.includes('serial')) ||
+      content.includes('serial}') ||
+      content.includes('Serial') ||
+      // Match a template literal or string concatenation with a serial number
+      content.match(/`[^`]*-\$\{[^}]*serial[^}]*\}[^`]*\.csv`/i) !== null ||
+      content.match(/-\d+\.csv/) !== null;
+    assert.ok(
+      hasSerialSuffix,
+      'Expected the serialised CSV path to append a numeric serial suffix (e.g., {number}-{slug}-{serial}.csv)',
+    );
+  },
+);
+
+Then(
+  'rebuildProjectCostCsv extracts issue number from the first dash-separated segment',
+  function () {
+    const content = sharedCtx.fileContent;
+    const funcStart = content.indexOf('function rebuildProjectCostCsv');
+    assert.ok(funcStart !== -1, 'Expected rebuildProjectCostCsv function');
+    const funcBody = content.slice(funcStart, funcStart + 1000);
+    // The existing parser uses filename.indexOf('-') to split issue number from description
+    // This naturally handles serialised filenames since the first segment is always the issue number
+    assert.ok(
+      funcBody.includes('indexOf') || funcBody.includes('substring') || funcBody.includes('split'),
+      'Expected rebuildProjectCostCsv to parse issue number from the first dash-separated segment of the filename',
+    );
+  },
+);

--- a/specs/issue-233-adw-y000tl-fix-issue-number-res-sdlc_planner-fix-pr-review-issue-number.md
+++ b/specs/issue-233-adw-y000tl-fix-issue-number-res-sdlc_planner-fix-pr-review-issue-number.md
@@ -1,0 +1,135 @@
+# Bug: Fix issue number resolution in PR review workflow and serialise cost CSVs
+
+## Metadata
+issueNumber: `233`
+adwId: `y000tl-fix-issue-number-res`
+issueJson: `{"number":233,"title":"Fix issue number resolution in PR review workflow and serialise cost CSVs","body":"## Problem\n\nWhen the PR review workflow completes, it attempts to move the associated issue on the project board. However, the issue number defaults to `0` when it cannot be extracted from the PR body (`Implements #N` pattern), causing a GitHub API error:\n\n```\ngh: Could not resolve to an Issue with the number of 0.\n```\n\nThis happens because:\n1. `fetchPRDetails()` returns `issueNumber: null` when the PR body has no `Implements #N` link\n2. `initializePRReviewWorkflow()` converts `null` → `0` via `prDetails.issueNumber || 0`\n3. `completePRReviewWorkflow()` passes `0` to `moveToStatus()` and `writeIssueCostCsv()`\n4. The project board GraphQL query fails for issue `#0`\n\nAdditionally, PR review cost CSV files are written with issue number `0` (e.g., `0-chore-30-update-adw-settings.csv`), making them hard to associate with the original issue.\n\n## Required Changes\n\n### 1. Branch-name fallback for issue number extraction\n### 2. Make issue number nullable in PR review config\n### 3. Guard downstream consumers\n### 4. Serialised cost CSV naming for PR reviews","state":"OPEN","author":"paysdoc","labels":[],"createdAt":"2026-03-18T13:18:36Z","comments":[],"actionableComment":null}`
+
+## Bug Description
+When the PR review workflow completes, it calls `moveToStatus()` and `writeIssueCostCsv()` with issue number `0`, because:
+- `fetchPRDetails()` only extracts issue numbers from the PR body (`Implements #N` pattern) — it has no branch-name fallback
+- `initializePRReviewWorkflow()` converts `null` → `0` via `prDetails.issueNumber || 0`
+- `completePRReviewWorkflow()` unconditionally passes `0` to `moveToStatus()` and `writeIssueCostCsv()`
+
+This causes a GitHub API error (`gh: Could not resolve to an Issue with the number of 0`) and produces cost CSV files prefixed with `0-` that cannot be associated with the original issue.
+
+**Expected:** Issue number is resolved from the branch name when the PR body has no `Implements #N` link; operations requiring a valid issue number are skipped when it remains `null`; PR review cost CSVs use serialised names (e.g., `30-update-adw-settings-1.csv`).
+
+**Actual:** Issue number defaults to `0`, project board API fails, cost CSVs are misnamed.
+
+## Problem Statement
+Four connected problems must be fixed:
+1. `fetchPRDetails()` has no branch-name fallback for issue number extraction
+2. `PRReviewWorkflowConfig.issueNumber` is typed `number` and defaults to `0` instead of being nullable
+3. `completePRReviewWorkflow()` calls `moveToStatus()` and `writeIssueCostCsv()` unconditionally
+4. PR review cost CSV files overwrite the original issue CSV instead of using a serial suffix
+
+## Solution Statement
+1. Extend `extractIssueNumberFromBranch()` to also match the ADW branch format (`{type}-{issueNumber}-{adwId}-{slug}`) and use it as a fallback in `fetchPRDetails()`
+2. Change `PRReviewWorkflowConfig.issueNumber` to `number | null` and remove the `|| 0` fallback
+3. Guard `moveToStatus()` and `writeIssueCostCsv()` calls with `if (config.issueNumber)`
+4. Add a `getNextSerialCsvPath()` function and use it when writing cost from `completePRReviewWorkflow()`
+
+## Steps to Reproduce
+1. Create a PR without an `Implements #N` link in the body (or with a body that uses a different pattern)
+2. Add a review comment requesting changes on the PR
+3. Trigger the PR review workflow via `adwPrReview.tsx` or the cron trigger
+4. Observe: `moveToStatus()` fails with `gh: Could not resolve to an Issue with the number of 0`
+5. Observe: cost CSV is written as `0-<slug>.csv` instead of `{issueNumber}-<slug>-{serial}.csv`
+
+## Root Cause Analysis
+The issue number resolution chain has two gaps:
+
+1. **`fetchPRDetails()`** (`adws/github/prApi.ts:67-68`): Only tries `Implements #(\d+)` regex on the PR body. When no match is found, returns `issueNumber: null`. The branch name (`headRefName`) is available in the raw PR details but is not used as a fallback.
+
+2. **`extractIssueNumberFromBranch()`** (`adws/triggers/webhookHandlers.ts:54-60`): Only matches the `issue-(\d+)` pattern (e.g., `feature/issue-42-slug`). Does NOT match the ADW branch format `{type}-{issueNumber}-{adwId}-{slug}` (e.g., `bugfix-233-y000tl-fix-issue`). This function is already used as a fallback in `handlePullRequestEvent()` but NOT in `fetchPRDetails()`.
+
+3. **`initializePRReviewWorkflow()`** (`adws/phases/prReviewPhase.ts:71`): Converts `null` to `0` via `prDetails.issueNumber || 0`, making downstream code unable to distinguish "no issue" from "issue #0".
+
+4. **`completePRReviewWorkflow()`** (`adws/phases/prReviewCompletion.ts:119,136`): Passes `config.issueNumber` (which is `0`) to `writeIssueCostCsv()` and `moveToStatus()` without checking for validity.
+
+Evidence of the problem: the `projects/AI_Dev_Workflow/` directory contains 13 CSV files prefixed with `0-` (e.g., `0-bug-52-issue-classifier-running-on-incorrect-repo.csv`) — all from PR reviews where issue number extraction failed.
+
+## Relevant Files
+Use these files to fix the bug:
+
+- `adws/triggers/webhookHandlers.ts` — Contains `extractIssueNumberFromBranch()` (line 54) which needs to be updated to match the ADW branch format. Also contains the existing fallback chain in `handlePullRequestEvent()` (line 108) which already works correctly — no changes needed there.
+- `adws/github/prApi.ts` — Contains `fetchPRDetails()` (line 56) which needs a branch-name fallback for issue number extraction when the PR body regex fails.
+- `adws/phases/prReviewPhase.ts` — Contains `PRReviewWorkflowConfig` interface (line 24) and `initializePRReviewWorkflow()` (line 45) where `issueNumber` type must change from `number` to `number | null` and the `|| 0` fallback on line 71 must be removed.
+- `adws/phases/prReviewCompletion.ts` — Contains `completePRReviewWorkflow()` (line 105) where `moveToStatus()` and `writeIssueCostCsv()` calls must be guarded with `if (config.issueNumber)`.
+- `adws/core/costCsvWriter.ts` — Contains `writeIssueCostCsv()` (line 112) and `getIssueCsvPath()` (line 20). A new `getNextSerialCsvPath()` function will be added here.
+- `adws/types/workflowTypes.ts` — Contains `PRDetails` interface (line 62) where `issueNumber` is already `number | null` — confirms the type is correct at the source.
+- `guidelines/coding_guidelines.md` — Coding guidelines to follow.
+- `app_docs/feature-trigger-should-commi-f8jwcf-commit-push-cost-csv.md` — Context on cost CSV tracking and commit/push logic.
+
+## Step by Step Tasks
+IMPORTANT: Execute every step in order, top to bottom.
+
+### Step 1: Update `extractIssueNumberFromBranch()` to match ADW branch format
+- In `adws/triggers/webhookHandlers.ts`, update the regex in `extractIssueNumberFromBranch()` (line 58)
+- Current regex: `/issue-(\d+)/` — only matches `feature/issue-42-slug` style
+- Add a second regex for the ADW branch format: `/^(?:feat|feature|bug|bugfix|chore|fix|hotfix)-(\d+)-/`
+- Try the existing `issue-(\d+)` pattern first (backward compatibility), then fall back to the ADW format
+- Return `null` if neither pattern matches
+
+### Step 2: Add branch-name fallback in `fetchPRDetails()`
+- In `adws/github/prApi.ts`, import `extractIssueNumberFromBranch` from `../triggers/webhookHandlers`
+- After the existing PR body regex (line 67-68), if `issueNumber` is `null`, try `extractIssueNumberFromBranch(raw.headRefName)` as a fallback
+- This ensures `PRDetails.issueNumber` is populated whenever the branch name encodes it
+
+### Step 3: Make `PRReviewWorkflowConfig.issueNumber` nullable
+- In `adws/phases/prReviewPhase.ts`, change the `PRReviewWorkflowConfig` interface (line 26): `issueNumber: number` → `issueNumber: number | null`
+- On line 71, change `const issueNumber = prDetails.issueNumber || 0;` to `const issueNumber = prDetails.issueNumber;`
+- Verify that `issueNumber` is used as `number | null` throughout the rest of `initializePRReviewWorkflow()` — the `ctx.issueNumber`, `initialState.issueNumber`, and the returned config should all accept `null`
+
+### Step 4: Guard downstream consumers in `completePRReviewWorkflow()`
+- In `adws/phases/prReviewCompletion.ts`, wrap the `moveToStatus()` call (line 136) with `if (config.issueNumber)`:
+  ```typescript
+  if (config.issueNumber) {
+    await repoContext.issueTracker.moveToStatus(config.issueNumber, BoardStatus.Review);
+  }
+  ```
+- Wrap the `writeIssueCostCsv()` call (line 119) with `if (config.issueNumber)` — but replace it with the serialised cost CSV logic (Step 5)
+
+### Step 5: Add serialised cost CSV naming for PR reviews
+- In `adws/core/costCsvWriter.ts`, add a new exported function `getNextSerialCsvPath()`:
+  ```typescript
+  export function getNextSerialCsvPath(repoRoot: string, repoName: string, issueNumber: number, issueTitle: string): string
+  ```
+  - Get the base CSV path using `getIssueCsvPath(repoName, issueNumber, issueTitle)` (e.g., `projects/repo/30-update-adw-settings.csv`)
+  - Strip the `.csv` extension to get the base name
+  - Scan the project directory for files matching `{base}-{N}.csv` where N is a number
+  - Find the highest existing serial number and return the path with `{base}-{N+1}.csv`
+  - If no serialised files exist, return `{base}-1.csv`
+- In `adws/phases/prReviewCompletion.ts`, update the cost CSV writing block inside `completePRReviewWorkflow()`:
+  - Guard with `if (config.issueNumber)`
+  - Use `getNextSerialCsvPath()` to determine the file path
+  - Write the cost CSV to the serialised path using `fs.writeFileSync()` with `formatIssueCostCsv()`
+  - Import `getNextSerialCsvPath` and `formatIssueCostCsv` from `../core`
+- Verify that `rebuildProjectCostCsv()` correctly parses serialised filenames — the existing parser (line 143-146 of `costCsvWriter.ts`) uses `filename.indexOf('-')` to split at the first dash, extracting the issue number prefix. Since serialised files still start with `{issueNumber}-`, the parser handles them naturally. No changes needed.
+
+### Step 6: Verify type compatibility across the codebase
+- Check that `PRReviewWorkflowConfig.issueNumber: number | null` does not break any call sites:
+  - `executePRReviewPlanPhase()` uses `if (issueNumber)` on line 147 — already handles `null` correctly
+  - `executePRReviewBuildPhase()` uses `issueNumber` only in `AgentStateManager.writeState()` metadata — accepts `null`
+  - `executePRReviewTestPhase()` does not use `issueNumber` — no changes needed
+  - `ctx.issueNumber` in `PRReviewWorkflowContext` — check this type accepts `null`
+- In `adws/github/index.ts`, check what `PRReviewWorkflowContext` expects for `issueNumber` and update if needed
+
+### Step 7: Run validation commands
+- Run the validation commands listed below to confirm the fix is correct and introduces no regressions.
+
+## Validation Commands
+Execute every command to validate the bug is fixed with zero regressions.
+
+- `bun run lint` — Run linter to check for code quality issues
+- `bun run build` — Build the application to verify no build errors
+- `bunx tsc --noEmit` — Type check the main project
+- `bunx tsc --noEmit -p adws/tsconfig.json` — Type check the adws sub-project
+- `bunx cucumber-js --tags "@regression"` — Run regression BDD scenarios
+
+## Notes
+- The `guidelines/coding_guidelines.md` must be followed: prefer pure functions, use type narrowing over `!` assertions, keep files under 300 lines, and use strict null checks.
+- The `extractIssueNumberFromBranch()` function is shared between `webhookHandlers.ts` and now `prApi.ts` — ensure the import does not create a circular dependency. `prApi.ts` is in `github/` and `webhookHandlers.ts` is in `triggers/` — no circular dependency risk.
+- The serialised cost CSV approach is backward-compatible: `rebuildProjectCostCsv()` already splits on the first `-` to extract the issue number, so `30-update-adw-settings-1.csv` correctly yields issue number `30`.
+- No new libraries required.


### PR DESCRIPTION
## Summary

Fixes a bug where the PR review workflow defaults the issue number to `0` when it cannot be extracted from the PR body, causing a GitHub API error when attempting to move the issue on the project board. Also introduces serialised cost CSV naming for PR review runs.

**Plan:** [y000tl-fix-issue-number-res](specs/issue-233-adw-y000tl-fix-issue-number-res-sdlc_planner-fix-pr-review-issue-number.md)

Closes #233

**ADW tracking ID:** y000tl-fix-issue-number-res

## What was done

- [x] Updated `extractIssueNumberFromBranch()` to match ADW branch format (`{type}-{issueNumber}-{adwId}-{slug}`)
- [x] `fetchPRDetails()` now falls back to branch-name extraction when the PR body has no `Implements #N` link
- [x] Changed `PRReviewWorkflowConfig.issueNumber` from `number` to `number | null`; removed the `|| 0` fallback
- [x] Guarded `moveToStatus()` and `writeIssueCostCsv()` in `completePRReviewWorkflow()` so they are skipped when `issueNumber` is `null`
- [x] Added serialised cost CSV naming for PR reviews: `{issueNumber}-{slug}-{serial}.csv` (e.g. `30-update-adw-settings-1.csv`)
- [x] Added BDD feature file and step definitions for the new behaviour

## Key changes

| File | Change |
|------|--------|
| `adws/github/prApi.ts` | Branch-name fallback in `fetchPRDetails()` |
| `adws/triggers/webhookHandlers.ts` | Extended `extractIssueNumberFromBranch()` regex |
| `adws/phases/prReviewPhase.ts` | `issueNumber: number \| null`, removed `\|\| 0` |
| `adws/phases/prReviewCompletion.ts` | Guards for null issue number; serialised CSV name |
| `adws/core/costCsvWriter.ts` | New `resolveNextSerialCostCsvName()` helper |
| `adws/types/agentTypes.ts` | Type updated to `number \| null` |
| `features/fix_pr_review_issue_number.feature` | BDD scenarios |
| `features/step_definitions/fixPrReviewIssueNumberSteps.ts` | Step definitions |