### PR TITLE
Widen HITL review-PR boundary to match Closes/Implements

### DIFF
--- a/adws/github/hitlBoardNotifier.ts
+++ b/adws/github/hitlBoardNotifier.ts
@@ -99,7 +99,7 @@ function findReviewPr(
   const lister = deps?.listOpenPRs ?? defaultListOpenPRs;
   const prs = lister(repoInfo);
   if (!prs) return null;
-  const boundary = new RegExp(`Implements #${issueNumber}(?!\\d)`);
+  const boundary = new RegExp(`(Closes|Implements) #${issueNumber}(?!\\d)`);
   const matched = prs.filter((pr) => pr.body && boundary.test(pr.body));
   const chosen = selectPreferredPR(matched) as HitlPREntry | null;
   return chosen?.url ?? null;

--- a/app_docs/agentic_kpis.md
+++ b/app_docs/agentic_kpis.md
@@ -8,13 +8,13 @@ Summary metrics across all ADW runs.
 
 | Metric            | Value            | Last Updated        |
 | ----------------- | ---------------- | ------------------- |
-| Current Streak    | 2                | 2026-06-15 22:29:36 |
-| Longest Streak    | 171              | 2026-06-15 22:29:36 |
-| Total Plan Size   | 2086 lines       | 2026-06-15 22:29:36 |
-| Largest Plan Size | 678 lines        | 2026-06-15 22:29:36 |
-| Total Diff Size   | 5945147 lines    | 2026-06-15 22:29:36 |
-| Largest Diff Size | 418153 lines     | 2026-06-15 22:29:36 |
-| Average Presence  | 1.22             | 2026-06-15 22:29:36 |
+| Current Streak    | 4                | 2026-06-15 23:36:55 |
+| Longest Streak    | 195              | 2026-06-15 23:36:55 |
+| Total Plan Size   | 5789 lines       | 2026-06-15 23:36:55 |
+| Largest Plan Size | 699 lines        | 2026-06-15 23:36:55 |
+| Total Diff Size   | 4560427 lines    | 2026-06-15 23:36:55 |
+| Largest Diff Size | 418153 lines     | 2026-06-15 23:36:55 |
+| Average Presence  | 1.10             | 2026-06-15 23:36:55 |
 
 ## ADW KPIs
 
@@ -246,3 +246,4 @@ Detailed metrics for individual ADW workflow runs.
 | 2026-06-15 | y6hjbr-durable-opt-out-unit | 576 | /feature | 3 | 0 | 1314/75/17 | 2026-06-15 21:32:48 | 2026-06-15 21:32:48 |
 | 2026-06-15 | 5jigj8-slack-notifications | 587 | /feature | 1 | 0 | 1596/11/17 | 2026-06-15 21:40:32 | 2026-06-15 21:40:32 |
 | 2026-06-15 | zyaojl-configurable-test-di | 577 | /feature | 2 | 0 | 2728/104/44 | 2026-06-15 22:29:36 | 2026-06-15 22:29:36 |
+| 2026-06-15 | u3l5q0-structured-report-ju | 578 | /feature | 2 | 0 | 1500/146/23 | 2026-06-15 23:36:55 | 2026-06-15 23:36:55 |


### PR DESCRIPTION
## Summary
- Widen the HITL board notifier's review-PR boundary regex to match both `Closes #N` and `Implements #N`, so PRs that reference an issue via `Closes` are now correctly linked.
- Routine `agentic_kpis.md` metrics refresh (streak, plan/diff sizes, latest ADW run row).

## Test plan
- [ ] Existing unit tests for `hitlBoardNotifier` pass with the widened boundary.

🤖 Generated with [Claude Code](https://claude.com/claude-code)