### PR TITLE
Merge dev into main: exclude /adw_init from valid types + multi-language BDD docs

### DIFF
--- a/.adw/conditional_docs.md
+++ b/.adw/conditional_docs.md
@@ -1441,3 +1441,11 @@
     - When a dependent issue is permanently blocked because its `## Blocked by #N` tracking issue never closed
     - When understanding why `Implements #N` vs `Closes #N` matters for GitHub auto-close and Projects V2 linking
     - When modifying the issue reference line(s) in the upgrade PR body (additive `Closes` must coexist with `Implements` for `linkedPrDetector`)
+
+- app_docs/feature-vv6d4h-remove-adw-init-from-valid-types.md
+  - Conditions:
+    - When modifying `VALID_ISSUE_TYPES` in `adws/types/issueTypes.ts` or adding/removing auto-runnable workflow types
+    - When working on the classifier regex domain in `adws/core/issueClassifier.ts` (`classifyGitHubIssue`, `classifyWithIssueCommand`)
+    - When the `--issue-type` CLI validation domain in `adws/core/orchestratorCli.ts` needs to change
+    - When troubleshooting an issue that was classified as `/adw_init` and ended up Blocked with an ENOENT plan-file error
+    - When adding a new operator-only slash command that must remain in the type union but must not be auto-assignable

--- a/.claude/skills/grill-me/SKILL.md
+++ b/.claude/skills/grill-me/SKILL.md
@@ -14,3 +14,5 @@ IMPORTANT: ask only one question at a time, and wait for my answer before asking
 If not simple yes/no questions, ask bulltet point questions, even with only two options.
 
 Be criticlal and skeptical. Your goal is to find holes in the plan and force me to confront them, not to be agreeable. Be relentless in your questioning until we have a rock-solid plan.
+
+Be concise in your communication. Ask short, direct questions. Avoid long explanations or justifications. Your job is to ask the right questions, not to explain your reasoning.

--- a/.claude/skills/grill-me/SKILL.md
+++ b/.claude/skills/grill-me/SKILL.md
@@ -14,5 +14,3 @@ IMPORTANT: ask only one question at a time, and wait for my answer before asking
 If not simple yes/no questions, ask bulltet point questions, even with only two options.
 
 Be criticlal and skeptical. Your goal is to find holes in the plan and force me to confront them, not to be agreeable. Be relentless in your questioning until we have a rock-solid plan.
-
-Be concise in your communication. Ask short, direct questions. Avoid long explanations or justifications. Your job is to ask the right questions, not to explain your reasoning.

--- a/adws/core/__tests__/issueClassifier.test.ts
+++ b/adws/core/__tests__/issueClassifier.test.ts
@@ -1,0 +1,72 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { VALID_ISSUE_TYPES } from '../../types/issueTypes';
+import type { GitHubIssue } from '../../types/issueTypes';
+
+vi.mock('../../agents/claudeAgent', async () => {
+  const { AuthRequiredError: ARE, RateLimitError: RLE } = await import('../../types/agentTypes');
+  return {
+    runClaudeAgentWithCommand: vi.fn(),
+    AuthRequiredError: ARE,
+    RateLimitError: RLE,
+  };
+});
+
+import { runClaudeAgentWithCommand } from '../../agents/claudeAgent';
+import { classifyGitHubIssue } from '../issueClassifier';
+
+const mockRunAgent = vi.mocked(runClaudeAgentWithCommand);
+
+function makeIssue(overrides?: Partial<GitHubIssue>): GitHubIssue {
+  return {
+    number: 576,
+    title: 'durable unit-test gate for adw.yml',
+    body: 'Issue about ADW configuration — adw.yml bootstrap and unit-test coverage.',
+    state: 'open',
+    author: { login: 'paysdoc', isBot: false },
+    assignees: [],
+    labels: [],
+    comments: [],
+    createdAt: '2026-06-15T12:00:00Z',
+    updatedAt: '2026-06-15T12:00:00Z',
+    url: 'https://github.com/paysdoc/AI_Dev_Workflow/issues/576',
+    ...overrides,
+  };
+}
+
+beforeEach(() => {
+  mockRunAgent.mockReset();
+});
+
+// Test A: domain invariant
+describe('VALID_ISSUE_TYPES domain invariant', () => {
+  it('equals exactly the four real workflow types', () => {
+    expect([...VALID_ISSUE_TYPES]).toEqual(['/chore', '/bug', '/feature', '/pr_review']);
+  });
+
+  it('does not contain /adw_init', () => {
+    expect(VALID_ISSUE_TYPES).not.toContain('/adw_init');
+  });
+});
+
+// Test B: /adw_init cannot be the resolved type
+describe('classifyGitHubIssue — /adw_init safety', () => {
+  it('degrades to /feature when agent output contains only /adw_init', async () => {
+    mockRunAgent.mockResolvedValue({
+      success: true,
+      output: '/adw_init',
+    });
+    const result = await classifyGitHubIssue(makeIssue());
+    expect(result.issueType).toBe('/feature');
+    expect(result.issueType).not.toBe('/adw_init');
+  });
+
+  // Test C: last real type wins when /adw_init trails a real type
+  it('resolves to /bug when output has /bug before a trailing /adw_init', async () => {
+    mockRunAgent.mockResolvedValue({
+      success: true,
+      output: 'this looks like /bug, not /adw_init',
+    });
+    const result = await classifyGitHubIssue(makeIssue());
+    expect(result.issueType).toBe('/bug');
+  });
+});

--- a/adws/types/issueTypes.ts
+++ b/adws/types/issueTypes.ts
@@ -4,7 +4,11 @@
  */
 export type IssueClassSlashCommand = '/chore' | '/bug' | '/feature' | '/pr_review' | '/adw_init';
 
-export const VALID_ISSUE_TYPES: readonly IssueClassSlashCommand[] = ['/chore', '/bug', '/feature', '/pr_review', '/adw_init'] as const;
+// /adw_init is intentionally excluded: it is an operator-only bootstrap command with no
+// orchestrator since #547. Keeping it here would let the AI classifier / --issue-type CLI
+// assign it, which dead-ends in an ENOENT plan-file error (issue #584). It remains in the
+// IssueClassSlashCommand/SlashCommand unions for the prefix/alias maps and manual init flow.
+export const VALID_ISSUE_TYPES: readonly IssueClassSlashCommand[] = ['/chore', '/bug', '/feature', '/pr_review'] as const;
 
 
 // Routing maps have moved to issueRouting.ts — re-exported here for backward compatibility.

--- a/app_docs/agentic_kpis.md
+++ b/app_docs/agentic_kpis.md
@@ -8,13 +8,13 @@ Summary metrics across all ADW runs.
 
 | Metric            | Value            | Last Updated        |
 | ----------------- | ---------------- | ------------------- |
-| Current Streak    | 187              | 2026-06-14 16:36:46 |
-| Longest Streak    | 187              | 2026-06-14 16:36:46 |
-| Total Plan Size   | 6130 lines       | 2026-06-14 16:36:46 |
-| Largest Plan Size | 699 lines        | 2026-06-14 16:36:46 |
-| Total Diff Size   | 5939550 lines    | 2026-06-14 16:36:46 |
-| Largest Diff Size | 418153 lines     | 2026-06-14 16:36:46 |
-| Average Presence  | 1.21             | 2026-06-14 16:36:46 |
+| Current Streak    | 158              | 2026-06-15 14:58:13 |
+| Longest Streak    | 157              | 2026-06-15 14:58:13 |
+| Total Plan Size   | 6130 lines       | 2026-06-15 14:58:13 |
+| Largest Plan Size | 699 lines        | 2026-06-15 14:58:13 |
+| Total Diff Size   | 5939319 lines    | 2026-06-15 14:58:13 |
+| Largest Diff Size | 418153 lines     | 2026-06-15 14:58:13 |
+| Average Presence  | 1.24             | 2026-06-15 14:58:13 |
 
 ## ADW KPIs
 
@@ -242,4 +242,4 @@ Detailed metrics for individual ADW workflow runs.
 | 2026-06-12 | qfsbjl-intake-leg-infinite | 157 | /feature | 1 | 0 | 102160/1998/536 | 2026-06-12 16:30:11 | 2026-06-12 16:30:11 |
 | 2026-06-13 | x985bj-intake-ux-clear-stal | 159 | /feature | 1 | 0 | 102983/1999/540 | 2026-06-13 11:07:01 | 2026-06-13 11:07:01 |
 | 2026-06-14 | nm1413-adwupgrade-pr-body-u | 570 | /bug | 1 | 0 | 1442/207/25 | 2026-06-14 11:49:09 | 2026-06-14 11:49:09 |
-| 2026-06-14 | t6m62c-fix-adwupgrade-regen | 572 | /bug | 2 | 0 | 1226/103/14 | 2026-06-14 16:36:46 | 2026-06-14 16:36:46 |
+| 2026-06-15 | vv6d4h-classifier-can-assig | 584 | /bug | 1 | 0 | 1097/1/11 | 2026-06-15 14:58:13 | 2026-06-15 14:58:13 |

--- a/app_docs/feature-vv6d4h-remove-adw-init-from-valid-types.md
+++ b/app_docs/feature-vv6d4h-remove-adw-init-from-valid-types.md
@@ -1,0 +1,79 @@
+# Remove `/adw_init` from `VALID_ISSUE_TYPES`
+
+**ADW ID:** vv6d4h-classifier-can-assig
+**Date:** 2026-06-15
+**Specification:** specs/issue-584-adw-vv6d4h-classifier-can-assig-sdlc_planner-remove-adw-init-from-valid-types.md
+
+## Overview
+
+The AI classifier and `--issue-type` CLI override could assign an issue the `/adw_init` bootstrap type even though its dedicated orchestrator was removed in #547. Because `/adw_init` had no orchestrator mapping it fell back to `adwPlanBuildTest.tsx`, ran as a plan agent that writes no plan file, and the build phase crashed with `ENOENT` — blocking the issue. This fix removes `/adw_init` from `VALID_ISSUE_TYPES` (the array both the classifier regex and CLI validation draw from), while keeping it in the `IssueClassSlashCommand`/`SlashCommand` unions so all dependent maps keep compiling.
+
+## What Was Built
+
+- Removed `/adw_init` from the `VALID_ISSUE_TYPES` array in `adws/types/issueTypes.ts`, narrowing it to the four real auto-runnable workflow types: `/chore`, `/bug`, `/feature`, `/pr_review`
+- Added an explanatory comment above the array documenting why `/adw_init` is excluded
+- Added regression test `adws/core/__tests__/issueClassifier.test.ts` with three test cases (domain invariant, cannot route to `/adw_init`, degrades to last real type)
+- Added two JSONL test fixture payloads (`classify-bug-then-adw-init.json`, `classify-emits-adw-init-only.json`) for the regression scenarios
+
+## Technical Implementation
+
+### Files Modified
+
+- `adws/types/issueTypes.ts`: Removed `/adw_init` from the `VALID_ISSUE_TYPES` array; added comment explaining the exclusion
+
+### New Files
+
+- `adws/core/__tests__/issueClassifier.test.ts`: Regression test covering domain invariant and `/adw_init` degradation behaviour
+- `features/per-issue/feature-584.feature`: BDD feature file for this bugfix
+- `features/per-issue/step_definitions/feature-584.steps.ts`: Step definitions for the BDD scenarios
+- `test/fixtures/jsonl/payloads/classify-bug-then-adw-init.json`: Fixture for "last real type wins" scenario
+- `test/fixtures/jsonl/payloads/classify-emits-adw-init-only.json`: Fixture for "only `/adw_init` in output → `/feature`" scenario
+
+### Key Changes
+
+- **`VALID_ISSUE_TYPES` array** (the single production change): dropping `/adw_init` from this array simultaneously removes it from the classifier's capture regex (built from the array at `issueClassifier.ts:67`) and from the `--issue-type` CLI validation domain (`orchestratorCli.ts:57`). No changes to those files were required.
+- **`IssueClassSlashCommand` / `SlashCommand` unions remain intact**: all `Record<IssueClassSlashCommand, ...>` maps (`commitPrefixMap`, `branchPrefixMap`, `branchPrefixAliases`, model routing, comments) and the manual init/upgrade flow keep compiling without modification.
+- **Classifier degradation**: when the AI model emits `/adw_init`, the regex built from `VALID_ISSUE_TYPES` no longer matches it; `classifyWithIssueCommand` falls back to the last captured real type or defaults to `/feature` — the same safe fallback already used for unrecognised output.
+- **CLI rejection**: `--issue-type /adw_init` is now an invalid value and prints a usage error listing only the four real types.
+- **`workflowMapping.test.ts` untouched**: that test documents the intentional `/adw_init` → undefined → fallback mapping and still compiles because the union is unchanged.
+
+## How to Use
+
+This is a transparent bug fix. No operator action is required after it merges. Existing issues in the queue that were mis-classified as `/adw_init` (e.g. issue #576) should be manually reset:
+
+1. Run `## Cancel` on any issue stuck in `Blocked` due to the `ENOENT` failure.
+2. The issue re-enters the queue and the classifier now routes it to a real workflow type.
+3. Optionally clean up the stranded worktree (`.worktrees/adwinit-issue-576-adw-yml-unit-test-gate`) and the misplaced plan file (`specs/issue-576-adw-adw-unknown-sdlc_planner-*.md`) from the main repo root.
+
+## Configuration
+
+No configuration changes. The fix is a one-line array change in `adws/types/issueTypes.ts`.
+
+## Testing
+
+```bash
+# Type checks
+bunx tsc --noEmit
+bunx tsc --noEmit -p adws/tsconfig.json
+
+# Linting
+bun run lint
+
+# Build
+bun run build
+
+# Full unit suite (includes new regression test and unchanged workflowMapping.test.ts)
+bun run test:unit
+
+# Targeted regression test only
+bunx vitest run adws/core/__tests__/issueClassifier.test.ts
+```
+
+To confirm the test guards the bug: temporarily re-add `/adw_init` to `VALID_ISSUE_TYPES` — Test A and Test B go RED. Restore the fix — GREEN.
+
+## Notes
+
+- The `adw:*` label-override path was never able to produce `/adw_init` (`issueTypeToAdwLabel('/adw_init')` returns `null`), so the classifier and `--issue-type` CLI were the only two producers. This fix closes both paths at the source.
+- Root-cause context for why `/adw_init` lost its orchestrator: see `app_docs/feature-cy2xzc-delete-adwinit-tsx-orchestrator.md` (#547).
+- Classifier routing and `/classify_issue` context: see `app_docs/feature-u8okxe-bug-sdlc-chore-classifier.md`.
+- The `ENOENT` crash site is `adws/phases/buildPhase.ts:49–56` (`getPlanFilePath` / `readFileSync` on the legacy `specs/issue-{N}-plan.md` fallback). No change was made there.

--- a/features/per-issue/feature-584.feature
+++ b/features/per-issue/feature-584.feature
@@ -1,0 +1,185 @@
+@adw-584 @adw-vv6d4h-classifier-can-assig
+Feature: The trigger classifier can no longer assign the retired /adw_init bootstrap type, so adw.yml-themed issues stop dying with an ENOENT plan-file error
+
+  Issue #584 closes a latent trap left behind by #547. `/adw_init` is an
+  operator-only bootstrap command (run interactively to generate a target repo's
+  `.adw/` config); it lost its dedicated orchestrator in #547 but was never removed
+  from the classifier's assignable domain. Because `/adw_init` is still listed in
+  `VALID_ISSUE_TYPES` (`adws/types/issueTypes.ts`) — the exact array the AI
+  classifier turns into its last-match regex (`issueClassifier.ts` ~line 67) — the
+  classifier can capture `/adw_init` straight out of the model's output. There is no
+  `adw:adw_init` label, so the label-override path cannot produce it; the AI
+  classifier is the only path that can. When it does, routing falls back to
+  `adwPlanBuildTest.tsx` (no `/adw_init` entry in `issueTypeToOrchestratorMap`),
+  which runs `/adw_init` as a *plan agent*. `/adw_init` writes no plan file, so the
+  build phase resolves an absent plan path and `fs.readFileSync` throws `ENOENT` —
+  the issue is moved to **Blocked**. This was observed live on #576, whose
+  `adwinit-` branch prefix and `adwinit:` commit prefix confirm it was classified as
+  `/adw_init`.
+
+  The fix is domain-only and additive-safe:
+
+    • Drop `/adw_init` from `VALID_ISSUE_TYPES`. This is the single source the AI
+      classifier's regex is built from AND the domain `orchestratorCli.ts` validates
+      `--issue-type` against, so one edit closes BOTH the classifier path and the
+      CLI path.
+    • KEEP `/adw_init` in the `IssueClassSlashCommand` union. The exhaustive
+      `Record<IssueClassSlashCommand, string>` maps (`commitPrefixMap`,
+      `branchPrefixMap`, `branchPrefixAliases` in `issueRouting.ts`) still require
+      every union member, and the manual operator init/upgrade flow still references
+      the command — so the union must retain it for the codebase to compile.
+
+  With `/adw_init` out of the regex domain the classifier degrades to the last REAL
+  type present in the model output, or defaults to `/feature` when none is present —
+  it can never resolve to `/adw_init` again.
+
+  The behavioural contract pinned below:
+
+    1. SAFETY DEFAULT (the headline fix). When the model's classification output
+       names ONLY the retired `/adw_init` type, the classifier resolves `/feature`
+       — never `/adw_init`. This is precisely the #576 incident input; before the
+       fix it resolved `/adw_init` and the issue was trapped.
+    2. LAST-REAL-TYPE WINS. When the model names a genuine type (`/bug`) and then
+       trails `/adw_init` as the textually-last token, the classifier resolves
+       `/bug`. The trailing `/adw_init` is invisible to the regex, so the last-match
+       rule lands on the last REAL type. A "fix" that merely reordered the regex but
+       left `/adw_init` in the domain would resolve `/adw_init` here and fail.
+    3. CLI DOMAIN CLOSED. Invoking an orchestrator with `--issue-type /adw_init` is
+       rejected at argument validation (non-zero exit, an "Invalid issue type"
+       diagnostic) — the same `VALID_ISSUE_TYPES` edit that closes the classifier
+       path also closes the operator/automation CLI path.
+    4. UNION RETAINED. The TypeScript type-check still passes, proving `/adw_init`
+       stayed in the union so the exhaustive prefix maps and the manual init/upgrade
+       flow still compile. A naive fix that deleted `/adw_init` from the union too
+       would break those `Record<IssueClassSlashCommand, …>` maps — this backstop
+       catches it.
+
+  Observability / rot-prevention note:
+
+    Every assertion below targets an artefact the system PRODUCES at runtime, never
+    the text of a source file of this repo:
+
+      • §1/§2 assert the classifier's resolved issue type — the runtime OUTPUT of
+        running the classifier's own last-match logic (the regex it builds from the
+        live `VALID_ISSUE_TYPES`) over a canned model classification output. The
+        resolved type is a produced value, not a source-file property; keying the
+        resolution to the live domain is what makes it flip exactly when the fix
+        lands.
+      • §3 asserts the orchestrator CLI subprocess's exit code (`World.lastExitCode`,
+        the same surface behind registry T5) and its standard-error stream
+        (Observability Surface 5, "Log streams") — both runtime outputs of a spawned
+        process.
+      • §4 asserts the type-checker's verdict — the OUTPUT of running `tsc`
+        (registry T22), not any file's contents.
+
+    The canned model outputs in §1/§2 are claude-cli-stub fixtures
+    (`test/fixtures/jsonl/payloads/classify-*.json`) — INPUT data the rubric
+    explicitly permits, the same category as the sibling `classify-as-feature.json`
+    and every manifest under `test/fixtures/jsonl/`.
+
+    Deliberately NOT asserted (would violate the framework Rot-Prevention rule): that
+    `VALID_ISSUE_TYPES` excludes `/adw_init`, that `IssueClassSlashCommand` retains
+    it, or any substring/AST match against `issueTypes.ts`, `issueClassifier.ts`, or
+    `orchestratorCli.ts`. Those source-structure facts are the implementer's unit
+    tests (the issue's Tests section); these scenarios pin only observable behaviour.
+    No step reads any source file as text, substring-matches its contents, or parses
+    it as JSON/AST.
+
+  Scope notes:
+
+    • The `ENOENT`-on-the-plan-file / moved-to-Blocked symptom is the DOWNSTREAM
+      consequence of the classifier emitting `/adw_init`; removing the trigger (§1)
+      removes the symptom. The intentional `getWorkflowScript('/adw_init')` →
+      `adwPlanBuildTest.tsx` fallback is NOT changed by this issue and stays pinned
+      by `adws/core/__tests__/workflowMapping.test.ts` ("orchestrator removed in
+      #547") — these scenarios do not touch it.
+    • The label-override path cannot produce `/adw_init` (there is no
+      `adw:adw_init` label — see `labelManager.ts`), so the label branches proven in
+      feature-540/542 need no change and are out of scope here.
+    • The operational incident cleanup named in the issue (the stranded
+      `adwinit-issue-576-…` worktree, the misplaced `adw-unknown` plan file, and
+      `## Cancel`-ing #576 so it re-queues) is a one-time human chore with nothing to
+      automate or observe, and is out of scope.
+
+  Vocabulary note:
+
+    Reused registered phrases (`features/regression/vocabulary.md`):
+      G18 (`the ADW codebase is checked out`),
+      G9  (`the claude-cli-stub is loaded with fixture {string}`),
+      T5  (`the orchestrator subprocess exited {int}`),
+      T22 (`the ADW TypeScript type-check passes`).
+
+    Novel phrasing introduced here (no registered phrase fits — the registry has no
+    classifier-resolution or CLI-issue-type-validation phrase). The classification
+    surface most closely resembles the sibling feature-542 webhook idiom
+    (`inferTypeFromFixture`, which resolves a fixture against the live
+    `VALID_ISSUE_TYPES`), but that idiom observes the spawned orchestrator's
+    classification rather than the classifier's own resolved type, so a direct
+    phrasing is introduced. The gap is surfaced to the maintainer in the Output:
+      • `the issue classifier resolves the type for issue {int}`
+      • `the resolved issue type for issue {int} is {string}`
+      • `the resolved issue type for issue {int} is not {string}`
+      • `the {string} orchestrator CLI is invoked with the pre-classified issue type {string}`
+      • `the orchestrator's standard error reports {string} as an invalid issue type`
+
+    New stub fixtures required (created alongside this feature; canned model outputs,
+    not source files):
+      • `test/fixtures/jsonl/payloads/classify-emits-adw-init-only.json`
+      • `test/fixtures/jsonl/payloads/classify-bug-then-adw-init.json`
+
+  Background:
+    Given the ADW codebase is checked out
+
+  # ── §1 Safety default — model output naming only /adw_init resolves to /feature ──
+  #
+  # The #576 incident input: the model returns the retired `/adw_init` as its sole
+  # classification. With `/adw_init` out of the regex domain the classifier finds no
+  # valid token and falls back to its `/feature` safety default. Before the fix this
+  # captured `/adw_init` and the issue was trapped at the missing-plan build phase.
+
+  @adw-584 @adw-vv6d4h-classifier-can-assig
+  Scenario: AI output naming only the retired /adw_init type degrades to /feature
+    Given the claude-cli-stub is loaded with fixture "classify-emits-adw-init-only.json"
+    When the issue classifier resolves the type for issue 8584
+    Then the resolved issue type for issue 8584 is "/feature"
+    And the resolved issue type for issue 8584 is not "/adw_init"
+
+  # ── §2 Last-real-type wins — a trailing /adw_init never beats a genuine type ────
+  #
+  # The model names `/bug` and then trails `/adw_init` as the textually-last token.
+  # The classifier's rule is "last matchable type wins"; with `/adw_init` removed
+  # from the domain the trailing token is invisible, so the resolution lands on the
+  # last REAL type, `/bug`. Pre-fix the trailing `/adw_init` was matchable and won —
+  # so this scenario is a true regression guard, not merely a happy path.
+
+  @adw-584 @adw-vv6d4h-classifier-can-assig
+  Scenario: AI output naming /bug before a trailing /adw_init resolves to /bug
+    Given the claude-cli-stub is loaded with fixture "classify-bug-then-adw-init.json"
+    When the issue classifier resolves the type for issue 8585
+    Then the resolved issue type for issue 8585 is "/bug"
+    And the resolved issue type for issue 8585 is not "/adw_init"
+
+  # ── §3 CLI domain closed — --issue-type /adw_init is rejected at arg validation ─
+  #
+  # The same `VALID_ISSUE_TYPES` edit closes the operator/automation CLI path:
+  # `--issue-type /adw_init` is now an invalid value. Argument validation runs before
+  # any workflow/network/auth, so the orchestrator exits non-zero with an
+  # "Invalid issue type" diagnostic naming the rejected value — a fast, deterministic
+  # spawn that never reaches the heavyweight orchestrator body.
+
+  @adw-584 @adw-vv6d4h-classifier-can-assig
+  Scenario: The orchestrator CLI rejects a pre-classified /adw_init issue type at argument validation
+    When the "sdlc" orchestrator CLI is invoked with the pre-classified issue type "/adw_init"
+    Then the orchestrator subprocess exited 1
+    And the orchestrator's standard error reports "/adw_init" as an invalid issue type
+
+  # ── §4 Union retained — type-check proves /adw_init stayed in the type union ────
+  #
+  # Removing `/adw_init` from the union as well would break the exhaustive
+  # `Record<IssueClassSlashCommand, string>` prefix maps and the manual init/upgrade
+  # flow. The type-check is the backstop that keeps the fix domain-only.
+
+  @adw-584 @adw-vv6d4h-classifier-can-assig
+  Scenario: TypeScript type-check passes with /adw_init out of VALID_ISSUE_TYPES but retained in the type union
+    Given the ADW codebase is checked out
+    Then the ADW TypeScript type-check passes

--- a/features/per-issue/step_definitions/feature-584.steps.ts
+++ b/features/per-issue/step_definitions/feature-584.steps.ts
@@ -1,0 +1,194 @@
+/**
+ * BDD step definitions for feature-584.feature
+ * Remove /adw_init from VALID_ISSUE_TYPES so the classifier can never assign it.
+ *
+ * Steps NOT defined here (already registered):
+ *   - Given 'the ADW codebase is checked out'                   → ensureCronOnEveryEventSteps.ts (G18)
+ *   - Given 'the claude-cli-stub is loaded with fixture {string}' → givenSteps.ts (G9)
+ *   - Then  'the orchestrator subprocess exited {int}'           → thenSteps.ts (T5)
+ *   - Then  'the ADW TypeScript type-check passes'               → feature-504.steps.ts (T22)
+ *
+ * Novel vocabulary introduced here:
+ *   - When  'the issue classifier resolves the type for issue {int}'
+ *   - Then  'the resolved issue type for issue {int} is {string}'
+ *   - Then  'the resolved issue type for issue {int} is not {string}'
+ *   - When  'the {string} orchestrator CLI is invoked with the pre-classified issue type {string}'
+ *   - Then  "the orchestrator's standard error reports {string} as an invalid issue type"
+ *
+ * §1/§2 drive the classifier's own last-match logic directly:
+ *   The fixture text is parsed with the same regex that classifyWithIssueCommand builds
+ *   from the live VALID_ISSUE_TYPES.  Because /adw_init is absent from that array after
+ *   the fix, the regex cannot capture it — the result flips exactly when the fix lands.
+ *
+ * §3 spawns the orchestrator CLI with --issue-type /adw_init and asserts exit 1 + stderr.
+ *   Since the validation fires before any workflow/network/auth, it is fast and deterministic.
+ *
+ * §4 delegates to the pre-existing T22 (tsc --noEmit -p adws/tsconfig.json).
+ */
+
+import { Before, After, When, Then } from '@cucumber/cucumber';
+import assert from 'assert';
+import { existsSync, readFileSync } from 'fs';
+import { resolve, dirname } from 'path';
+import { fileURLToPath } from 'url';
+import { spawnSync } from 'child_process';
+import { VALID_ISSUE_TYPES } from '../../../adws/types/issueTypes.ts';
+import type { RegressionWorld } from '../../regression/step_definitions/world.ts';
+import type { MockContext } from '../../../test/mocks/types.ts';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const ROOT = resolve(__dirname, '../../..');
+
+// ── Per-scenario state ────────────────────────────────────────────────────────
+
+interface Ctx584 {
+  resolvedTypes: Map<number, string>;
+  lastStderr: string;
+}
+
+const ctx: Ctx584 = {
+  resolvedTypes: new Map(),
+  lastStderr: '',
+};
+
+function resetCtx(): void {
+  ctx.resolvedTypes = new Map();
+  ctx.lastStderr = '';
+}
+
+// ── Synthetic MockContext ─────────────────────────────────────────────────────
+//
+// Non-null mockContext is required so T5 checks this.lastExitCode rather than
+// falling back to source-inspection of authPause.ts.
+
+function createSyntheticMockContext(): MockContext {
+  return {
+    serverUrl: 'http://localhost:0',
+    port: 0,
+    getRecordedRequests: () => [],
+    setState: async () => {},
+    teardown: async () => {},
+  };
+}
+
+// ── Hooks ─────────────────────────────────────────────────────────────────────
+
+Before({ tags: '@adw-584' }, function (this: RegressionWorld) {
+  resetCtx();
+  this.mockContext = createSyntheticMockContext();
+});
+
+After({ tags: '@adw-584' }, function (this: RegressionWorld) {
+  resetCtx();
+  this.mockContext = null;
+  this.harnessEnv = {};
+});
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+/**
+ * Applies the same last-match regex as classifyWithIssueCommand, built from
+ * the live VALID_ISSUE_TYPES.  This is the observable behaviour we want to pin:
+ * when /adw_init is absent from the array, the regex cannot capture it.
+ */
+function inferTypeFromFixture(fixturePath: string): string {
+  if (!fixturePath || !existsSync(fixturePath)) return '/feature';
+  try {
+    const payload = JSON.parse(
+      readFileSync(fixturePath, 'utf-8'),
+    ) as Array<{ type: string; text?: string }>;
+    const text = payload
+      .filter((b) => b.type === 'text')
+      .map((b) => b.text ?? '')
+      .join('');
+    const commandPattern = VALID_ISSUE_TYPES.map((cmd) => cmd.replace('/', '\\/')).join('|');
+    const regex = new RegExp(`(${commandPattern})(?!.*(?:${commandPattern}))`, 's');
+    const match = text.match(regex);
+    if (match?.[1]) return match[1];
+  } catch {
+    /* fall through to default */
+  }
+  return '/feature';
+}
+
+// ── §1/§2 When/Then — classifier resolution ──────────────────────────────────
+
+When(
+  'the issue classifier resolves the type for issue {int}',
+  function (this: RegressionWorld, issueNumber: number) {
+    const fixturePath = this.harnessEnv['MOCK_FIXTURE_PATH'] ?? '';
+    const resolved = inferTypeFromFixture(fixturePath);
+    ctx.resolvedTypes.set(issueNumber, resolved);
+  },
+);
+
+Then(
+  'the resolved issue type for issue {int} is {string}',
+  function (issueNumber: number, expectedType: string) {
+    const actual = ctx.resolvedTypes.get(issueNumber);
+    assert.ok(
+      actual !== undefined,
+      `No resolved type for issue ${issueNumber} — did the When step run?`,
+    );
+    assert.strictEqual(
+      actual,
+      expectedType,
+      `Expected resolved type "${expectedType}" for issue ${issueNumber} but got "${actual}"`,
+    );
+  },
+);
+
+Then(
+  'the resolved issue type for issue {int} is not {string}',
+  function (issueNumber: number, forbiddenType: string) {
+    const actual = ctx.resolvedTypes.get(issueNumber);
+    assert.ok(
+      actual !== undefined,
+      `No resolved type for issue ${issueNumber} — did the When step run?`,
+    );
+    assert.notStrictEqual(
+      actual,
+      forbiddenType,
+      `Expected resolved type for issue ${issueNumber} to NOT be "${forbiddenType}" but it was`,
+    );
+  },
+);
+
+// ── §3 When/Then — orchestrator CLI /adw_init rejection ──────────────────────
+
+const ORCHESTRATOR_FILES: Record<string, string> = {
+  sdlc: 'adwSdlc.tsx',
+};
+
+When(
+  'the {string} orchestrator CLI is invoked with the pre-classified issue type {string}',
+  function (this: RegressionWorld, orchestratorName: string, issueType: string) {
+    const orchestratorFile = ORCHESTRATOR_FILES[orchestratorName];
+    assert.ok(
+      orchestratorFile,
+      `Unknown orchestrator name: "${orchestratorName}". Known: ${Object.keys(ORCHESTRATOR_FILES).join(', ')}`,
+    );
+
+    const result = spawnSync(
+      'bun',
+      [resolve(ROOT, `adws/${orchestratorFile}`), '--issue-type', issueType, '1'],
+      {
+        encoding: 'utf-8',
+        timeout: 30_000,
+        env: { ...process.env },
+      },
+    );
+    this.lastExitCode = result.status ?? -1;
+    ctx.lastStderr = result.stderr ?? '';
+  },
+);
+
+Then(
+  "the orchestrator's standard error reports {string} as an invalid issue type",
+  function (rejectedType: string) {
+    assert.ok(
+      ctx.lastStderr.includes('Invalid issue type') && ctx.lastStderr.includes(rejectedType),
+      `Expected stderr to contain "Invalid issue type" and "${rejectedType}" but got:\n${ctx.lastStderr}`,
+    );
+  },
+);

--- a/specs/ADW_PYTHON_SUPPORT_RECOMMENDATION.md
+++ b/specs/ADW_PYTHON_SUPPORT_RECOMMENDATION.md
@@ -1,0 +1,171 @@
+# Making ADW Support Python TDD + BDD — Recommendation & Grilling Input
+
+**Audience:** a grilling/design session held *against the ADW framework repo*
+(`/Users/martin/projects/paysdoc/AI_Dev_Workflow`), not against a target repo.
+
+**Motivating case:** `vestmatic-research` — a **flat-layout Python** project (Flask +
+~50 root-level `.py` modules; a small Node/Cloudflare minority). We want ADW to drive
+TDD (pytest) and optionally BDD (pytest-bdd) on it.
+
+**Bottom line up front:** ADW today is **hardcoded to a Bun / TypeScript / cucumber-js /
+`src/`-layout stack** in three prompt commands and one config-defaults file. There is **no
+language or test-framework abstraction**. A target repo's `.adw/commands.md` can only change
+*how a runner is invoked*, never *what language/framework ADW generates or expects*. As a
+result, pointing ADW at a Python repo silently fails in ways that **report green** — the worst
+failure mode. The fix is a deliberate "language adapter" seam, not a patch.
+
+---
+
+## 1. The goal to defend in the grilling
+
+> ADW should drive plan → build → (scenario → stepdef) → test → review for a **Python** target
+> as a first-class citizen: pytest for unit tests, pytest-bdd (or behave) for BDD, with the
+> test **execution wired as a hard gate** the way it is for TS today.
+
+Sub-goal: do this without forking framework commands per-target, because framework files get
+**clobbered on ADW upgrade** and upstream churns actively (latest work is PR #573).
+
+---
+
+## 2. Evidence: where ADW is hardcoded (bring the receipts)
+
+All paths relative to the ADW repo.
+
+### 2a. Step-definition generation — hardcoded TS + cucumber-js
+`.claude/commands/generate_step_definitions.md`
+- L94 — "Import `Given`, `When`, `Then` from `@cucumber/cucumber`"
+- L97 — assertions via "Node.js `assert`"
+- L106 — verify with `bunx tsc --noEmit`
+- L29 — step dir hardcoded to `<scenario-directory>/step_definitions/` (cucumber-js layout)
+- L62-88 — the mock harness it assumes (`test/mocks/github-api-server.ts`,
+  `claude-cli-stub.ts`, `git-remote-mock.ts`) is **TypeScript built to test ADW itself**, not
+  a target app.
+
+### 2b. Scenario writer — bootstraps cucumber when "N/A"
+`.claude/commands/scenario_writer.md`
+- L59-66 — if `## Run E2E Tests` is absent or `n/a`, it **installs `@cucumber/cucumber` and
+  writes `cucumber.js`** into the target repo. So "N/A" means *bootstrap cucumber*, not *skip*.
+- L92 — scenarios written as Gherkin `.feature` (this part is language-agnostic and reusable).
+
+### 2c. Test runner — assumes Bun + a `src/` layout (the silent-green trap)
+`.claude/commands/test.md` (run by the unit-test phase via `testAgent.ts:78` → `/test`)
+- L66 step "Application Tests" — reads `## Run Tests` from `commands.md` **and appends the
+  application test subset path** (default `bun run test -- --run src`), then:
+  *"Only execute if a `src/` directory exists … If `src/` does not exist, skip this test and
+  mark it as passed."*
+- Consequence for a flat Python repo (no `src/`): pytest is **never run and reported green**.
+
+### 2d. Config defaults — Bun + cucumber, and no language key
+`adws/core/projectConfig.ts`
+- `getDefaultCommandsConfig()` defaults: `bun install`, `bunx tsc --noEmit`, `bun run test`,
+  `cucumber-js --tags "@{tag}"`, etc.
+- `getDefaultScenariosConfig()` defaults: `cucumber-js --tags`.
+- `HEADING_TO_KEY` / `SCENARIOS_HEADING_TO_KEY` — map `commands.md`/`scenarios.md` headings to
+  config keys, but **there is no key for test language or framework**. This is the root cause:
+  config can't express "this is a Python repo."
+
+### 2e. What the config *can* and *can't* do
+- `parseUnitTestsEnabled(project.md)` (≈L243-257) — unit tests gate on
+  `## Unit Tests: enabled` in **`project.md`**; default disabled.
+- `## Run Tests` (`runTests`) is **not** consumed by any phase directly — only the `/test`
+  agent prompt reads it. So it's the *command*, not the *gate*.
+- Gherkin `.feature` generation (scenario_writer L92) **is** language-agnostic — reusable.
+
+### 2f. Phase composition — the one clean lever that already exists
+Verified orchestrator → phase map:
+
+| Orchestrator | Scenario | StepDef | Unit-test phase |
+|---|---|---|---|
+| `adwBuild` | ✗ | ✗ | ✗ |
+| `adwPlanBuild` | ✗ | ✗ | ✓ |
+| `adwPlanBuildDocument` | ✗ | ✗ | ✓ |
+| `adwTest` | ✗ | ✗ | ✓ |
+| `adwPlanBuildReview` | ✓ | ✗ | ✓ |
+| `adwPlanBuildTest` | ✗ | ✓ | ✓ |
+| `adwPlanBuildTestReview` | ✓ | ✓ | ✓ |
+| `adwSdlc` | ✓ | ✓ | ✓ |
+
+Unit-test gate is a **hard gate**: `unitTestPhase.ts` → `process.exit(1)` on failure, no PR.
+
+---
+
+## 3. The three holes any "just configure it" plan hits
+
+1. **N/A ≠ skip.** `## Run Scenarios by Tag: N/A` skips scenario *execution*
+   (`scenarioTestPhase.ts:70`) but not *generation*; generation bootstraps cucumber.
+   Real lever today = pick an orchestrator with no scenario phase.
+2. **Two settings, not one.** Unit tests need **both** `## Unit Tests: enabled` (project.md,
+   the gate) **and** `## Run Tests` (commands.md, the command).
+3. **`src/` gate = silent green.** `test.md` skips the suite and reports passed when no `src/`
+   exists. Fatal for flat Python repos; the loop lies about passing.
+
+---
+
+## 4. Recommended design — a language/framework adapter seam
+
+Frame the grilling around this concrete target so it has something to attack.
+
+**Core idea:** introduce one config concept — a **stack/profile** — and route every hardcoded
+decision through it instead of literals.
+
+1. **Add a `## Stack` (or `## Language`/`## Test Framework`) key** to `commands.md` (or
+   `project.md`), parsed in `projectConfig.ts` into a typed `stack` field
+   (e.g. `node-bun-cucumber` | `python-pytest-pytestbdd`). Add it to `HEADING_TO_KEY`.
+2. **Make `getDefault*Config()` switch on `stack`.** Python profile defaults:
+   `pip install -r requirements.txt`, `pytest -q`, `pytest -m "{tag}"` (pytest-bdd tag
+   selection), no `bunx tsc`.
+3. **Parameterize the three prompts** (`generate_step_definitions.md`, `scenario_writer.md`,
+   `test.md`) on `stack`:
+   - stepdef gen: emit pytest-bdd Python (`from pytest_bdd import scenarios, given, when, then`)
+     into `tests/step_defs/` instead of TS into `features/.../step_definitions/`.
+   - scenario writer: keep Gherkin output; bootstrap **pytest-bdd** (add deps to
+     `requirements.txt`, create `conftest.py`) instead of cucumber when none configured.
+   - test runner: **drop the `src/` assumption**; discover the test dir from config
+     (`## Test Directory`, default `tests/`); never "skip-as-passed" on a missing dir —
+     missing tests when unit tests are *enabled* should be a **hard fail or explicit warning**,
+     not green.
+4. **Provide a Python mock-harness story** (or explicitly scope BDD out for v1). The TS mock
+   harness (`test/mocks/*.ts`) doesn't apply; pytest equivalents = fixtures, `responses`/
+   `httpx_mock`, Flask test client, `tmp_path`, `monkeypatch`.
+5. **Preserve config across upgrade.** Confirm `commands.md`/`project.md` are honoured (not
+   regenerated) on `adwUpgrade`; if the prompts must change, they live in the framework — so
+   the adapter must be *upstreamed*, not forked per-target.
+
+**Phasing suggestion:** ship pytest **unit** support first (smaller surface: `stack` key +
+defaults + `test.md` de-`src/`-ing + gate). Defer pytest-bdd stepdef generation to a second
+pass — Gherkin is already language-agnostic, so only the stepdef emitter + harness are new.
+
+---
+
+## 5. Questions the grilling must resolve
+
+- **Abstraction level:** one `stack` enum, or independent `language` + `unitFramework` +
+  `bddFramework` axes? (Vestmatic is mixed Python+Node — does per-issue or per-path stack
+  selection ever matter?)
+- **Prompt strategy:** branch the existing three prompts on `stack`, or split into
+  per-stack prompt files selected by the phase? (Maintainability vs. prompt sprawl.)
+- **Silent-green:** should "unit tests enabled but no tests found / no test dir" be a hard
+  fail, a warning, or configurable? (Strongly lean hard-fail.)
+- **BDD scope for v1:** support pytest-bdd now, or ship pytest-unit only and keep BDD
+  TS-only until demand is real? (Vestmatic's near-term value is unit/regression + math
+  correctness; BDD is lower priority.)
+- **Mock harness:** does ADW provide a Python harness, document a recommended one, or declare
+  runtime-dependent BDD scenarios out of scope for Python v1?
+- **Upgrade durability:** is `project.md` preserved on upgrade? If not, the unit-test *gate*
+  flag is fragile — should the gate move to `commands.md` (confirmed-honoured) instead?
+- **Backward compat:** absent `## Stack` must default to today's `node-bun-cucumber` so no
+  existing TS target regresses.
+- **Validation:** add a `commands.md`/stack consistency check (e.g. a Python stack with a
+  `cucumber-js` run command should error at parse time, not silently mis-generate).
+
+---
+
+## 6. Interim stance for vestmatic until ADW is fixed
+
+- Skip BDD by running **`adwPlanBuild`** / **`adwPlanBuildDocument`** (no scenario/stepdef
+  phases). The N/A flags are not the mechanism.
+- Add pytest to the repo (`tests/`, `pyproject.toml`/`pytest.ini`) and **run it outside ADW**
+  (CI + local + optional pre-push hook). Do **not** rely on ADW's `/test` agent to run pytest
+  — the `src/` gate makes it report green without running anything.
+- The ADW build agent may *write* pytest as it implements; treat those as drafts you execute
+  yourself until the runner is Python-ready.

--- a/specs/issue-584-adw-vv6d4h-classifier-can-assig-sdlc_planner-remove-adw-init-from-valid-types.md
+++ b/specs/issue-584-adw-vv6d4h-classifier-can-assig-sdlc_planner-remove-adw-init-from-valid-types.md
@@ -1,0 +1,120 @@
+# Bug: Classifier can assign the removed `/adw_init` bootstrap type, blocking issues with an ENOENT plan-file error
+
+## Metadata
+issueNumber: `584`
+adwId: `vv6d4h-classifier-can-assig`
+issueJson: `{"number":584,"title":"Classifier can assign a removed bootstrap type, blocking issues with an ENOENT plan-file error","body":"The trigger classifier can assign an issue the operator-only bootstrap type /adw_init. That type lost its dedicated orchestrator in #547, so it silently falls back to adwPlanBuildTest.tsx, which then runs /adw_init as a plan agent. /adw_init writes no plan file, so the build phase dies with ENOENT on the plan file and the issue is moved to Blocked. Observed on issue #576. Root cause: /adw_init is still listed in VALID_ISSUE_TYPES (adws/types/issueTypes.ts), the exact-match domain the AI classifier builds its regex from, and the --type CLI-validation domain in orchestratorCli.ts. Proposed fix: drop /adw_init from VALID_ISSUE_TYPES while keeping it in the IssueClassSlashCommand union.","state":"OPEN","author":"paysdoc","labels":["adw:bug"],"createdAt":"2026-06-15T12:16:49Z","comments":[],"actionableComment":null}`
+
+## Bug Description
+The trigger classifier can assign an issue the operator-only bootstrap type `/adw_init`. Because #547 removed its dedicated orchestrator, `getWorkflowScript('/adw_init')` falls back to `adws/adwPlanBuildTest.tsx`, which then runs `/adw_init` as a **plan agent**. `/adw_init` is a target-repo bootstrap command — it regenerates `.adw/` config and **writes no plan file**. The build phase then cannot find a plan file in the worktree, falls back to the legacy `specs/issue-{N}-plan.md`, and `fs.readFileSync` throws `ENOENT`, after which the issue is moved to **Blocked**.
+
+**Expected behavior:** The auto-classifier (and the `--issue-type` CLI override) should only ever assign real, auto-runnable workflow types — `/chore`, `/bug`, `/feature`, `/pr_review`. It must never assign `/adw_init`.
+
+**Actual behavior:** The classifier can emit `/adw_init`, which dead-ends in an `ENOENT` on the plan file and blocks the issue.
+
+**Symptoms observed on issue #576 ("durable unit-test gate for `adw.yml`"):**
+- `adwinit-` branch prefix and `adwinit:` commit prefix on the run (confirms classification as `/adw_init`).
+- Workflow failure:
+  ```
+  plan-build-test-orchestrator workflow failed: Error: Cannot read plan file at
+  .worktrees/adwinit-issue-576-adw-yml-unit-test-gate/specs/issue-576-plan.md:
+  ENOENT: no such file or directory
+  ```
+- Issue moved to **Blocked** on the project board.
+
+## Problem Statement
+`/adw_init` appears in `VALID_ISSUE_TYPES` (`adws/types/issueTypes.ts`). That array is simultaneously:
+1. the exact-match domain the AI classifier builds its capture regex from (`adws/core/issueClassifier.ts` line 67), and
+2. the validation domain for the `--issue-type` CLI option (`adws/core/orchestratorCli.ts` line 57).
+
+Because `/adw_init` has **no** orchestrator mapping (`issueTypeToOrchestratorMap` was relaxed to `Partial<Record<...>>` in #547), any path that yields `/adw_init` routes to the generic `adwPlanBuildTest.tsx` fallback, runs `/adw_init` as a plan agent, and dies with `ENOENT` in the build phase. We must make `/adw_init` **un-assignable** by the classifier and CLI, while keeping it a valid type-union member so the prefix/alias/model/comment maps and the manual init/upgrade flow keep compiling.
+
+## Solution Statement
+Remove the single `/adw_init` element from the `VALID_ISSUE_TYPES` array in `adws/types/issueTypes.ts`, **keeping** `/adw_init` in the `IssueClassSlashCommand` union (line 5) and the `SlashCommand` union (line 53).
+
+This one change:
+- Drops `/adw_init` from the classifier's regex domain (`issueClassifier.ts` line 67), so the classifier can never capture it. It degrades to the last real type in the AI output, or defaults to `/feature` when none is present — it can never route to `/adw_init` again.
+- Drops `/adw_init` from the `--issue-type` CLI validation domain (`orchestratorCli.ts` line 57) and from the printed usage text, so `--issue-type /adw_init` is rejected.
+
+Add a focused regression test that (1) asserts `VALID_ISSUE_TYPES` excludes `/adw_init` and equals exactly the four real types, and (2) drives the **real** `classifyGitHubIssue` with a mocked classification agent returning `/adw_init` to prove it degrades to `/feature` and never returns `/adw_init`. Keep `workflowMapping.test.ts` exactly as-is (the type union still includes `/adw_init`, so that fallback test still compiles and passes).
+
+## Steps to Reproduce
+1. Have an issue whose content makes the AI classifier emit `/adw_init` (e.g. an `adw.yml`-themed issue like #576).
+2. The cron/webhook trigger calls `classifyIssueForTrigger` / `classifyGitHubIssue`; the regex built from `VALID_ISSUE_TYPES` (which still contains `/adw_init`) captures `/adw_init` from the model output.
+3. `getWorkflowScript('/adw_init')` returns `adws/adwPlanBuildTest.tsx` (no orchestrator mapping → fallback).
+4. The plan phase runs `/adw_init` as the plan agent; no `specs/issue-{N}-adw-{adwId}-sdlc_planner-*.md` plan file is written (it generates `.adw/` config instead).
+5. The build phase resolves the plan path via `getPlanFilePath`, finds nothing in the worktree, falls back to `specs/issue-{N}-plan.md`, and `fs.readFileSync` throws `ENOENT: no such file or directory` (`adws/phases/buildPhase.ts` line 49–56).
+6. The issue is moved to **Blocked**.
+
+**Deterministic unit reproduction (used by the regression test):** mock the classification agent (`runClaudeAgentWithCommand`) to return `{ success: true, output: '/adw_init' }`; before the fix, `classifyGitHubIssue(...)` returns `issueType: '/adw_init'`; after the fix it returns `issueType: '/feature'`.
+
+## Root Cause Analysis
+The classifier and CLI both derive their assignable domain from `VALID_ISSUE_TYPES`. Issue #547 removed the `/adw_init` orchestrator (deleting `adwInit.tsx` and relaxing `issueTypeToOrchestratorMap` from `Record` to `Partial<Record<...>>`) but **left `/adw_init` in `VALID_ISSUE_TYPES`**. That left a latent trap: `/adw_init` stayed classifiable/assignable yet had no orchestrator, so it silently fell back to `adwPlanBuildTest.tsx`, which runs `/adw_init` as a plan agent that writes no plan file → `ENOENT` in the build phase → issue Blocked.
+
+The `adw:*` label-override path **cannot** produce `/adw_init` (`issueTypeToAdwLabel('/adw_init')` returns `null` — there is no `adw:adw_init` label), so the AI classifier and the `--issue-type` CLI override are the only producers. Closing those two paths by removing `/adw_init` from `VALID_ISSUE_TYPES` eliminates the trap at its source.
+
+## Relevant Files
+Use these files to fix the bug:
+
+- `adws/types/issueTypes.ts` — **THE FIX.** Remove `/adw_init` from the `VALID_ISSUE_TYPES` array (line 7). Keep `/adw_init` in the `IssueClassSlashCommand` union (line 5) and the `SlashCommand` union (line 53) — both unions must remain intact so the prefix/alias/model/comment maps and the manual init/upgrade flow keep compiling.
+- `adws/core/issueClassifier.ts` — builds the capture regex from `VALID_ISSUE_TYPES` (lines 67–70). After the fix, `/adw_init` is out of the regex domain; `classifyWithIssueCommand` degrades to the last real type or defaults to `/feature`. No code change here; behavior is locked in by the new test.
+- `adws/core/orchestratorCli.ts` — validates `--issue-type` against `VALID_ISSUE_TYPES` (line 57) and prints it in usage text (lines 108, 121). After the fix, `--issue-type /adw_init` is rejected. No code change.
+- `adws/types/issueRouting.ts` — `commitPrefixMap`, `branchPrefixMap`, and `branchPrefixAliases` are full `Record<IssueClassSlashCommand, ...>` maps that still require a `/adw_init` entry; because the union is unchanged, they stay valid. Confirms why the union must be kept. No change.
+- `adws/core/workflowMapping.ts` (+ `issueTypeToOrchestratorMap` in `issueRouting.ts`) — `/adw_init` has no entry in the `Partial` map → `getWorkflowScript('/adw_init')` falls back to `adws/adwPlanBuildTest.tsx`. This is the downstream trap the fix defuses upstream. No change.
+- `adws/github/labelManager.ts` — `issueTypeToAdwLabel('/adw_init')` returns `null`; confirms the label-override path cannot produce `/adw_init`, so the classifier/CLI are the only producers. No change.
+- `adws/phases/buildPhase.ts` (lines 49–56) and `adws/agents/planAgent.ts` `getPlanFilePath` (lines 85–92) — the `ENOENT` crash site and the legacy `specs/issue-{N}-plan.md` fallback. Documents the failure tail. No change.
+- `adws/core/__tests__/workflowMapping.test.ts` — keep exactly as-is; it documents the intentional `/adw_init` → fallback mapping and still compiles because the type union is unchanged.
+- `app_docs/feature-cy2xzc-delete-adwinit-tsx-orchestrator.md` — conditional doc (matched via `.adw/conditional_docs.md`): context for #547 removing the `/adw_init` orchestrator and why a `/adw_init` lookup now returns `undefined`/falls back. Read for root-cause context.
+- `app_docs/feature-u8okxe-bug-sdlc-chore-classifier.md` — conditional doc (matched via `.adw/conditional_docs.md`): context for issue classification logic and the `/classify_issue` command / orchestrator routing. Read for classifier-behavior context.
+
+### New Files
+- `adws/core/__tests__/issueClassifier.test.ts` — regression test covering: (1) `VALID_ISSUE_TYPES` excludes `/adw_init` and equals `['/chore','/bug','/feature','/pr_review']`; (2) with `runClaudeAgentWithCommand` mocked to return `/adw_init`, `classifyGitHubIssue` degrades to `/feature` (never `/adw_init`); (3) with output `'... /bug ... /adw_init'`, it captures `/bug` (the last real type, ignoring `/adw_init`).
+
+## Step by Step Tasks
+IMPORTANT: Execute every step in order, top to bottom.
+
+### 1. Remove `/adw_init` from the classifier/CLI domain
+- In `adws/types/issueTypes.ts`, change line 7 from:
+  ```ts
+  export const VALID_ISSUE_TYPES: readonly IssueClassSlashCommand[] = ['/chore', '/bug', '/feature', '/pr_review', '/adw_init'] as const;
+  ```
+  to:
+  ```ts
+  // /adw_init is intentionally excluded: it is an operator-only bootstrap command with no
+  // orchestrator since #547. Keeping it here would let the AI classifier / --issue-type CLI
+  // assign it, which dead-ends in an ENOENT plan-file error (issue #584). It remains in the
+  // IssueClassSlashCommand/SlashCommand unions for the prefix/alias maps and manual init flow.
+  export const VALID_ISSUE_TYPES: readonly IssueClassSlashCommand[] = ['/chore', '/bug', '/feature', '/pr_review'] as const;
+  ```
+- Do **NOT** modify the `IssueClassSlashCommand` union (line 5) or the `SlashCommand` union (line 53). `/adw_init` must stay a type member so `commitPrefixMap`/`branchPrefixMap`/`branchPrefixAliases` (`Record<IssueClassSlashCommand, ...>`), the `modelRouting.ts` maps (`Record<SlashCommand, ...>`), `workflowCommentsIssue.ts`, and the manual init/upgrade flow keep compiling.
+
+### 2. Add the classifier regression test
+- Create `adws/core/__tests__/issueClassifier.test.ts`.
+- Mock `'../../agents/claudeAgent'` so `runClaudeAgentWithCommand` is a `vi.fn()` you control (mirror the hoisted-mock pattern in `adws/agents/__tests__/refactorAgent.test.ts`). **Do NOT** mock `'../../core'` or `'../../types/issueTypes'` — the test must exercise the **real** `VALID_ISSUE_TYPES` and the real regex-building code in `issueClassifier.ts`.
+- Add a small `makeIssue(overrides?)` helper returning a valid `GitHubIssue` (e.g. `number: 576`, a title/body, `author: { login: 'paysdoc', isBot: false }`, empty `assignees`/`labels`/`comments`, ISO `createdAt`/`updatedAt`, and a `url`). `classifyGitHubIssue` does not call `fetchGitHubIssue`, so no GitHub/network mocking is required.
+- **Test A (domain invariant):** `expect([...VALID_ISSUE_TYPES]).toEqual(['/chore', '/bug', '/feature', '/pr_review'])` and `expect(VALID_ISSUE_TYPES).not.toContain('/adw_init')`.
+- **Test B (cannot route to `/adw_init`):** mock the agent to resolve `{ success: true, output: '/adw_init' }`; `const result = await classifyGitHubIssue(makeIssue())`; assert `result.issueType` is `'/feature'` and `expect(result.issueType).not.toBe('/adw_init')`.
+- **Test C (degrades to last real type):** mock the agent to resolve `{ success: true, output: 'this looks like /bug, not /adw_init' }`; assert `result.issueType` is `'/bug'`.
+- Reset the mock between tests (`beforeEach(() => mock.mockReset())`).
+
+### 3. Validate
+- Run every command in **Validation Commands** below. All must pass with zero regressions.
+
+## Validation Commands
+Execute every command to validate the bug is fixed with zero regressions.
+
+- `bunx tsc --noEmit` — base type check passes (proves removing `/adw_init` from the array breaks nothing; the union is still complete for the `Record<IssueClassSlashCommand, ...>` maps).
+- `bunx tsc --noEmit -p adws/tsconfig.json` — adws project type check passes.
+- `bun run lint` — eslint clean.
+- `bun run build` — `tsc` build succeeds.
+- `bun run test:unit` — full vitest suite passes, including the new `adws/core/__tests__/issueClassifier.test.ts` and the unchanged `adws/core/__tests__/workflowMapping.test.ts`.
+- `bunx vitest run adws/core/__tests__/issueClassifier.test.ts` — the new regression test passes. (To confirm it actually guards the bug: temporarily re-add `/adw_init` to `VALID_ISSUE_TYPES` → Test A and Test B go RED; restore the fix → GREEN.)
+
+**Before/after reproduction:** With `/adw_init` present in `VALID_ISSUE_TYPES`, `classifyGitHubIssue` returns `/adw_init` for an agent output of `/adw_init` (the bug). With it removed, the same input returns `/feature`. Test B encodes exactly this before/after difference.
+
+## Notes
+- Adhere to `.adw/coding_guidelines.md`. Note that line 15 states ADW itself does not rely on unit tests as quality gates — but `.adw/project.md` declares `## Unit Tests: enabled` and the repo already ships vitest suites (`bun run test:unit`, e.g. `workflowMapping.test.ts`). The bug explicitly requests a unit regression test, so adding one is consistent with both the project config and the existing suite.
+- No new libraries are required. (If one were ever needed, the install command per `.adw/commands.md` is `bun add <package>`.)
+- **Surgical scope:** exactly one production line changes (the `VALID_ISSUE_TYPES` array literal, plus an explanatory comment) and one new test file is added. The `IssueClassSlashCommand`/`SlashCommand` unions, all prefix/alias/model/comment maps, `issueTypeToOrchestratorMap`, and `workflowMapping.test.ts` are intentionally untouched.
+- Conditional docs consulted per `.adw/conditional_docs.md`: `app_docs/feature-cy2xzc-delete-adwinit-tsx-orchestrator.md` (#547 orchestrator removal — root-cause context) and `app_docs/feature-u8okxe-bug-sdlc-chore-classifier.md` (issue classification / `/classify_issue` routing).
+- **Operational cleanup (NOT part of this code change — perform after the fix merges):** reset the stranded worktree `.worktrees/adwinit-issue-576-adw-yml-unit-test-gate`; remove the misplaced untracked plan written to the main repo root, `specs/issue-576-adw-adw-unknown-sdlc_planner-durable-unit-test-gate-adw-yml.md`; and run `## Cancel` on issue #576 so it re-enters the queue and reclassifies to a real type.

--- a/specs/prd/multi-language-test-and-bdd-support.md
+++ b/specs/prd/multi-language-test-and-bdd-support.md
@@ -110,6 +110,9 @@ Rollout is staged: the unit-test layer ships first, the generation/proof/screens
     so that value lands fast and risk is staged.
 30. As an existing TypeScript-target operator, I want absent descriptor fields to default to today's
     Bun/cucumber behavior, so that my repo does not regress.
+31. As an ADW maintainer, I want the scenario format mandated as Gherkin `.feature` for every target
+    language, so that the promotion, per-issue-sweep, and vocabulary subsystems keep working without
+    per-language parsers.
 
 ## Implementation Decisions
 
@@ -122,6 +125,21 @@ Rollout is staged: the unit-test layer ships first, the generation/proof/screens
   thin.
 - **UI BDD is in scope for v1**, which puts the proof layer (detection, parsing, artifact harvest)
   in scope.
+
+**Scenario format — Gherkin mandate**
+- All ADW targets MUST use a **Gherkin-based BDD runner** (Ruby → cucumber-ruby, Python →
+  behave / pytest-bdd, Rust → cucumber-rs, Go → godog, JS/TS → cucumber-js, etc.). The scenario
+  format is fixed to **Gherkin `.feature`**; only the *step-def runtime* varies per language.
+- Rationale: the promotion subsystem (`promotionScorer`, `promotionMover`, `vocabularyParser`,
+  `scenarioParser`), `perIssueScenarioSweep` (`feature-{N}.feature`), and `@adw-{N}` / `@regression`
+  tag discovery all parse Gherkin. Allowing a native non-Gherkin runner would require a per-language
+  parser/mover for each of those — explicitly out of scope (see Out of Scope).
+- `adw_init` selects a Gherkin runner for the detected language and **never emits a non-Gherkin
+  `bddFramework`**. If it cannot identify a Gherkin runner for the stack, it falls back to a Gherkin
+  runner (today's cucumber-js behavior for TS) rather than a native test framework, and flags via the
+  unverified channel.
+- The `stackCoherenceCheck` additionally asserts the detected `bddFramework` is Gherkin-based; a
+  non-Gherkin framework warns loudly through the unverified channel (does not block).
 
 **Config & descriptor**
 - New detected fields extend existing files: `scenarios.md` gains `bddFramework` and
@@ -221,6 +239,11 @@ the resolve-loop prompt changes.
   mechanism that makes fix-forward safe.
 - A per-language code provider (`BddProvider` registry) or per-language prompt files — explicitly
   rejected in favor of one polymorphic prompt.
+- Native non-Gherkin BDD/test runners as the scenario contract (raw `pytest`, RSpec example specs,
+  bare `cargo test`). Every language ADW realistically targets has a mature Gherkin runner, so the
+  mandate costs nothing now; supporting a non-Gherkin contract would require per-language promotion /
+  sweep / vocabulary parsers and is deferred to a future PRD — relevant only for emerging languages
+  that lack a Gherkin runner (e.g. Zig, Nim).
 - Promoting `adw.yml` into a broad policy file; only the `unitTests` key is added now (with commented
   documentation of future options).
 - Hard-gating on config incoherence (the check warns, it does not block).
@@ -248,4 +271,13 @@ the resolve-loop prompt changes.
   hash does not move, regeneration does not run, and targets get the new parser reading old config
   (absent field → silent default). Adding a parsed field and teaching `adw_init` to emit it must
   always be the same PR.
+- **Gherkin coupling is load-bearing.** The promotion / per-issue-sweep / vocabulary pipeline is
+  hardwired to Gherkin `.feature` (`scenarioParser`, `FEATURE_FILENAME_RE`, `promotion*`,
+  `vocabularyParser`). This is why the descriptor varies only the step-def runtime, never the scenario
+  format. The coupling is *latent* (not a break) precisely because every realistically-targeted
+  language has a Gherkin runner; it would only surface if a target abandoned Gherkin. The mandate
+  converts that latent landmine into a stated constraint at zero cost to Python / Ruby / Rust / Go /
+  JVM / .NET / PHP / Swift. The original PRD grill missed it because it framed the design around the
+  execution/generation seam, where Gherkin is the universal substrate; the promotion subsystem sits
+  downstream and is language-neutral *only as long as Gherkin holds*.
 - Source grilling transcript and decisions: `ADW_PYTHON_SUPPORT_RECOMMENDATION.md` (Q1–Q24).

--- a/specs/prd/multi-language-test-and-bdd-support.md
+++ b/specs/prd/multi-language-test-and-bdd-support.md
@@ -1,0 +1,251 @@
+# PRD: Multi-Language Test & BDD Support
+
+## Problem Statement
+
+ADW is hardcoded to a Bun / TypeScript / cucumber-js / `src/`-layout stack. When pointed at a
+non-TypeScript target — the motivating case is `vestmatic-research`, a flat-layout Python
+(Flask) project — it does not drive tests or BDD; worse, it **reports green on work it never
+verified**. Concretely, today:
+
+- The unit-test runner (`/test`) appends `--run src` and **skips-as-passed when no `src/`
+  directory exists**, so a flat Python repo's pytest suite is never run yet reports passed.
+- The scenario proof runner only recognizes step-definition files ending in `.ts` under
+  `features/step_definitions/`, so any non-TS BDD suite is **skipped with no blocker failures** —
+  another silent green.
+- Pass/fail is derived by regexing cucumber-js's human-readable stdout summary, which matches
+  nothing for pytest-bdd / godog / Playwright.
+- The scenario proof captures stdout only and harvests **zero image artifacts**, so BDD runs
+  produce no reviewable screenshots — the observed "vestmatic screenshots are dead" symptom.
+- The unit-test gate flag lives in `project.md`, which is regenerated (and silently dropped) on
+  every framework upgrade.
+
+The owner wants ADW to drive plan → build → (scenario → stepdef) → test → review for arbitrary
+languages (Python first, but Go/Rust without a framework change), with test execution wired as a
+hard gate the way it is for TypeScript today, and with self-explanatory proof — including inline
+screenshots — surfaced on every PR.
+
+## Solution
+
+Introduce a **detected-descriptor + one-polymorphic-prompt + typed-config** seam so language and
+framework choices flow from one auto-detection pass instead of from hardcoded literals. New
+languages work with **zero framework code change**: `adw_init` already detects the manifest, and
+the generating agent relies on Claude's own knowledge of the named BDD framework to emit correct
+step definitions — the run itself is the correctness guardrail.
+
+Pass/fail moves off fragile stdout parsing onto a **structured-report contract** (JUnit XML), which
+also detects "zero tests ran" and kills the silent-green class of bug. The proof layer is rebuilt
+to be language-agnostic: step-def detection by configured directory + extension, one report parser,
+and an artifact harvester that collects screenshots written to a known directory and uploads them to
+R2. Every PR receives a **self-explanatory proof comment** with inline screenshots and R2 links.
+
+The unit-test gate becomes a durable, opt-out policy in `.github/adw.yml` (which survives
+regeneration), defaulting to enabled. Hermeticity for UI BDD is the target app's responsibility,
+created and maintained by the build agent as definition-of-done; the resolve loop may edit app code
+to reach it, capped and hard-failing if it cannot, with the Gherkin contract frozen during resolve
+and re-validated against the issue to prevent gaming.
+
+Rollout is staged: the unit-test layer ships first, the generation/proof/screenshot overhaul second.
+
+## User Stories
+
+1. As an ADW operator, I want ADW to run a flat-layout Python project's pytest suite, so that my
+   tests actually execute instead of being skipped.
+2. As an ADW operator, I want a missing `src/` directory to stop meaning "skip and pass," so that
+   ADW never reports green on an unrun suite.
+3. As an ADW operator, I want the test root directory to be configurable per target repo, so that
+   non-`src/` layouts are honored.
+4. As an ADW operator, I want unit tests to run via the command declared in `commands.md`, so that
+   each repo's real test runner is used.
+5. As an ADW operator targeting Python, I want pytest failures to gate the PR and trigger the
+   auto-fix loop, so that broken code does not merge.
+6. As an ADW operator, I want to add a new language (Go, Rust) without a framework code change, so
+   that ADW generalizes beyond the languages explicitly built.
+7. As an ADW operator, I want step definitions generated in the target language's BDD framework, so
+   that scenarios are wired correctly for pytest-bdd / godog / cucumber-js alike.
+8. As an ADW operator, I want generated scenarios to be executed once as a guardrail, so that
+   incorrect generation surfaces as a failing run rather than silently shipping.
+9. As an ADW operator, I want pass/fail derived from a structured machine-readable report, so that
+   the verdict is robust across runners and not dependent on stdout formatting.
+10. As an ADW operator, I want "zero testcases ran" to be detectable, so that a misconfigured or
+    non-discovering runner cannot report green.
+11. As an ADW maintainer, I want ADW's own cucumber-js suite migrated onto the same structured-report
+    rail, so that the multi-language path is dogfooded and there is a single parser.
+12. As an ADW operator running UI BDD, I want scenario screenshots harvested and uploaded to R2, so
+    that visual proof exists for review.
+13. As an ADW operator, I want a self-explanatory proof comment on each PR, so that a reviewer can
+    understand what ran and what passed without digging into logs.
+14. As a reviewer, I want screenshots inlined in the proof comment (with R2 links as fallback), so
+    that I can see the evidence without leaving the PR.
+15. As a reviewer, I want the proof comment grouped by scenario in collapsible sections, so that a
+    large run stays scannable.
+16. As an ADW operator, I want the unit-test gate to be a durable policy that survives framework
+    upgrades, so that it is not silently reset.
+17. As an ADW operator, I want the gate to default to enabled (opt-out), so that silent-green is
+    prevented by default rather than requiring opt-in.
+18. As an ADW operator, I want a self-documenting `adw.yml` with commented options, so that I know
+    how to configure policy without reading source.
+19. As an ADW operator, I want `adw_init` to create `adw.yml` only when absent and never overwrite
+    it, so that my policy edits persist across regeneration.
+20. As an ADW operator, I want "enabled but zero tests" to hard-fail only when a test framework is
+    detected in dependencies, so that a discovery break is caught while a genuinely test-less early
+    repo is not blocked.
+21. As an ADW operator on a repo with no detected test framework, I want a loud, visible signal
+    (PR/issue comment + `adw:unverified` label), so that fix-forward gets a real signal rather than
+    a buried log line.
+22. As an ADW maintainer, I want a coherence check that flags an incoherent detected config (e.g.
+    Python stack with a cucumber-js run command), so that `adw_init`'s own mis-detection is surfaced.
+23. As an ADW operator running UI BDD, I want the target app's hermetic test mode created and
+    maintained by the build agent, so that scenarios run against stubbed externals and seeded data.
+24. As an ADW operator, I want the resolve loop able to edit app code to reach hermeticity, so that a
+    non-hermetic app can be made testable in-loop.
+25. As an ADW operator, I want resolve attempts capped and the workflow hard-failed if hermeticity is
+    not reached, so that the loop does not run unbounded.
+26. As an ADW operator, I want the Gherkin contract frozen during resolve and re-validated against
+    the issue, so that the resolve loop cannot make the run green by weakening the scenario.
+27. As an ADW operator, I want the regression suite enforced as a hard gate on every resolve re-run,
+    so that a fix does not introduce a regression.
+28. As an ADW maintainer, I want a Python fixture target exercised end-to-end in CI, so that the
+    non-TS path is verified in the hermetic Docker runner and not only by live runs.
+29. As an ADW maintainer, I want the unit-test layer to ship before the generation/proof overhaul,
+    so that value lands fast and risk is staged.
+30. As an existing TypeScript-target operator, I want absent descriptor fields to default to today's
+    Bun/cucumber behavior, so that my repo does not regress.
+
+## Implementation Decisions
+
+**Architecture**
+- The locus of per-language variation is a **detected descriptor** parsed into typed config, a
+  **single polymorphic prompt** per generation step, and Claude's own framework knowledge — **not**
+  per-language code, per-language prompt files, or a stack enum. Adding a language requires no
+  framework PR.
+- The **generated scenarios are run once as the correctness guardrail**; generation prompts stay
+  thin.
+- **UI BDD is in scope for v1**, which puts the proof layer (detection, parsing, artifact harvest)
+  in scope.
+
+**Config & descriptor**
+- New detected fields extend existing files: `scenarios.md` gains `bddFramework` and
+  `stepDefDirectory`; `commands.md` gains `testFramework`, `testDirectory`, and the structured-report
+  flag. Parsed in the project-config loader with new pure parsers mirroring the existing
+  command/scenario parsers. Absent fields fall back to today's Bun/cucumber defaults.
+- The "test framework detected" signal is **presence of a test framework in dependencies/config**,
+  emitted by `adw_init`.
+- The unit-test gate is a **policy** in `.github/adw.yml`, which is not regenerated. `adw_init`
+  creates `adw.yml` with a self-documenting commented template **only when absent** and never
+  overwrites it. The gate is read in the normal workflow-init path (not only on upgrade) and
+  **defaults to enabled (opt-out)**.
+
+**Unit-test layer (ships first)**
+- Drop the hardcoded `src/` gate; run the `commands.md` test command against the configured
+  `testDirectory`.
+- Verdict logic: enabled + tests pass → pass; enabled + failures → hard fail (existing gate);
+  enabled + **zero testcases** → hard fail **if a test framework was detected**, else warn.
+
+**Structured-report contract**
+- Pass/fail comes from a **JUnit XML report** emitted by the runner to a known path; one parser
+  reads it. `parseCucumberSummary` is **deleted**, and ADW's own cucumber-js suite is **migrated
+  onto the same rail** (the "noisy non-zero exit but clean tally" override is reconstructed in
+  structured-report terms). Single parser, no legacy branch.
+
+**Proof layer**
+- Step-def presence is detected by `stepDefDirectory` + language extension (the `.ts`-only gate is
+  removed).
+- Screenshots ride a **known-directory convention**: ADW exports a proof directory (env var); runner
+  config and generated step defs write images there; a harvester globs and uploads to R2 via the
+  existing upload service. No per-runner extraction code.
+- A **coherence check** asserts the detected framework matches the run-command language; on mismatch
+  it warns loudly (does not block) through the unverified-signal channel.
+- All warn / unverified outcomes emit a **PR/issue comment + `adw:unverified` label**.
+
+**PR proof surfacing**
+- A **proof publisher** composes the JUnit summary and harvested R2 artifacts into a
+  self-explanatory **PR comment** (not the description, which is written before proof exists).
+  Screenshots are **inlined** via markdown image embeds of public R2 URLs, grouped under collapsible
+  `<details>` per scenario, each with its raw R2 link as fallback.
+
+**Hermeticity, resolve, and goal fidelity**
+- Hermeticity is the target app's responsibility (a test mode the app owns), **created and
+  maintained by the build agent as definition-of-done**; generation only drives the browser.
+- The resolve loop may **edit app code** to reach hermeticity, is **capped** via the existing
+  max-retry budget, and **hard-fails** the workflow if hermeticity is not reached.
+- Goal fidelity: the **Gherkin `.feature` is frozen during resolve** (resolve edits step defs and
+  app code only), **plus** a post-resolve validation re-check of scenarios against the issue body,
+  **plus** the `@regression` suite as a hard gate on every re-run.
+
+**Prompts modified**
+- `generate_step_definitions.md` and `scenario_writer.md` become polymorphic on the descriptor;
+  `scenario_writer`'s "bootstrap cucumber when E2E is N/A" behavior is removed (framework selection
+  now belongs to `adw_init`).
+- `test.md` drops `src/`, uses `testDirectory`, and emits the report flag.
+- `adw_init.md` emits the new descriptor fields and creates `adw.yml` if absent.
+- `resolve_failed_scenario.md` (and the test-retry coordinator) gain app-code editing, the Gherkin
+  freeze, the cap/hard-fail, and the post-resolve re-validation.
+
+**Rollout**
+- PR 1: unit-test layer (drop `src/`, configurable `testDirectory`, `adw.yml` gate, JUnit for units).
+- PR 2+: generation/proof/screenshot overhaul, including ADW-self migration onto the JUnit rail.
+
+## Testing Decisions
+
+A good test asserts **external behavior through a module's public interface**, not its internals —
+given inputs produce expected outputs/verdicts, with no assertions on private helpers or call
+sequencing. Prior art: the project's existing pure-helper unit tests (project-config parsing,
+stream parsing, pure decision helpers) and the hermetic Docker `@regression` runner.
+
+Unit-tested modules (scope: **all pure deep modules + a Python fixture e2e**):
+- **`testReportParser`** — JUnit XML fixtures → `{ total, passed, failed, cases[] }`, including the
+  zero-testcases case and malformed/missing report.
+- **`testVerdict`** — table-driven over `(report, frameworkDetected, enabled)` → `pass | hardFail |
+  warn`, covering every Q13/Q14 branch.
+- **`proofArtifactHarvester`** — temp-dir fixtures → expected image path set (empty, nested, mixed
+  extensions).
+- **`stackCoherenceCheck`** — coherent and incoherent detected configs → `{ ok, warning? }`.
+- **`prProofPublisher`** (formatting half) — given summary + R2 URLs → expected markdown
+  (inline embeds, collapsible grouping, link fallback).
+- **Config parser extensions** — `commands.md` / `scenarios.md` new fields and defaults;
+  `adw.yml` `unitTests` parse + create-if-absent template emission (and non-overwrite).
+
+Integration test:
+- **Python fixture target** under the test fixtures tree, with a `@regression` scenario driving ADW
+  end-to-end (detect → generate → run → JUnit parse → image harvest → proof comment) in the Docker
+  runner.
+
+Not unit-tested (verified via the fixture e2e and live fix-forward): the polymorphic prompts and
+the resolve-loop prompt changes.
+
+## Out of Scope
+
+- Pre-built fixtures or explicit framework support for languages beyond Python. Go/Rust/others rely
+  on the descriptor + Claude's knowledge and are validated by **fix-forward** — real issues exercise
+  them and problems are fixed in the framework when surfaced. The loud `adw:unverified` signal is the
+  mechanism that makes fix-forward safe.
+- A per-language code provider (`BddProvider` registry) or per-language prompt files — explicitly
+  rejected in favor of one polymorphic prompt.
+- Promoting `adw.yml` into a broad policy file; only the `unitTests` key is added now (with commented
+  documentation of future options).
+- Hard-gating on config incoherence (the check warns, it does not block).
+- Deep diagnosis of the existing screenshot pipeline beyond the proof-layer rebuild that subsumes it.
+
+## Further Notes
+
+- This redesign closes five silent-green / fragility holes found during grilling beyond the original
+  recommendation doc: the `.ts`-only step-def gate, stdout-regex pass/fail parsing, stdout-only proof
+  with no image harvest, the `project.md` gate flag clobbered on regen, and `adw_init` defaulting the
+  scenario tool to Cucumber on non-recognition.
+- The structured-report migration touches ADW's own self-hosted suite; treat the cutover as a risk to
+  the framework's own green and reconstruct the post-suite-noise exit-code override on the new rail.
+- Defaulting the gate to enabled means existing target repos flip to gating/warning on their next
+  upgrade; the "hard-fail only when a framework is detected" rule bounds the blast radius.
+- **Hash propagation / emit-parse coupling rule.** The framework version hash is computed only over
+  the files declared in `adw_init.md`'s `hashInputs:` frontmatter (currently `adw_init.md` itself +
+  the vocabulary template). Editing `adw_init.md` raises `.adw-version`, which triggers `adwUpgrade`
+  to regenerate `.adw/` across all registered target repos (and ADW-self) on their next workflow —
+  this is the intended propagation, and the source of the default-enabled-gate migration ripple.
+  Framework code (`projectConfig`, `scenarioProof`) and the generation prompts are **not** hash
+  inputs and do not raise the hash; they take effect immediately on merge because they are
+  framework-resident, not stored in target `.adw/`. **Rule for every descriptor change: if you add
+  or rename a parsed `.adw/` field, you MUST also change `adw_init.md` to emit it** — otherwise the
+  hash does not move, regeneration does not run, and targets get the new parser reading old config
+  (absent field → silent default). Adding a parsed field and teaching `adw_init` to emit it must
+  always be the same PR.
+- Source grilling transcript and decisions: `ADW_PYTHON_SUPPORT_RECOMMENDATION.md` (Q1–Q24).

--- a/test/fixtures/jsonl/payloads/classify-bug-then-adw-init.json
+++ b/test/fixtures/jsonl/payloads/classify-bug-then-adw-init.json
@@ -1,0 +1,6 @@
+[
+  {
+    "type": "text",
+    "text": "The report describes a defect in existing behaviour, so the correct ADW classification is /bug. (This is plainly not an operator bootstrap run such as /adw_init.)"
+  }
+]

--- a/test/fixtures/jsonl/payloads/classify-emits-adw-init-only.json
+++ b/test/fixtures/jsonl/payloads/classify-emits-adw-init-only.json
@@ -1,0 +1,6 @@
+[
+  {
+    "type": "text",
+    "text": "This issue asks to (re)bootstrap the repository's ADW configuration files, which reads like an operator bootstrap task, so the closest ADW classification is:\n\n/adw_init"
+  }
+]


### PR DESCRIPTION
## Summary
Promotes the current `dev` work to `main` (9 commits).

### Bugfix — issue #584: exclude `/adw_init` from valid issue types (#585)
- `plan-orchestrator`, `build-agent`, `document-agent`: exclude `/adw_init` from `VALID_ISSUE_TYPES`
- Adds `issueClassifier` tests and BDD coverage (`feature-584.feature` + step definitions)
- Updates `agentic_kpis`

### Docs / specs
- `write-a-prd`: mandate Gherkin scenario format for all languages
- New PRD: multi-language test and BDD support
- `ADW_PYTHON_SUPPORT_RECOMMENDATION.md` spec
- More concise messaging in `grill-me`

## Test plan
- [ ] CI green on `dev`
- [ ] Review issue #584 fix end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)