### PR TITLE
Promote dev → main: adwUpgrade target-repo auth fix + grill-me hardening

### DIFF
--- a/.claude/skills/grill-me/SKILL.md
+++ b/.claude/skills/grill-me/SKILL.md
@@ -13,6 +13,19 @@ If a question can be answered by exploring the codebase, explore the codebase in
 IMPORTANT: ask only one question at a time, and wait for my answer before asking the next question. Do not ask multiple questions at once.
 If not simple yes/no questions, ask bulltet point questions, even with only two options.
 
-Be criticlal and skeptical. Your goal is to find holes in the plan and force me to confront them, not to be agreeable. Be relentless in your questioning until we have a rock-solid plan.
+Be critical and skeptical. Your goal is to find holes in the plan and force me to confront them, not to be agreeable. Be relentless in your questioning until we have a rock-solid plan.
 
 Be concise in your communication. Ask short, direct questions. Avoid long explanations or justifications. Your job is to ask the right questions, not to explain your reasoning.
+
+## Hold your own claims to the same standard you hold mine
+
+Turn the skepticism on yourself. Every factual or causal claim you make during the grill is either:
+
+- **Verified** — you ran a check that *could have failed and didn't*. Name the check.
+- **Hypothesis** — you have not. Label it as one. Do not state it as settled.
+
+Rules:
+- Do NOT present a root cause, diagnosis, or "the reason is X" as fact until you have reproduced it — ideally with a test that **isolates a single variable** and **reproduces the observed symptom**. Prefer running the falsifiable test over arguing for the explanation.
+- When I give you counter-evidence, treat your prior conclusion as **falsified, not under attack**. Re-derive from the evidence; do not defend the old story.
+- Distinguish a snapshot/tool artifact from ground truth before building on it (e.g. a launch-time env dump is not a live runtime value; a token's scope is not proof an installation does or doesn't exist). State the limitation of your evidence out loud.
+- If you have been wrong, say so plainly and account for *why* (what you asserted ahead of the evidence). Do not grovel, and do not ask me to trust the next claim — give me a check I can run myself instead.

--- a/adws/adwUpgrade.tsx
+++ b/adws/adwUpgrade.tsx
@@ -50,7 +50,7 @@ import {
   type IssueCommentRecord,
 } from './core';
 import { ADW_BLOCKED_LABEL } from './github/labelManager';
-import { commentOnIssue, mergePR, type RepoInfo, gitContextFor } from './github';
+import { commentOnIssue, mergePR, type RepoInfo, gitContextFor, activateGitHubAppAuth } from './github';
 import { defaultFindPRByBranch, hasWontFixLabel, type RawPR } from './github/prApi';
 import type { GitContext } from './gitContext';
 import { runClaudeAgentWithCommand } from './agents';
@@ -510,6 +510,11 @@ async function main(): Promise<void> {
   const adwId = parsedAdwId ?? generateAdwId('adwupgrade');
   const repoId = buildRepoIdentifier(targetRepo);
   const repoInfo: RepoInfo = { owner: repoId.owner, repo: repoId.repo };
+  // The raw upgrade lifecycle skips workflowInit, which is where normal
+  // orchestrators activate target-repo App auth. Without this, the workspace
+  // setup below runs `gh` on whatever token is ambient (e.g. the multi-repo
+  // webhook's own-repo token) and fails to resolve the target repo.
+  if (targetRepo) activateGitHubAppAuth(repoId.owner, repoId.repo);
   const baseRepoPath = targetRepo ? ensureTargetRepoWorkspace(targetRepo) : process.cwd();
   const frameworkRepoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
   const gitCtx = await gitContextFor({ owner: repoId.owner, repo: repoId.repo, selfHost: !targetRepo });


### PR DESCRIPTION
Promotes `dev` to `main`. Two commits:

## `fix:` adwUpgrade activates target-repo App auth before workspace setup (`39ee605`)
The raw upgrade lifecycle skips `workflowInit`, where normal orchestrators activate target-repo GitHub App auth. Without it, `ensureTargetRepoWorkspace → fetchLatestRefs` ran `gh repo view` on whatever token was ambient (the multi-repo webhook's own-repo paysdoc token) and **crashed uncaught** against a target repo with "Could not resolve to a Repository" — the live failure observed on `vestmatic/vestmatic` #200 via `## continue`.

Fix activates the target-repo installation token before workspace setup, matching `workflowInit`/`prReviewPhase`. `adwUpgrade` is a single-repo subprocess, so the activation is bleed-safe. Surgical stopgap until the per-command auth absorption (GitContext bootstrap slice) lands.

**Not addressed here** (tracked for the GitContext allowlist-to-zero epic): the webhook's non-fatal concurrency-check log error, and the identical missing-auth gap in `adwMerge.tsx:274`.

## `chore:` grill-me skill holds its own claims to evidence (`823f676`)
Adds a self-skepticism section: label claims verified vs hypothesis, reproduce a root cause with a single-variable test before asserting it, treat counter-evidence as falsification, and flag snapshot/tool artifacts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)