### PR TITLE
bug: #235 - Project board: fall back to GITHUB_PAT when app token cannot access Projects V2

### DIFF
--- a/.adw/conditional_docs.md
+++ b/.adw/conditional_docs.md
@@ -220,3 +220,11 @@
     - When modifying or reviewing the model tier assigned to `/scenario_writer`
     - When adding a new slash command and deciding which model tier to assign
     - When troubleshooting scenario writer producing lower-quality output or using unexpected model
+
+- app_docs/feature-9tknkw-project-board-pat-fallback.md
+  - Conditions:
+    - When working with `moveIssueToStatus()` or `findRepoProjectId()` in `adws/github/projectBoardApi.ts`
+    - When troubleshooting project board status updates that silently skip on user-owned repositories
+    - When the GitHub App token cannot access Projects V2 (user-owned repos like `paysdoc/AI_Dev_Workflow`)
+    - When configuring `GITHUB_PAT` as a fallback for project board GraphQL calls
+    - When investigating why issues remain in "Todo" despite workflow phases completing

--- a/README.md
+++ b/README.md
@@ -26,13 +26,14 @@ bun install
 
 ### 3. Configure Environment
 
-Copy `.env.sample` to `.env` and fill in the required values:
+Copy the root-level `.env.sample` to `.env` and fill in the required values:
 
 ```bash
 cp .env.sample .env
+# Then edit .env with your actual credentials and configuration
 ```
 
-Then edit `.env` with your values:
+Required and optional environment variables (see `.env.sample` for full reference):
 - `GITHUB_REPO_URL` - Your GitHub repository URL
 - `ANTHROPIC_API_KEY` - Your Anthropic API key
 - `CLAUDE_CODE_PATH` - (Optional) Path to Claude CLI, defaults to `claude`
@@ -269,18 +270,14 @@ adws/                   # ADW workflow system
 ├── healthCheckChecks.ts
 ├── workflowPhases.ts   # Workflow phase re-exports
 ├── index.ts
-├── healthCheck.tsx
-├── healthCheckChecks.ts
-├── workflowPhases.ts
-├── index.ts
 ├── tsconfig.json
 └── README.md
 app_docs/               # Generated feature documentation
 bun.lock                # Bun lockfile
 eslint.config.js        # ESLint configuration
 cucumber.js             # Cucumber.js configuration
-features/               # BDD feature files
-└── step_definitions/   # BDD step definitions
+features/               # BDD feature files (Gherkin .feature)
+└── step_definitions/   # Cucumber step definition files (.ts)
 guidelines/
 └── coding_guidelines.md
 projects/               # Cost tracking CSV files per project

--- a/adws/github/projectBoardApi.ts
+++ b/adws/github/projectBoardApi.ts
@@ -5,8 +5,9 @@
 
 import { execSync } from 'child_process';
 import { log } from '../core';
+import { GITHUB_PAT } from '../core/config';
 import { type RepoInfo } from './githubApi';
-import { refreshTokenIfNeeded } from './githubAppAuth';
+import { isGitHubAppConfigured, refreshTokenIfNeeded } from './githubAppAuth';
 
 
 interface ProjectItem {
@@ -225,20 +226,34 @@ export async function moveIssueToStatus(
   targetStatus: string,
   repoInfo: RepoInfo,
 ): Promise<boolean> {
+  let savedToken: string | undefined;
+  let usingPatFallback = false;
   try {
     const { owner, repo } = repoInfo;
 
     refreshTokenIfNeeded(owner, repo);
 
-    const projectId = findRepoProjectId(owner, repo);
+    let projectId = findRepoProjectId(owner, repo);
+
+    // PAT fallback: if app token can't access Projects V2, retry with GITHUB_PAT
+    if (!projectId && isGitHubAppConfigured() && GITHUB_PAT && GITHUB_PAT !== process.env.GH_TOKEN) {
+      log('App token cannot access Projects V2, retrying with GITHUB_PAT', 'info');
+      savedToken = process.env.GH_TOKEN;
+      process.env.GH_TOKEN = GITHUB_PAT;
+      usingPatFallback = true;
+      projectId = findRepoProjectId(owner, repo);
+    }
+
     if (!projectId) {
-      log(`No project linked to ${owner}/${repo}, skipping status update`, 'info');
+      log(`No project linked to ${owner}/${repo}, skipping status update`, 'warn');
       return false;
     }
 
+    const authLabel = usingPatFallback ? 'GITHUB_PAT' : 'app token';
+
     const projectItem = findIssueProjectItem(owner, repo, issueNumber, projectId);
     if (!projectItem) {
-      log(`Issue #${issueNumber} not found in project, skipping status update`, 'info');
+      log(`Issue #${issueNumber} not found in project, skipping status update`, 'warn');
       return false;
     }
 
@@ -250,13 +265,13 @@ export async function moveIssueToStatus(
 
     const statusField = getStatusFieldOptions(projectId);
     if (!statusField) {
-      log(`No Status field found in project, skipping status update`, 'info');
+      log(`No Status field found in project, skipping status update`, 'warn');
       return false;
     }
 
     const matchedOption = matchStatusOption(targetStatus, statusField.options);
     if (!matchedOption) {
-      log(`Status "${targetStatus}" not found in project options, skipping`, 'info');
+      log(`Status "${targetStatus}" not found in project options, skipping`, 'warn');
       return false;
     }
 
@@ -267,10 +282,15 @@ export async function moveIssueToStatus(
     }
 
     updateProjectItemStatus(projectId, projectItem.itemId, statusField.fieldId, matchedOption.id);
-    log(`Moved issue #${issueNumber} to "${matchedOption.name}" on project board`, 'success');
+    log(`Moved issue #${issueNumber} to "${matchedOption.name}" on project board (auth: ${authLabel})`, 'success');
     return true;
   } catch (error) {
     log(`Failed to move issue #${issueNumber} to "${targetStatus}": ${error}`, 'error');
     return false;
+  } finally {
+    // Restore original GH_TOKEN if PAT fallback was used
+    if (usingPatFallback) {
+      process.env.GH_TOKEN = savedToken;
+    }
   }
 }

--- a/app_docs/feature-9tknkw-project-board-pat-fallback.md
+++ b/app_docs/feature-9tknkw-project-board-pat-fallback.md
@@ -1,0 +1,76 @@
+# Project Board PAT Fallback for App Token Failures
+
+**ADW ID:** 9tknkw-project-board-fall-b
+**Date:** 2026-03-18
+**Specification:** specs/issue-235-adw-9tknkw-project-board-fall-b-sdlc_planner-project-board-pat-fallback.md
+
+## Overview
+
+`moveIssueToStatus()` silently failed when the GitHub App installation token could not access Projects V2 on user-owned repositories. This fix adds a PAT fallback in `projectBoardApi.ts`: when the app token returns no project, the function retries with `GITHUB_PAT`, keeping the app token active for all other operations. Log levels for silent-failure paths were also promoted from `info` to `warn`.
+
+## What Was Built
+
+- PAT fallback in `moveIssueToStatus()` — retries `findRepoProjectId()` (and all subsequent project board calls) with `GITHUB_PAT` when the app token returns `null`
+- `GH_TOKEN` swap with guaranteed restoration via `finally` block
+- Auth label logging: successful project board moves now report which auth method was used (`app token` or `GITHUB_PAT`)
+- Log level upgrades from `info` to `warn` for all "skipping status update" paths
+- New BDD scenarios covering PAT fallback behavior added to `features/project_board_pat_fallback.feature`
+
+## Technical Implementation
+
+### Files Modified
+
+- `adws/github/projectBoardApi.ts`: Added `GITHUB_PAT` import, `isGitHubAppConfigured` import, inline PAT fallback logic in `moveIssueToStatus()`, `finally` block for token restoration, and `warn`-level log upgrades
+- `features/project_board_pat_fallback.feature`: New BDD feature file with scenarios for PAT fallback behavior
+- `features/step_definitions/projectBoardPatFallbackSteps.ts`: New step definitions for PAT fallback BDD scenarios
+- `features/harden_project_board_status.feature`: Minor updates to existing project board scenarios
+- `features/step_definitions/hardenProjectBoardStatusSteps.ts`: Additional step definitions
+
+### Key Changes
+
+- When `findRepoProjectId()` returns `null` and GitHub App auth is active (`isGitHubAppConfigured()`) and `GITHUB_PAT` differs from the current `GH_TOKEN`, the function swaps `process.env.GH_TOKEN = GITHUB_PAT` and retries the full operation
+- The PAT remains active for all project board calls within the same `moveIssueToStatus()` invocation (`findIssueProjectItem`, `getStatusFieldOptions`, `updateProjectItemStatus`)
+- The original `GH_TOKEN` is unconditionally restored in a `finally` block so all other `gh` CLI calls (issue comments, PR creation, etc.) continue using the app token
+- "No project linked", "Issue not found in project", "No Status field found", and "Status not found in options" messages are now `warn` level for better observability
+- Condition for PAT fallback: `!projectId && isGitHubAppConfigured() && GITHUB_PAT && GITHUB_PAT !== process.env.GH_TOKEN`
+
+## How to Use
+
+No configuration changes are required. The fallback is automatic when the following conditions are met:
+
+1. `GITHUB_APP_ID`, `GITHUB_APP_SLUG`, and `GITHUB_APP_PRIVATE_KEY_PATH` are set (GitHub App mode is active)
+2. `GITHUB_PAT` is set in `.env` to a user PAT that has access to Projects V2
+3. The workflow runs against a user-owned repository (e.g., `paysdoc/AI_Dev_Workflow`) where App tokens cannot access Projects V2
+
+When the fallback activates, the log will show:
+```
+[info]  App token cannot access Projects V2, retrying with GITHUB_PAT
+[success] Moved issue #235 to "In Progress" on project board (auth: GITHUB_PAT)
+```
+
+## Configuration
+
+| Variable | Description |
+|---|---|
+| `GITHUB_PAT` | User PAT with `project` scope. Used as fallback when app token cannot access Projects V2. Already required for other operations; no new setup needed. |
+
+## Testing
+
+Run the PAT fallback BDD scenarios:
+
+```bash
+bunx cucumber-js --tags "@adw-wrzj5j-harden-project-board"
+```
+
+Run the full regression suite to verify no regressions:
+
+```bash
+bunx cucumber-js --tags "@regression"
+```
+
+## Notes
+
+- This is a targeted fix to `projectBoardApi.ts` only. No changes to the provider layer (`types.ts`, `githubIssueTracker.ts`) were needed since the fallback is internal to the GraphQL calls.
+- The PAT fallback only applies to project board GraphQL operations. All other `gh` CLI calls (comments, PRs, labels) continue using the app token.
+- For org-owned repositories where the GitHub App has the "Projects" org permission enabled, the app token will succeed on the first attempt and the fallback is never triggered.
+- Root cause: GitHub App tokens cannot access Projects V2 on user-owned accounts — the Projects V2 permission only exists at the org level.

--- a/features/harden_project_board_status.feature
+++ b/features/harden_project_board_status.feature
@@ -112,3 +112,25 @@ Feature: Harden project board status propagation
   Scenario: TypeScript type-check passes after project board hardening changes
     Given the ADW codebase is checked out
     Then the ADW TypeScript type-check passes
+
+  # ── F: PAT fallback for user-owned Projects V2 ───────────────────────────────
+
+  @adw-wrzj5j-harden-project-board @regression
+  Scenario: projectBoardApi.ts imports GITHUB_PAT from core config
+    Given "adws/github/projectBoardApi.ts" is read
+    Then the file contains "GITHUB_PAT"
+
+  @adw-wrzj5j-harden-project-board @regression
+  Scenario: projectBoardApi.ts imports isGitHubAppConfigured from githubAppAuth
+    Given "adws/github/projectBoardApi.ts" is read
+    Then the file contains "isGitHubAppConfigured"
+
+  @adw-wrzj5j-harden-project-board @regression
+  Scenario: moveIssueToStatus logs warn level when no project is found
+    Given "adws/github/projectBoardApi.ts" is read
+    Then the "No project linked" log in moveIssueToStatus uses warn level
+
+  @adw-wrzj5j-harden-project-board @regression
+  Scenario: moveIssueToStatus attempts PAT fallback when app token fails
+    Given "adws/github/projectBoardApi.ts" is read
+    Then the file contains "retrying with GITHUB_PAT"

--- a/features/project_board_pat_fallback.feature
+++ b/features/project_board_pat_fallback.feature
@@ -1,0 +1,54 @@
+@adw-9tknkw-project-board-fall-b
+Feature: Project board PAT fallback when app token cannot access Projects V2
+
+  When the GitHub App installation token cannot access Projects V2 (e.g., user-owned
+  projects), moveIssueToStatus should fall back to GITHUB_PAT for project board
+  GraphQL calls. Additionally, non-fatal failure log messages should be promoted
+  from info to warn, and the auth method used should be logged.
+
+  Background:
+    Given the ADW codebase is checked out
+
+  # ── A: PAT fallback mechanism ──────────────────────────────────────────────────
+
+  @adw-9tknkw-project-board-fall-b @regression
+  Scenario: projectBoardApi.ts imports GITHUB_PAT from config
+    Given "adws/github/projectBoardApi.ts" is read
+    Then the file contains "GITHUB_PAT"
+    And the file contains "from '../core/config'"
+
+  @adw-9tknkw-project-board-fall-b @regression
+  Scenario: moveIssueToStatus retries with GITHUB_PAT when findRepoProjectId returns null
+    Given "adws/github/projectBoardApi.ts" is read
+    Then moveIssueToStatus contains a GITHUB_PAT fallback after findRepoProjectId returns null
+
+  @adw-9tknkw-project-board-fall-b @regression
+  Scenario: PAT fallback restores original GH_TOKEN after project board operations
+    Given "adws/github/projectBoardApi.ts" is read
+    Then moveIssueToStatus restores the original GH_TOKEN after PAT fallback
+
+  # ── B: Log level promotion ─────────────────────────────────────────────────────
+
+  @adw-9tknkw-project-board-fall-b @regression
+  Scenario: "No project linked" log message uses warn level
+    Given "adws/github/projectBoardApi.ts" is read
+    Then the "No project linked" log message in moveIssueToStatus uses warn level
+
+  @adw-9tknkw-project-board-fall-b @regression
+  Scenario: "status not found" log messages use warn level
+    Given "adws/github/projectBoardApi.ts" is read
+    Then all status-not-found log messages in moveIssueToStatus use warn level
+
+  # ── C: Auth method logging ─────────────────────────────────────────────────────
+
+  @adw-9tknkw-project-board-fall-b @regression
+  Scenario: moveIssueToStatus logs which auth method was used for project board operations
+    Given "adws/github/projectBoardApi.ts" is read
+    Then moveIssueToStatus logs the auth method used for project board operations
+
+  # ── D: GITHUB_PAT accessible in config ─────────────────────────────────────────
+
+  @adw-9tknkw-project-board-fall-b @regression
+  Scenario: GITHUB_PAT is exported from config.ts
+    Given "adws/core/config.ts" is read
+    Then the file contains "export const GITHUB_PAT"

--- a/features/step_definitions/hardenProjectBoardStatusSteps.ts
+++ b/features/step_definitions/hardenProjectBoardStatusSteps.ts
@@ -53,6 +53,21 @@ Then('the IssueTracker moveToStatus method returns Promise<boolean>', function (
 });
 
 Then(
+  'the {string} log in moveIssueToStatus uses warn level',
+  function (logFragment: string) {
+    const content = sharedCtx.fileContent;
+    const funcStart = content.indexOf('async function moveIssueToStatus');
+    assert.ok(funcStart !== -1, 'Expected "async function moveIssueToStatus" in the file');
+    const funcBody = content.slice(funcStart);
+    const idx = funcBody.indexOf(logFragment);
+    assert.ok(idx !== -1, `Expected log message containing "${logFragment}" in moveIssueToStatus`);
+    const context = funcBody.slice(idx, idx + 200);
+    const hasWarn = context.includes("'warn'") || context.includes('"warn"');
+    assert.ok(hasWarn, `Expected the "${logFragment}" log in moveIssueToStatus to use 'warn' level`);
+  },
+);
+
+Then(
   'refreshTokenIfNeeded is called before findRepoProjectId in moveIssueToStatus',
   function () {
     const content = sharedCtx.fileContent;

--- a/features/step_definitions/projectBoardPatFallbackSteps.ts
+++ b/features/step_definitions/projectBoardPatFallbackSteps.ts
@@ -1,0 +1,134 @@
+import { Then } from '@cucumber/cucumber';
+import assert from 'assert';
+import { sharedCtx } from './commonSteps.ts';
+
+/**
+ * Extracts the moveIssueToStatus function body from the shared file content.
+ */
+function getMoveIssueBody(): string {
+  const content = sharedCtx.fileContent;
+  const funcStart = content.indexOf('async function moveIssueToStatus');
+  if (funcStart === -1) {
+    // Also check for `export async function moveIssueToStatus`
+    const exportStart = content.indexOf('export async function moveIssueToStatus');
+    assert.ok(exportStart !== -1, 'Expected moveIssueToStatus function in projectBoardApi.ts');
+    return content.slice(exportStart);
+  }
+  return content.slice(funcStart);
+}
+
+Then(
+  'moveIssueToStatus contains a GITHUB_PAT fallback after findRepoProjectId returns null',
+  function () {
+    const funcBody = getMoveIssueBody();
+
+    // Must reference GITHUB_PAT somewhere in the function
+    assert.ok(
+      funcBody.includes('GITHUB_PAT'),
+      'Expected moveIssueToStatus to reference GITHUB_PAT for fallback',
+    );
+
+    // findRepoProjectId should appear, and there should be a second attempt or fallback path
+    const firstFind = funcBody.indexOf('findRepoProjectId');
+    assert.ok(firstFind !== -1, 'Expected findRepoProjectId call in moveIssueToStatus');
+
+    // After the first findRepoProjectId, GITHUB_PAT should be referenced (fallback logic)
+    const afterFirstFind = funcBody.slice(firstFind);
+    assert.ok(
+      afterFirstFind.includes('GITHUB_PAT'),
+      'Expected GITHUB_PAT fallback after findRepoProjectId returns null',
+    );
+  },
+);
+
+Then(
+  'moveIssueToStatus restores the original GH_TOKEN after PAT fallback',
+  function () {
+    const funcBody = getMoveIssueBody();
+
+    // The function should save the original GH_TOKEN before swapping
+    const savesOriginal =
+      funcBody.includes('GH_TOKEN') &&
+      (funcBody.includes('originalToken') ||
+        funcBody.includes('savedToken') ||
+        funcBody.includes('prevToken') ||
+        funcBody.includes('originalGhToken') ||
+        // Check for a pattern like: const X = process.env.GH_TOKEN
+        /const\s+\w+\s*=\s*process\.env\.GH_TOKEN/.test(funcBody));
+
+    assert.ok(
+      savesOriginal,
+      'Expected moveIssueToStatus to save the original GH_TOKEN before PAT fallback',
+    );
+  },
+);
+
+Then(
+  'the "No project linked" log message in moveIssueToStatus uses warn level',
+  function () {
+    const funcBody = getMoveIssueBody();
+
+    // Find the "No project linked" log line
+    const noProjectMatch = funcBody.match(/log\([^)]*No project linked[^)]*,\s*'(\w+)'\s*\)/);
+    assert.ok(noProjectMatch, 'Expected a log message containing "No project linked"');
+    assert.strictEqual(
+      noProjectMatch[1],
+      'warn',
+      `Expected "No project linked" log level to be 'warn', got '${noProjectMatch[1]}'`,
+    );
+  },
+);
+
+Then(
+  'all status-not-found log messages in moveIssueToStatus use warn level',
+  function () {
+    const funcBody = getMoveIssueBody();
+
+    // Check "No Status field found" log
+    const noFieldMatch = funcBody.match(/log\([^)]*No Status field[^)]*,\s*'(\w+)'\s*\)/);
+    if (noFieldMatch) {
+      assert.strictEqual(
+        noFieldMatch[1],
+        'warn',
+        `Expected "No Status field" log level to be 'warn', got '${noFieldMatch[1]}'`,
+      );
+    }
+
+    // Check "not found in project options" log
+    const notFoundMatch = funcBody.match(/log\([^)]*not found in project options[^)]*,\s*'(\w+)'\s*\)/);
+    if (notFoundMatch) {
+      assert.strictEqual(
+        notFoundMatch[1],
+        'warn',
+        `Expected "not found in project options" log level to be 'warn', got '${notFoundMatch[1]}'`,
+      );
+    }
+
+    // At least one of the patterns must exist
+    assert.ok(
+      noFieldMatch || notFoundMatch,
+      'Expected at least one status-not-found log message in moveIssueToStatus',
+    );
+  },
+);
+
+Then(
+  'moveIssueToStatus logs the auth method used for project board operations',
+  function () {
+    const funcBody = getMoveIssueBody();
+
+    // Should log something about which auth method is being used (app token, PAT, fallback, etc.)
+    const hasAuthLog =
+      funcBody.includes('app token') ||
+      funcBody.includes('App token') ||
+      funcBody.includes('PAT') ||
+      funcBody.includes('personal access token') ||
+      funcBody.includes('fallback') ||
+      funcBody.includes('auth method');
+
+    assert.ok(
+      hasAuthLog,
+      'Expected moveIssueToStatus to log the auth method used (app token, PAT, or fallback)',
+    );
+  },
+);

--- a/specs/issue-235-adw-9tknkw-project-board-fall-b-sdlc_planner-project-board-pat-fallback.md
+++ b/specs/issue-235-adw-9tknkw-project-board-fall-b-sdlc_planner-project-board-pat-fallback.md
@@ -1,0 +1,117 @@
+# Bug: Project board falls back to GITHUB_PAT when app token cannot access Projects V2
+
+## Metadata
+issueNumber: `235`
+adwId: `9tknkw-project-board-fall-b`
+issueJson: `{"number":235,"title":"Project board: fall back to GITHUB_PAT when app token cannot access Projects V2","body":"## Problem\n\n`moveIssueToStatus()` in `projectBoardApi.ts` silently fails when the GitHub App installation token cannot see Projects V2. This happens because:\n\n1. **User-owned projects** (e.g., `paysdoc/AI_Dev_Workflow`) are not accessible via GitHub App tokens — the Projects V2 org permission does not apply to user accounts\n2. The `findRepoProjectId()` GraphQL query returns `nodes: []` with the app token but correctly returns the project with a user PAT\n3. The failure is logged at `info` level (\"No project linked to...\") and returns `false` — callers ignore the return value\n\nThis causes issues to remain stuck in \"Todo\" despite completing workflow phases.\n\n## Proposed Solution\n\nIn `projectBoardApi.ts`, when `GH_TOKEN` is set (app token) and `findRepoProjectId` returns null, temporarily swap to `GITHUB_PAT` for the project board GraphQL calls and retry. This keeps the app token as primary auth for all other operations while ensuring project board updates work for user-owned projects.\n\nAdditionally:\n- Promote \"No project linked\" and \"status not found\" log messages from `info` to `warn`\n- Log which auth method was used for project board operations to aid debugging\n\n## Files to Change\n\n- `adws/github/projectBoardApi.ts` — add PAT fallback in `moveIssueToStatus`, upgrade log levels\n- `adws/core/config.ts` — ensure `GITHUB_PAT` is accessible for fallback\n\n## Context\n\n- Confirmed via direct test: app token returns `{\"nodes\":[]}` for `repository.projectsV2`, user token returns the project\n- `paysdoc` is a User account (not an Org), so the \"Projects\" V2 org permission cannot help here\n- For org-owned repos like `vestmatic`, the app's \"Projects\" org permission can be enabled separately\n- Related to issue #233 where the plan phase completed but the issue stayed in \"Todo\"","state":"OPEN","author":"paysdoc","labels":[],"createdAt":"2026-03-18T13:39:38Z","comments":[],"actionableComment":null}`
+
+## Bug Description
+`moveIssueToStatus()` in `projectBoardApi.ts` silently fails when the GitHub App installation token (`GH_TOKEN`) cannot see Projects V2. The `findRepoProjectId()` GraphQL query returns `nodes: []` with the app token but correctly returns the project with a user PAT (`GITHUB_PAT`). The failure is logged at `info` level ("No project linked to...") and returns `false`, so callers silently skip the update. This causes issues to remain stuck in "Todo" despite completing workflow phases.
+
+**Expected behavior**: Issue moves to the correct project board column (e.g., "In Progress", "Building", "Review") as the workflow progresses.
+
+**Actual behavior**: Issue stays in "Todo" because the app token cannot access user-owned Projects V2, and no fallback to `GITHUB_PAT` is attempted.
+
+## Problem Statement
+GitHub App installation tokens cannot access Projects V2 on user-owned accounts (the Projects V2 org permission does not apply to user accounts). When `GH_TOKEN` is set (app token mode), `findRepoProjectId()` returns `null` for user-owned repos like `paysdoc/AI_Dev_Workflow`, and `moveIssueToStatus` logs at `info` level and returns `false` without attempting `GITHUB_PAT` as a fallback.
+
+## Solution Statement
+In `moveIssueToStatus()`, when `GH_TOKEN` is set (app token) and `findRepoProjectId()` returns `null`, temporarily swap `GH_TOKEN` to the value of `GITHUB_PAT` for the project board GraphQL calls and retry. If the PAT succeeds, continue using it for the remaining project board operations within that call. Restore the original `GH_TOKEN` after the operation completes. Additionally, promote "No project linked" and "status not found" log messages from `info` to `warn`, and log which auth method was used.
+
+## Steps to Reproduce
+1. Configure a GitHub App with `GITHUB_APP_ID`, `GITHUB_APP_SLUG`, `GITHUB_APP_PRIVATE_KEY_PATH`
+2. Set `GITHUB_PAT` in `.env` to a user PAT that can access the Projects V2
+3. Run a workflow on a user-owned repo (e.g., `paysdoc/AI_Dev_Workflow`)
+4. Observe that `moveIssueToStatus` logs "No project linked to paysdoc/AI_Dev_Workflow" at `info` level
+5. The issue remains in "Todo" on the project board
+
+## Root Cause Analysis
+The `gh` CLI uses `GH_TOKEN` from `process.env` for authentication. When GitHub App auth is active, `GH_TOKEN` is set to the app's installation token (see `githubAppAuth.ts:196`). This token can perform most GitHub API operations, but GitHub App tokens cannot access Projects V2 on user-owned accounts — only org-level "Projects" permissions exist. The `findRepoProjectId()` GraphQL query returns `{nodes:[]}` with the app token, causing `moveIssueToStatus` to early-return `false` with an `info`-level log. No fallback to `GITHUB_PAT` is attempted.
+
+## Relevant Files
+Use these files to fix the bug:
+
+- `adws/github/projectBoardApi.ts` — Main file to modify. Contains `moveIssueToStatus()` and all helper functions (`findRepoProjectId`, `findIssueProjectItem`, `getStatusFieldOptions`, `updateProjectItemStatus`). The PAT fallback logic goes here.
+- `adws/core/config.ts` — Already exports `GITHUB_PAT` (line 58). Import it in `projectBoardApi.ts` for fallback auth.
+- `adws/github/githubAppAuth.ts` — Contains `isGitHubAppConfigured()` which we'll use to detect app token mode. Already imported `refreshTokenIfNeeded` but need `isGitHubAppConfigured`.
+- `features/harden_project_board_status.feature` — Existing BDD feature file for project board status. Add new scenarios for PAT fallback behavior.
+- `features/step_definitions/hardenProjectBoardStatusSteps.ts` — Existing step definitions. Add new steps for PAT fallback scenarios.
+- `app_docs/feature-wrzj5j-harden-project-board-status.md` — Existing docs on project board hardening for context.
+
+## Step by Step Tasks
+IMPORTANT: Execute every step in order, top to bottom.
+
+### Step 1: Add PAT fallback logic to `projectBoardApi.ts`
+
+- Import `GITHUB_PAT` from `../core/config` at the top of the file
+- Import `isGitHubAppConfigured` from `./githubAppAuth` (add to existing import)
+- Create a helper function `withPatFallback<T>(fn: () => T): T` that:
+  - Calls `fn()` first with the current `GH_TOKEN`
+  - If the result is `null` (project not found), and `process.env.GH_TOKEN` is set (app token mode), and `GITHUB_PAT` is available and differs from `process.env.GH_TOKEN`:
+    - Save the current `GH_TOKEN`
+    - Set `process.env.GH_TOKEN = GITHUB_PAT`
+    - Log that we're retrying with PAT: `log('App token cannot access Projects V2, retrying with GITHUB_PAT', 'info')`
+    - Call `fn()` again
+    - Restore the original `GH_TOKEN` in a `finally` block (critical — other `gh` CLI calls must keep the app token)
+    - Return the result
+  - If PAT is not available, return the original `null` result
+- In `moveIssueToStatus()`, wrap the `findRepoProjectId()` call with `withPatFallback`:
+  - Replace `const projectId = findRepoProjectId(owner, repo);` with `const projectId = withPatFallback(() => findRepoProjectId(owner, repo));`
+  - If the PAT fallback succeeded (i.e., projectId is not null after retry), save the original `GH_TOKEN` and set `process.env.GH_TOKEN = GITHUB_PAT` for the remaining calls in this function (`findIssueProjectItem`, `getStatusFieldOptions`, `updateProjectItemStatus`), and restore in a `finally` block
+- Simplification: Instead of the generic `withPatFallback` approach, use a simpler inline pattern in `moveIssueToStatus`:
+  - After `findRepoProjectId` returns `null`, check if PAT fallback is possible
+  - If yes, swap `GH_TOKEN`, retry, and keep PAT active for the rest of the function
+  - Restore original `GH_TOKEN` in the outer `finally` block
+- Log which auth method was used for the successful project board update: `log(\`Moved issue #\${issueNumber} to "\${matchedOption.name}" on project board (auth: \${authLabel})\`, 'success')`
+
+### Step 2: Upgrade log levels from `info` to `warn`
+
+In `moveIssueToStatus()`:
+- Change `log(\`No project linked to \${owner}/\${repo}, skipping status update\`, 'info')` → `'warn'`
+- Change `log(\`Issue #\${issueNumber} not found in project, skipping status update\`, 'info')` → `'warn'`
+- Change `log(\`No Status field found in project, skipping status update\`, 'info')` → `'warn'`
+- Change `log(\`Status "\${targetStatus}" not found in project options, skipping\`, 'info')` → `'warn'`
+- Keep the "already in status" messages at `info` level (these are informational, not warning-worthy)
+
+### Step 3: Add BDD scenarios for PAT fallback
+
+In `features/harden_project_board_status.feature`, add new scenarios under a PAT fallback section:
+
+- Scenario: `projectBoardApi.ts imports GITHUB_PAT from core config`
+  - Given "adws/github/projectBoardApi.ts" is read
+  - Then the file contains "GITHUB_PAT"
+- Scenario: `projectBoardApi.ts imports isGitHubAppConfigured from githubAppAuth`
+  - Given "adws/github/projectBoardApi.ts" is read
+  - Then the file contains "isGitHubAppConfigured"
+- Scenario: `moveIssueToStatus logs warn level when no project is found`
+  - Given "adws/github/projectBoardApi.ts" is read
+  - Then the "No project linked" log in moveIssueToStatus uses warn level
+- Scenario: `moveIssueToStatus attempts PAT fallback when app token fails`
+  - Given "adws/github/projectBoardApi.ts" is read
+  - Then the file contains "retrying with GITHUB_PAT"
+
+Add corresponding step definitions in `features/step_definitions/hardenProjectBoardStatusSteps.ts` for any new steps not covered by existing generic steps (like "the file contains").
+
+### Step 4: Run validation commands
+
+- Run `bun run lint` — verify no lint errors
+- Run `bunx tsc --noEmit` — verify root TypeScript compiles
+- Run `bunx tsc --noEmit -p adws/tsconfig.json` — verify adws TypeScript compiles
+- Run `bunx cucumber-js --tags "@adw-wrzj5j-harden-project-board"` — verify existing + new BDD scenarios pass
+- Run `bunx cucumber-js --tags "@regression"` — verify no regressions
+
+## Validation Commands
+Execute every command to validate the bug is fixed with zero regressions.
+
+- `bun run lint` — Run linter to check for code quality issues
+- `bunx tsc --noEmit` — Root TypeScript type-check
+- `bunx tsc --noEmit -p adws/tsconfig.json` — ADW TypeScript type-check
+- `bunx cucumber-js --tags "@adw-wrzj5j-harden-project-board"` — Run existing + new project board BDD scenarios
+- `bunx cucumber-js --tags "@regression"` — Run all regression scenarios to verify no regressions
+
+## Notes
+- `GITHUB_PAT` is already exported from `adws/core/config.ts` (line 58) — no changes needed there.
+- The `GH_TOKEN` swap must be wrapped in a `try/finally` to guarantee restoration, since all other `gh` CLI calls (issue comments, PR creation, etc.) must continue using the app token.
+- The PAT fallback is only attempted when both conditions are true: (1) `GH_TOKEN` is set (app token mode), and (2) `GITHUB_PAT` is available and different from `GH_TOKEN`. If `GITHUB_PAT` is not set or equals the current `GH_TOKEN`, the fallback is skipped.
+- This is a targeted fix to `projectBoardApi.ts` only — no changes needed to the provider layer (`types.ts`, `githubIssueTracker.ts`) since the fallback is internal to the GraphQL calls.
+- Strictly adhere to the coding guidelines in `guidelines/coding_guidelines.md`.


### PR DESCRIPTION
## Summary

Fixes silent failures in `moveIssueToStatus()` when the GitHub App installation token cannot access Projects V2 on user-owned repositories (e.g. `paysdoc/AI_Dev_Workflow`).

**Root cause**: GitHub App tokens cannot access user-owned Projects V2 — the org-level \"Projects\" permission only applies to organization accounts. The `findRepoProjectId()` GraphQL query returns `nodes: []` with an app token, causing issues to silently remain in \"Todo\" despite workflow phases completing.

**Fix**: When `GH_TOKEN` (app token) is set and `findRepoProjectId` returns null, fall back to `GITHUB_PAT` for project board GraphQL calls and retry. All other operations continue to use the app token as primary auth.

Additional improvements:
- Promote \"No project linked\" and \"status not found\" log messages from `info` to `warn`
- Log which auth method was used for project board operations

## Implementation Plan

[specs/issue-235-adw-9tknkw-project-board-fall-b-sdlc_planner-project-board-pat-fallback.md](specs/issue-235-adw-9tknkw-project-board-fall-b-sdlc_planner-project-board-pat-fallback.md)

## Changes

- `adws/github/projectBoardApi.ts` — PAT fallback logic in `moveIssueToStatus`, upgraded log levels
- `features/project_board_pat_fallback.feature` — BDD scenarios for PAT fallback behaviour
- `features/harden_project_board_status.feature` — additional hardening scenarios
- `features/step_definitions/projectBoardPatFallbackSteps.ts` — step definitions
- `features/step_definitions/hardenProjectBoardStatusSteps.ts` — step definitions
- `README.md` — updated docs

## Checklist

- [x] PAT fallback added to `moveIssueToStatus` when app token returns no project
- [x] Log levels upgraded for silent failure paths
- [x] Auth method logged for debugging
- [x] BDD feature files and step definitions added
- [x] README updated

Closes #235

---
ADW: `9tknkw-project-board-fall-b`