### PR TITLE
fix: restore reverted upgrade-claim/#UPG hardening (94059b5)

### DIFF
--- a/adws/core/__tests__/upgradeClaim.integration.test.ts
+++ b/adws/core/__tests__/upgradeClaim.integration.test.ts
@@ -13,7 +13,12 @@ import * as fs from 'fs';
 import * as os from 'os';
 import * as path from 'path';
 import { execSync } from 'child_process';
-import { claimUpgradeOrFindExisting, buildClaimBranchName, type UpgradeClaimDeps } from '../upgradeClaim';
+import {
+  claimUpgradeOrFindExisting,
+  buildClaimBranchName,
+  defaultPushClaimBranch,
+  type UpgradeClaimDeps,
+} from '../upgradeClaim';
 import type { RepoInfo } from '../../github/githubApi';
 
 const REPO_INFO: RepoInfo = { owner: 'sandbox', repo: 'target' };
@@ -50,78 +55,14 @@ function createClone(name: string): string {
 }
 
 /**
- * Builds a pushClaimBranch that uses real git operations but fetches from the
- * bare repo using 'main' as the default branch (avoiding the gh CLI call in
- * getDefaultBranch which requires a real GitHub remote).
+ * Wraps the REAL defaultPushClaimBranch against the sandbox clone, injecting a fixed
+ * default branch so it does not shell out to `gh repo view`. Exercising the real function
+ * (instead of a hand-copied reimplementation) is the whole point — the copy is what let the
+ * original `git checkout -b` collision and process.cwd() target-repo bugs pass the suite.
  */
 function makeRealPushClaimBranch(clonePath: string, defaultBranch: string) {
-  return function pushClaimBranch(branchName: string, hash: string): boolean {
-    execSync(`git fetch origin "${defaultBranch}"`, { stdio: 'pipe', cwd: clonePath });
-
-    const tmpdir = fs.mkdtempSync(path.join(os.tmpdir(), 'adw-claim-integ-'));
-    try {
-      execSync(
-        `git worktree add --detach "${tmpdir}" "origin/${defaultBranch}"`,
-        { stdio: 'pipe', cwd: clonePath },
-      );
-      execSync(`git checkout -b "${branchName}"`, {
-        stdio: 'pipe',
-        cwd: tmpdir,
-        env: {
-          ...process.env,
-          GIT_AUTHOR_NAME: 'test',
-          GIT_AUTHOR_EMAIL: 'test@test.com',
-          GIT_COMMITTER_NAME: 'test',
-          GIT_COMMITTER_EMAIL: 'test@test.com',
-        },
-      });
-
-      const nonce = Math.random().toString(36).slice(2, 10);
-      execSync(
-        `git commit --allow-empty -m "ADW upgrade in progress: ${hash} [${nonce}]"`,
-        {
-          stdio: 'pipe',
-          cwd: tmpdir,
-          env: {
-            ...process.env,
-            GIT_AUTHOR_NAME: 'test',
-            GIT_AUTHOR_EMAIL: 'test@test.com',
-            GIT_COMMITTER_NAME: 'test',
-            GIT_COMMITTER_EMAIL: 'test@test.com',
-          },
-        },
-      );
-
-      try {
-        execSync(`git push origin "${branchName}"`, { stdio: 'pipe', cwd: tmpdir });
-        return true;
-      } catch (pushErr) {
-        const buf = (pushErr as { stderr?: Buffer | string }).stderr;
-        const msg = buf instanceof Buffer ? buf.toString() : (typeof buf === 'string' ? buf : String(pushErr));
-        const lower = msg.toLowerCase();
-        if (
-          lower.includes('rejected') ||
-          lower.includes('non-fast-forward') ||
-          lower.includes('failed to push some refs') ||
-          lower.includes('already exists')
-        ) {
-          return false;
-        }
-        throw pushErr;
-      }
-    } finally {
-      try {
-        execSync(`git worktree remove --force "${tmpdir}"`, { stdio: 'pipe', cwd: clonePath });
-      } catch {
-        // best-effort
-      }
-      try {
-        fs.rmSync(tmpdir, { recursive: true, force: true });
-      } catch {
-        // best-effort
-      }
-    }
-  };
+  return (branchName: string, hash: string): boolean =>
+    defaultPushClaimBranch(branchName, hash, clonePath, () => defaultBranch);
 }
 
 function makePartialDeps(clonePath: string, defaultBranch = 'main'): UpgradeClaimDeps {
@@ -287,5 +228,25 @@ describe('temp worktree cleanup', () => {
     const worktrees = execSync(`git -C "${clone2}" worktree list`, { encoding: 'utf-8' });
     const lines = worktrees.trim().split('\n').filter(Boolean);
     expect(lines).toHaveLength(1);
+  });
+});
+
+// ── §5 Regression: leftover local branch must not crash the claim (Bug B) ──────
+
+describe('regression: pre-existing local claim branch does not crash the push (Bug B)', () => {
+  it('still wins when a stale local branch of the same name already exists in the clone', async () => {
+    const clone1 = createClone('clone1');
+    // Simulate the leftover the original incident left behind: a prior attempt's local
+    // branch of the same deterministic name. The old `git checkout -b "<branch>"` threw
+    // "a branch named '<branch>' already exists" here, crashed the orchestrator, and bypassed
+    // the loser path. The detached-HEAD + `push HEAD:refs/heads/<branch>` impl never touches
+    // the local branch namespace, so this must just win.
+    git(clone1, 'branch', CLAIM_BRANCH, 'origin/main');
+
+    const result = await claimUpgradeOrFindExisting(HASH, REPO_INFO, makePartialDeps(clone1));
+
+    expect(result).toEqual({ won: true, branch: CLAIM_BRANCH });
+    const refs = execSync(`git -C "${bareRepoPath}" branch`, { encoding: 'utf-8' }).trim();
+    expect(refs).toContain(CLAIM_BRANCH);
   });
 });

--- a/adws/core/upgradeClaim.ts
+++ b/adws/core/upgradeClaim.ts
@@ -107,21 +107,33 @@ function cleanupClaimTempWorktree(cwd: string, tmpdir: string): void {
   }
 }
 
-function defaultPushClaimBranch(
+/**
+ * Exported (and `getDefaultBranchFn`-injectable) so integration tests can exercise the
+ * REAL push logic against a sandbox bare repo, rather than hand-copying it — the copy is
+ * exactly what let the original `git checkout -b` + process.cwd() bugs survive the suite.
+ */
+export function defaultPushClaimBranch(
   branchName: string,
   hash: string,
   baseRepoPath: string,
+  getDefaultBranchFn: (cwd: string) => string = getDefaultBranch,
 ): boolean {
-  const defaultBranch = getDefaultBranch(baseRepoPath);
+  const defaultBranch = getDefaultBranchFn(baseRepoPath);
   execSync(`git fetch origin "${defaultBranch}"`, { stdio: 'pipe', cwd: baseRepoPath });
 
   const tmpdir = fs.mkdtempSync(path.join(os.tmpdir(), 'adw-claim-'));
   try {
+    // Detached worktree at origin/<default>. We deliberately do NOT create a local
+    // branch: a named `git checkout -b <branchName>` is not idempotent and a leftover
+    // local branch from a prior attempt (cleanup removes the worktree, not the branch)
+    // makes the next run crash with "branch already exists" — a hard throw that escapes
+    // the push try/catch below and bypasses the loser path entirely. Committing in
+    // detached HEAD and pushing HEAD to the remote namespace keeps the remote push as
+    // the single atomic gate and leaves no local branch to leak.
     execSync(
       `git worktree add --detach "${tmpdir}" "origin/${defaultBranch}"`,
       { stdio: 'pipe', cwd: baseRepoPath },
     );
-    execSync(`git checkout -b "${branchName}"`, { stdio: 'pipe', cwd: tmpdir });
 
     const nonce = Math.random().toString(36).slice(2, 10);
     execSync(
@@ -130,7 +142,7 @@ function defaultPushClaimBranch(
     );
 
     try {
-      execSync(`git push origin "${branchName}"`, { stdio: 'pipe', cwd: tmpdir });
+      execSync(`git push origin "HEAD:refs/heads/${branchName}"`, { stdio: 'pipe', cwd: tmpdir });
       return true;
     } catch (pushErr) {
       const buf = (pushErr as { stderr?: Buffer | string }).stderr;

--- a/adws/phases/upgradeGate.ts
+++ b/adws/phases/upgradeGate.ts
@@ -11,7 +11,7 @@
 
 import { computeFrameworkHash } from '../core/hashComputer';
 import { readAdwVersion } from '../core/adwVersion';
-import { claimUpgradeOrFindExisting } from '../core/upgradeClaim';
+import { claimUpgradeOrFindExisting, buildDefaultUpgradeClaimDeps } from '../core/upgradeClaim';
 import {
   createIssue,
   updateIssueBody,
@@ -168,7 +168,13 @@ export function buildDefaultUpgradeGateDeps(
   return {
     computeFrameworkHash,
     readAdwVersion,
-    claimUpgrade: (hash, repoInfo) => claimUpgradeOrFindExisting(hash, repoInfo),
+    // The atomic claim must run against the TARGET repo's branch namespace, not the
+    // framework checkout. Pin baseRepoPath to the target worktree (whose `origin` is the
+    // target remote) — otherwise it defaults to process.cwd() (the framework repo) and
+    // pushes the claim branch to the framework's own GitHub, scoping the winner/loser
+    // election globally across every target repo instead of per-target.
+    claimUpgrade: (hash, repoInfo) =>
+      claimUpgradeOrFindExisting(hash, repoInfo, buildDefaultUpgradeClaimDeps(worktreePath)),
     createIssue,
     applyLabel,
     updateIssueBody,

--- a/adws/triggers/__tests__/webhookGatekeeper.test.ts
+++ b/adws/triggers/__tests__/webhookGatekeeper.test.ts
@@ -1,0 +1,96 @@
+/**
+ * Tests for the adw:upgrade short-circuit in classifyAndSpawnWorkflow (Bug C′).
+ *
+ * The #UPG tracking issue carries the adw:upgrade label. It must be routed directly to
+ * adwUpgrade.tsx and must NEVER reach evaluateCandidate / the normal classifier — otherwise
+ * the classifier reads its title, mislabels it as a chore, and re-enters the upgrade gate on
+ * the issue that represents the upgrade itself (loop/crash/runaway).
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// vi.mock factories are hoisted above the module body, so any mock fns they reference must
+// be created via vi.hoisted (also hoisted) rather than as plain top-level consts.
+const { spawnMock, issueHasLabelMock, evaluateCandidateMock, releaseIssueSpawnLockMock } = vi.hoisted(() => ({
+  spawnMock: vi.fn(() => ({ unref: () => {} })),
+  issueHasLabelMock: vi.fn(),
+  evaluateCandidateMock: vi.fn(),
+  releaseIssueSpawnLockMock: vi.fn(),
+}));
+
+vi.mock('child_process', () => ({ spawn: spawnMock, execSync: vi.fn() }));
+vi.mock('../../github/issueApi', () => ({ issueHasLabel: issueHasLabelMock, closeIssue: vi.fn() }));
+vi.mock('../../github/labelManager', () => ({
+  ADW_UPGRADE_LABEL: 'adw:upgrade',
+  applyLabel: vi.fn(),
+  issueTypeToAdwLabel: vi.fn(),
+}));
+vi.mock('../../github', () => ({
+  getRepoInfo: vi.fn(() => ({ owner: 'acme', repo: 'target' })),
+  isAdwRunningForIssue: vi.fn(() => Promise.resolve(false)),
+}));
+vi.mock('../takeoverHandler', () => ({ evaluateCandidate: evaluateCandidateMock }));
+vi.mock('../spawnGate', () => ({ releaseIssueSpawnLock: releaseIssueSpawnLockMock }));
+vi.mock('../../core/authGate', () => ({ readAuthGate: vi.fn(() => null) }));
+vi.mock('../../core', () => ({
+  log: vi.fn(),
+  generateAdwId: vi.fn(() => 'gen-adw-id'),
+  REPO_ROOT: '/repo',
+  LOGS_DIR: '/logs',
+}));
+vi.mock('../../core/issueClassifier', () => ({
+  classifyIssueForTrigger: vi.fn(() => Promise.resolve({ issueType: '/chore', success: true, adwId: undefined })),
+  getWorkflowScript: vi.fn(() => 'adws/adwChore.tsx'),
+}));
+vi.mock('../../core/agentState', () => ({
+  AgentStateManager: { readTopLevelState: vi.fn(() => null) },
+}));
+
+import { classifyAndSpawnWorkflow } from '../webhookGatekeeper';
+
+const REPO_INFO = { owner: 'acme', repo: 'target' };
+const TARGET_ARGS = ['--target-repo', 'acme/target'];
+
+function spawnedScripts(): string[] {
+  return (spawnMock.mock.calls as unknown as unknown[][]).flatMap((call) => (call[1] as string[]) ?? []);
+}
+
+describe('classifyAndSpawnWorkflow — adw:upgrade short-circuit (Bug C′)', () => {
+  beforeEach(() => {
+    spawnMock.mockClear();
+    evaluateCandidateMock.mockClear();
+    releaseIssueSpawnLockMock.mockClear();
+    issueHasLabelMock.mockReset();
+  });
+
+  it('routes an adw:upgrade issue to adwUpgrade.tsx and never calls evaluateCandidate', async () => {
+    issueHasLabelMock.mockReturnValue(true);
+
+    await classifyAndSpawnWorkflow(132, REPO_INFO, TARGET_ARGS);
+
+    expect(issueHasLabelMock).toHaveBeenCalledWith(132, 'adw:upgrade', REPO_INFO);
+    expect(spawnedScripts().some((a) => a.endsWith('adws/adwUpgrade.tsx'))).toBe(true);
+    expect(spawnedScripts()).toContain('132');
+    expect(evaluateCandidateMock).not.toHaveBeenCalled();
+    expect(releaseIssueSpawnLockMock).toHaveBeenCalledWith(REPO_INFO, 132);
+  });
+
+  it('does NOT spawn a normal workflow script for an adw:upgrade issue', async () => {
+    issueHasLabelMock.mockReturnValue(true);
+
+    await classifyAndSpawnWorkflow(132, REPO_INFO, TARGET_ARGS);
+
+    expect(spawnedScripts().some((a) => a.endsWith('adws/adwChore.tsx'))).toBe(false);
+    expect(spawnedScripts().some((a) => a.endsWith('adws/adwSdlc.tsx'))).toBe(false);
+  });
+
+  it('falls through to evaluateCandidate for a non-upgrade issue', async () => {
+    issueHasLabelMock.mockReturnValue(false);
+    evaluateCandidateMock.mockReturnValue({ kind: 'skip_terminal', terminalStage: 'completed' });
+
+    await classifyAndSpawnWorkflow(200, REPO_INFO, TARGET_ARGS);
+
+    expect(evaluateCandidateMock).toHaveBeenCalledTimes(1);
+    expect(spawnedScripts().some((a) => a.endsWith('adws/adwUpgrade.tsx'))).toBe(false);
+  });
+});

--- a/adws/triggers/webhookGatekeeper.ts
+++ b/adws/triggers/webhookGatekeeper.ts
@@ -11,9 +11,9 @@ import * as path from 'path';
 import { log, generateAdwId, REPO_ROOT, LOGS_DIR } from '../core';
 import type { RepoInfo } from '../github/githubApi';
 import { getRepoInfo } from '../github';
-import { closeIssue } from '../github/issueApi';
+import { closeIssue, issueHasLabel } from '../github/issueApi';
 import { classifyIssueForTrigger, getWorkflowScript } from '../core/issueClassifier';
-import { applyLabel, issueTypeToAdwLabel } from '../github/labelManager';
+import { applyLabel, issueTypeToAdwLabel, ADW_UPGRADE_LABEL } from '../github/labelManager';
 import type { IssueClassSlashCommand } from '../types/issueTypes';
 import { AgentStateManager } from '../core/agentState';
 
@@ -76,6 +76,20 @@ export async function classifyAndSpawnWorkflow(
 
   if (readAuthGate() !== null) {
     log(`Issue #${issueNumber}: auth gate set, skipping spawn`, 'warn');
+    releaseIssueSpawnLock(resolvedRepoInfo, issueNumber);
+    return;
+  }
+
+  // Upgrade-tracking issues (adw:upgrade) are driven solely by adwUpgrade.tsx, never by
+  // normal classification. Must be intercepted BEFORE evaluateCandidate: otherwise the
+  // classifier reads the #UPG issue's title, mislabels it (e.g. as a chore), and re-enters
+  // the upgrade gate on the very issue that represents the upgrade — a loop/crash/runaway.
+  // Routing it to adwUpgrade is also the self-heal: adwUpgrade's own per-issue lifecycle
+  // lock makes re-dispatch idempotent (live → no-op, dead → resume), so no separate watchdog
+  // is needed. We release the spawn lock here so adwUpgrade can acquire its lifecycle lock.
+  if (issueHasLabel(issueNumber, ADW_UPGRADE_LABEL, resolvedRepoInfo)) {
+    log(`Issue #${issueNumber}: adw:upgrade tracking issue, routing to adwUpgrade`, 'success');
+    spawnDetached('bunx', ['tsx', 'adws/adwUpgrade.tsx', String(issueNumber), ...targetRepoArgs]);
     releaseIssueSpawnLock(resolvedRepoInfo, issueNumber);
     return;
   }


### PR DESCRIPTION
## Restores commit `94059b5` ("harden upgrade-claim and #UPG issue routing"), which was silently reverted by the #573 merge

### What happened
`94059b5` (your hardening, landed on `main` ~14:36 on 2026-06-14) was **orphaned** when PR #573 (the autonomous issue-#572 fix) rewrote history — `94059b5` is no longer an ancestor of `origin/main` or `origin/dev`, and both remote tips ended up with the hardening reverted. The implementation **and its guarding tests** were removed together, which is why #573 merged green.

### Three root-cause fixes restored
| File | Fix |
|---|---|
| `upgradeGate.ts` | `buildDefaultUpgradeClaimDeps(worktreePath)` **pin** — claim runs against the *target* repo, not `process.cwd()` (the framework repo). Stops claim branches landing on the wrong remote. |
| `upgradeClaim.ts` | `git push origin "HEAD:refs/heads/<branch>"` from a detached worktree — **no local branch is ever created**, so the leftover-branch `git checkout -b` collision (and the uncaught crash it caused) is structurally impossible. |
| `webhookGatekeeper.ts` (+ restored `webhookGatekeeper.test.ts`) | `adw:upgrade` tracking-issue routing to `adwUpgrade`. |

### Conflict resolution
Cherry-picked `94059b5` onto `origin/dev`. Four files applied cleanly. The two conflicts (`adwUpgrade.tsx`, `adwUpgrade.test.ts`) were resolved to the **#572 side**, which is a superset — it already contains the idempotency guard from `94059b5` *plus* the `wontfix` escape hatch. No #572 regen work is lost; no hardening is lost.

### Verification
- `tsc --noEmit -p adws/tsconfig.json` — clean.
- `vitest run` on the four affected suites — **104 tests passing**.

### Why HITL
This touches the coordination kernel. Per the agreed prevention policy, kernel changes must be human-reviewed — hence the `hitl` label. Do not let this auto-merge.

### Follow-ups (not in this PR)
- Implement the kernel-HITL auto-gate so any ADW PR touching kernel files is `hitl`-labeled automatically (this is what would have prevented the revert).
- Branch protection on `main`.
- Clean up the stranded `adw-upgrade-993…` branches/worktrees (framework repo local+remote; vestmatic-research) once this is deployed.
