### PR TITLE
chore: #343 - fix parseOwnerRepoFromUrl for dotted repo names

### DIFF
--- a/adws/providers/__tests__/repoContext.test.ts
+++ b/adws/providers/__tests__/repoContext.test.ts
@@ -1,0 +1,84 @@
+import { describe, it, expect } from 'vitest';
+import { parseOwnerRepoFromUrl } from '../repoContext';
+
+describe('parseOwnerRepoFromUrl', () => {
+  describe('HTTPS URLs', () => {
+    it('parses standard repo name', () => {
+      expect(parseOwnerRepoFromUrl('https://github.com/paysdoc/AI_Dev_Workflow')).toEqual({
+        owner: 'paysdoc',
+        repo: 'AI_Dev_Workflow',
+      });
+    });
+
+    it('parses standard repo name with .git suffix', () => {
+      expect(parseOwnerRepoFromUrl('https://github.com/paysdoc/AI_Dev_Workflow.git')).toEqual({
+        owner: 'paysdoc',
+        repo: 'AI_Dev_Workflow',
+      });
+    });
+
+    it('parses dotted repo name', () => {
+      expect(parseOwnerRepoFromUrl('https://github.com/paysdoc/paysdoc.nl')).toEqual({
+        owner: 'paysdoc',
+        repo: 'paysdoc.nl',
+      });
+    });
+
+    it('parses dotted repo name with .git suffix', () => {
+      expect(parseOwnerRepoFromUrl('https://github.com/paysdoc/paysdoc.nl.git')).toEqual({
+        owner: 'paysdoc',
+        repo: 'paysdoc.nl',
+      });
+    });
+
+    it('parses repo name with multiple dots', () => {
+      expect(parseOwnerRepoFromUrl('https://github.com/org/api.v2.staging.git')).toEqual({
+        owner: 'org',
+        repo: 'api.v2.staging',
+      });
+    });
+  });
+
+  describe('SSH URLs', () => {
+    it('parses standard repo name', () => {
+      expect(parseOwnerRepoFromUrl('git@github.com:paysdoc/AI_Dev_Workflow')).toEqual({
+        owner: 'paysdoc',
+        repo: 'AI_Dev_Workflow',
+      });
+    });
+
+    it('parses standard repo name with .git suffix', () => {
+      expect(parseOwnerRepoFromUrl('git@github.com:paysdoc/AI_Dev_Workflow.git')).toEqual({
+        owner: 'paysdoc',
+        repo: 'AI_Dev_Workflow',
+      });
+    });
+
+    it('parses dotted repo name', () => {
+      expect(parseOwnerRepoFromUrl('git@github.com:paysdoc/paysdoc.nl')).toEqual({
+        owner: 'paysdoc',
+        repo: 'paysdoc.nl',
+      });
+    });
+
+    it('parses dotted repo name with .git suffix', () => {
+      expect(parseOwnerRepoFromUrl('git@github.com:paysdoc/paysdoc.nl.git')).toEqual({
+        owner: 'paysdoc',
+        repo: 'paysdoc.nl',
+      });
+    });
+
+    it('parses repo name with multiple dots', () => {
+      expect(parseOwnerRepoFromUrl('git@github.com:org/api.v2.staging.git')).toEqual({
+        owner: 'org',
+        repo: 'api.v2.staging',
+      });
+    });
+  });
+
+  describe('edge cases', () => {
+    it('returns null for unrecognised URL format', () => {
+      expect(parseOwnerRepoFromUrl('not-a-url')).toBeNull();
+    });
+  });
+});

--- a/adws/providers/repoContext.ts
+++ b/adws/providers/repoContext.ts
@@ -140,9 +140,9 @@ export function parseOwnerRepoFromUrl(
   remoteUrl: string,
 ): { owner: string; repo: string } | null {
   // HTTPS: https://hostname/owner/repo.git or https://hostname/owner/repo
-  const httpsMatch = remoteUrl.match(/https?:\/\/[^/]+\/([^/]+)\/([^/.]+)/);
+  const httpsMatch = remoteUrl.match(/https?:\/\/[^/]+\/([^/]+)\/([^/]+?)(?:\.git)?\/?$/);
   // SSH: git@hostname:owner/repo.git or git@hostname:owner/repo
-  const sshMatch = remoteUrl.match(/git@[^:]+:([^/]+)\/([^/.]+)/);
+  const sshMatch = remoteUrl.match(/git@[^:]+:([^/]+)\/([^/]+?)(?:\.git)?\/?$/);
   const match = httpsMatch || sshMatch;
   if (!match) return null;
   return { owner: match[1], repo: match[2] };

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -2,6 +2,6 @@ import { defineConfig } from 'vitest/config';
 
 export default defineConfig({
   test: {
-    include: ['adws/cost/__tests__/**/*.test.ts'],
+    include: ['adws/**/__tests__/**/*.test.ts'],
   },
 });


### PR DESCRIPTION
Use greedy match with explicit .git suffix strip so repo names containing dots (e.g. paysdoc.nl) are captured in full. Broaden vitest include glob to cover all adws unit tests. Add unit tests for HTTPS and SSH URLs with dotted/multi-dot names.