### PR TITLE
fix: correct dependency insertion formatting in upgradeGate

### DIFF
--- a/adws/phases/upgradeGate.ts
+++ b/adws/phases/upgradeGate.ts
@@ -85,7 +85,7 @@ export function addDependencyToBody(body: string, upgNumber: number): string {
       : body.length;
     const section = body.slice(headingIdx, sectionEnd);
     if (section.includes(ref)) return body;
-    const insert = `\n- ${ref}`;
+    const insert = `\n- ${ref}\n`;
     return body.slice(0, sectionEnd) + insert + body.slice(sectionEnd);
   }
 


### PR DESCRIPTION
## Summary
- Fixes broken dependency addition in `addDependencyToBody`: appends a trailing newline after the inserted dependency reference so subsequent body content is not concatenated onto the same line.

## Changes
- `adws/phases/upgradeGate.ts`: insert `\n- ${ref}\n` instead of `\n- ${ref}` when adding a dependency reference to an issue body.

## Test plan
- [ ] Verify dependency references are inserted on their own line and preserve following content.

🤖 Generated with [Claude Code](https://claude.com/claude-code)