### PR TITLE
fix: park adwUpgrade as claim_lost on non-ff push

### DIFF
--- a/adws/__tests__/adwUpgrade.test.ts
+++ b/adws/__tests__/adwUpgrade.test.ts
@@ -9,7 +9,7 @@ import {
   type UpgradeDeps,
   type UpgradeRunResult,
 } from '../adwUpgrade';
-import { buildClaimBranchName, isAdwComment, parseAdwYml } from '../core';
+import { buildClaimBranchName, isAdwComment, parseAdwYml, isPushRejectionError } from '../core';
 import { commentOnIssue } from '../github';
 import type { CreatePROptions } from '../providers/types';
 
@@ -32,6 +32,7 @@ function makeDeps(overrides: Partial<UpgradeDeps> = {}): UpgradeDeps {
     writeAdwVersion: vi.fn(),
     commitChanges: vi.fn().mockReturnValue(true),
     pushBranch: vi.fn(),
+    isPushRejection: vi.fn().mockReturnValue(false),
     createPullRequest: vi.fn().mockReturnValue({ url: 'https://github.com/acme/target/pull/99', number: 99 }),
     commentOnIssue: vi.fn<typeof commentOnIssue>(),
     ensureLogsDirectory: vi.fn().mockReturnValue('/logs/adwupgrade'),
@@ -255,6 +256,67 @@ describe('executeUpgrade — merge failure (non-fatal)', () => {
     await expect(
       executeUpgrade(541, 'test-id', REPO_INFO, BASE_REPO, FRAMEWORK_ROOT, deps),
     ).resolves.toBeDefined();
+  });
+});
+
+// ── Claim-lost path (non-fast-forward push) ───────────────────────────────────
+
+describe('executeUpgrade — non-fast-forward push parks instead of crashing', () => {
+  function rejectingDeps(extra: Partial<UpgradeDeps> = {}): UpgradeDeps {
+    const nonFf = Object.assign(new Error('failed to push some refs'), {
+      stderr: Buffer.from(' ! [rejected] adw-upgrade-x -> adw-upgrade-x (non-fast-forward)'),
+    });
+    return makeDeps({
+      pushBranch: vi.fn().mockImplementation(() => { throw nonFf; }),
+      isPushRejection: vi.fn().mockReturnValue(true),
+      ...extra,
+    });
+  }
+
+  it('returns outcome=completed, reason=claim_lost on a rejected push', async () => {
+    const result = await executeUpgrade(541, 'test-id', REPO_INFO, BASE_REPO, FRAMEWORK_ROOT, rejectingDeps());
+
+    expect(result.outcome).toBe('completed');
+    expect(result.reason).toBe('claim_lost');
+  });
+
+  it('does not open a PR, merge, or comment when the push is rejected', async () => {
+    const deps = rejectingDeps();
+    await executeUpgrade(541, 'test-id', REPO_INFO, BASE_REPO, FRAMEWORK_ROOT, deps);
+
+    expect(deps.createPullRequest).not.toHaveBeenCalled();
+    expect(deps.mergePR).not.toHaveBeenCalled();
+    expect(deps.commentOnIssue).not.toHaveBeenCalled();
+  });
+
+  it('does not swallow a genuine (non-rejection) push failure — rethrows it', async () => {
+    const fatal = Object.assign(new Error('fatal: unable to access remote'), {
+      stderr: Buffer.from('fatal: Could not read from remote repository'),
+    });
+    const deps = makeDeps({
+      pushBranch: vi.fn().mockImplementation(() => { throw fatal; }),
+      isPushRejection: vi.fn().mockReturnValue(false),
+    });
+
+    await expect(
+      executeUpgrade(541, 'test-id', REPO_INFO, BASE_REPO, FRAMEWORK_ROOT, deps),
+    ).rejects.toThrow('unable to access remote');
+  });
+});
+
+describe('isPushRejectionError', () => {
+  it('classifies a non-fast-forward execSync error (stderr Buffer) as a rejection', () => {
+    const err = Object.assign(new Error('Command failed: git push'), {
+      stderr: Buffer.from(' ! [rejected] branch -> branch (non-fast-forward)'),
+    });
+    expect(isPushRejectionError(err)).toBe(true);
+  });
+
+  it('does not classify an auth/connection failure as a rejection', () => {
+    const err = Object.assign(new Error('Command failed: git push'), {
+      stderr: Buffer.from('fatal: Could not read from remote repository'),
+    });
+    expect(isPushRejectionError(err)).toBe(false);
   });
 });
 

--- a/adws/adwUpgrade.tsx
+++ b/adws/adwUpgrade.tsx
@@ -39,6 +39,7 @@ import {
   ensureTargetRepoWorkspace,
   buildClaimBranchName,
   computeFrameworkHash,
+  isPushRejectionError,
   writeAdwVersion,
   readAdwYmlConfig,
   type AdwYmlConfig,
@@ -85,6 +86,8 @@ export interface UpgradeDeps {
   readonly writeAdwVersion: (worktreePath: string, hash: string) => void;
   readonly commitChanges: (message: string, cwd: string) => boolean;
   readonly pushBranch: (branch: string, cwd: string) => void;
+  /** True when a push error is a non-fast-forward rejection (another orchestrator owns the claim branch). */
+  readonly isPushRejection: (err: unknown) => boolean;
   readonly createPullRequest: (options: CreatePROptions) => PullRequestResult;
   readonly commentOnIssue: typeof commentOnIssue;
   readonly ensureLogsDirectory: (adwId: string) => string;
@@ -289,7 +292,25 @@ export async function executeUpgrade(
   // 6. Write .adw-version, commit the regen, push
   deps.writeAdwVersion(worktreePath, hash);
   deps.commitChanges(`chore: regenerate .adw/ for framework upgrade ${hash.slice(0, 12)}`, worktreePath);
-  deps.pushBranch(branch, worktreePath);
+  try {
+    deps.pushBranch(branch, worktreePath);
+  } catch (error) {
+    // Non-fast-forward rejection: the remote claim branch advanced under us. Either a
+    // concurrent claim cycle (different nonce) re-created it, or this worktree was reused
+    // stale and built regen on a superseded claim commit. We must NOT force-push — that
+    // clobbers the rightful claim owner. Park cleanly instead of crashing: the claim owner
+    // carries the upgrade forward, and if it died the next cron re-dispatch finds no PR on
+    // the branch and rebuilds (idempotency guard above). No comment — matches the silent
+    // pr_already_exists "someone else owns this" path.
+    if (deps.isPushRejection(error)) {
+      deps.log(
+        `adwUpgrade: push to claim branch ${branch} rejected (non-fast-forward) — another orchestrator owns this claim; parking as loser`,
+        'warn',
+      );
+      return { outcome: 'completed', reason: 'claim_lost' };
+    }
+    throw error;
+  }
 
   // 7. Open PR — no workflow comment; the PR is the success signal
   const pr = deps.createPullRequest({
@@ -358,6 +379,7 @@ function buildDefaultUpgradeDeps(repoId: RepoIdentifier): UpgradeDeps {
     writeAdwVersion,
     commitChanges,
     pushBranch,
+    isPushRejection: isPushRejectionError,
     createPullRequest: (options) => codeHost.createPullRequest(options),
     commentOnIssue,
     ensureLogsDirectory,

--- a/adws/core/index.ts
+++ b/adws/core/index.ts
@@ -201,7 +201,7 @@ export { computeFrameworkHash, defaultDeps as hashComputerDefaultDeps, ADW_INIT_
 export type { HashComputerDeps } from './hashComputer';
 
 // Upgrade claim
-export { claimUpgradeOrFindExisting, buildDefaultUpgradeClaimDeps, buildClaimBranchName, buildClaimResult } from './upgradeClaim';
+export { claimUpgradeOrFindExisting, buildDefaultUpgradeClaimDeps, buildClaimBranchName, buildClaimResult, isPushRejectionError, extractGitErrorText } from './upgradeClaim';
 export type { UpgradeClaimDeps, UpgradeClaimResult } from './upgradeClaim';
 
 // Workflow comment parsing (platform-agnostic)

--- a/adws/core/upgradeClaim.ts
+++ b/adws/core/upgradeClaim.ts
@@ -94,6 +94,30 @@ function isRejectionError(stderr: string): boolean {
   return REJECTION_PATTERNS.some((pat) => lower.includes(pat));
 }
 
+/**
+ * Extracts the human-readable git error text from an unknown thrown value.
+ * execSync rejections carry the useful text on `.stderr` (a Buffer); fall back to
+ * String(err) for anything else. Shared by the claim-push loser detection and any
+ * caller (e.g. adwUpgrade's regen-push) that must distinguish a non-fast-forward
+ * "someone else owns this branch" rejection from a genuine git failure.
+ */
+export function extractGitErrorText(err: unknown): string {
+  const buf = (err as { stderr?: Buffer | string }).stderr;
+  if (buf instanceof Buffer) return buf.toString();
+  if (typeof buf === 'string') return buf;
+  return String(err);
+}
+
+/**
+ * True when a thrown git error is a non-fast-forward / branch-already-exists
+ * rejection — i.e. the remote ref moved out from under us and a non-force push
+ * was refused. Callers treat this as "another orchestrator owns this branch"
+ * rather than a crash, and must NOT respond by force-pushing.
+ */
+export function isPushRejectionError(err: unknown): boolean {
+  return isRejectionError(extractGitErrorText(err));
+}
+
 function cleanupClaimTempWorktree(cwd: string, tmpdir: string): void {
   try {
     execSync(`git worktree remove --force "${tmpdir}"`, { stdio: 'pipe', cwd });
@@ -145,9 +169,7 @@ export function defaultPushClaimBranch(
       execSync(`git push origin "HEAD:refs/heads/${branchName}"`, { stdio: 'pipe', cwd: tmpdir });
       return true;
     } catch (pushErr) {
-      const buf = (pushErr as { stderr?: Buffer | string }).stderr;
-      const msg = buf instanceof Buffer ? buf.toString() : (typeof buf === 'string' ? buf : String(pushErr));
-      if (isRejectionError(msg)) return false;
+      if (isPushRejectionError(pushErr)) return false;
       throw pushErr;
     }
   } finally {


### PR DESCRIPTION
## What

Wrap the regen push in `executeUpgrade` (`adwUpgrade.tsx`) so a **non-fast-forward rejection** — the remote claim branch advanced under us because another orchestrator owns it — parks cleanly as `claim_lost` instead of throwing an unhandled `execSync` error that crashes the process. A genuine (non-rejection) push failure still rethrows.

Adds `isPushRejectionError` / `extractGitErrorText` to `upgradeClaim` (re-exported from `core`) and reuses them at both the claim-push and regen-push sites, replacing the inline rejection-detection that previously lived only in `defaultPushClaimBranch`.

## Why

Observed in production: a duplicate-spawn race on the upgrade path left two orchestrators building the same `adw-upgrade-<hash>` claim branch. The loser's regen push hit `! [rejected] (non-fast-forward)` and crashed with exit 1 (`adwUpgrade.tsx` `pushBranch`). The correct behaviour is to defer to the claim owner — never force-push — and exit cleanly so the cron re-dispatch safety net carries the upgrade forward.

## Tests

- New `executeUpgrade` cases: rejected push → `completed`/`claim_lost`, no PR/merge/comment; genuine push failure still rethrows.
- New `isPushRejectionError` unit tests (non-ff stderr buffer vs auth-failure buffer).
- `tsc` clean; targeted suites green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)