### PR TITLE
fix: restore explicit --head in GitContext PR creation

### DIFF
--- a/adws/gitContext/__tests__/gitContextOperations.test.ts
+++ b/adws/gitContext/__tests__/gitContextOperations.test.ts
@@ -273,3 +273,34 @@ describe('explicit cwd (not process.cwd())', () => {
     expect(calls[0].cwd).not.toBe('/tmp');
   });
 });
+
+// ── createPR() head-branch contract ──────────────────────────────────────────
+// Regression guard: gh pr create must carry an explicit --head. Without it, gh
+// infers the head from the cwd's current branch (the context base path, on the
+// default branch), producing an empty-diff PR against the wrong head. The
+// GitContext gh-ops migration dropped --head and shipped exactly that bug
+// (PR opened with head=main → "0 files changed").
+describe('createPR() head-branch contract', () => {
+  it('includes an explicit --head set to the source branch', () => {
+    const { exec, calls } = makeSpyExec('https://github.com/acme/webapp/pull/12\n');
+    const ctx = new GitContext(validOptions({ owner: 'acme', repo: 'webapp' }), { exec });
+    ctx.createPR('My title', 'body text', 'feature-issue-7-do-thing', 'dev');
+    expect(calls[0].command).toContain('--head "feature-issue-7-do-thing"');
+  });
+
+  it('does not rely on the cwd-inferred head (head differs from base path branch)', () => {
+    // Spy returns 'main' for any command; the head must still be the passed branch.
+    const { exec, calls } = makeSpyExec('main\n');
+    const ctx = new GitContext(validOptions(), { exec });
+    ctx.createPR('T', 'b', 'feature-issue-99-x', 'dev');
+    expect(calls[0].command).toContain('--head "feature-issue-99-x"');
+    expect(calls[0].command).toContain('--base dev');
+  });
+
+  it('passes the PR body via --body-file - on stdin', () => {
+    const { exec, calls } = makeSpyExec('https://github.com/acme/webapp/pull/1\n');
+    const ctx = new GitContext(validOptions(), { exec });
+    ctx.createPR('T', 'the body', 'feature-issue-1-y');
+    expect(calls[0].command).toContain('--body-file -');
+  });
+});

--- a/adws/gitContext/commands/prCommands.ts
+++ b/adws/gitContext/commands/prCommands.ts
@@ -38,7 +38,10 @@ export function fetchAllPRsCmd(owner: string, repo: string): string {
   return `gh pr list --repo ${owner}/${repo} --state all --json number,body,state,mergedAt --limit 200`;
 }
 
-export function createPRCmd(owner: string, repo: string, title: string, baseBranch?: string): string {
+export function createPRCmd(owner: string, repo: string, title: string, headBranch: string, baseBranch?: string): string {
   const baseArg = baseBranch ? ` --base ${baseBranch}` : '';
-  return `gh pr create --repo ${owner}/${repo} --title '${title}' --body-file -${baseArg}`;
+  // --head must be explicit: gh otherwise infers it from the cwd's current
+  // branch (the context base path, on the default branch), producing an
+  // empty-diff PR against the wrong head.
+  return `gh pr create --repo ${owner}/${repo} --title '${title}' --head "${headBranch}" --body-file -${baseArg}`;
 }

--- a/adws/gitContext/gitContext.ts
+++ b/adws/gitContext/gitContext.ts
@@ -400,8 +400,8 @@ export class GitContext {
     return this.#run(fetchAllPRsCmd(this.#owner, this.#repo));
   }
 
-  createPR(title: string, body: string, baseBranch?: string): string {
-    return this.#run(createPRCmd(this.#owner, this.#repo, title, baseBranch), { input: body });
+  createPR(title: string, body: string, headBranch: string, baseBranch?: string): string {
+    return this.#run(createPRCmd(this.#owner, this.#repo, title, headBranch, baseBranch), { input: body });
   }
 
   createLabel(name: string, color: string, description: string): void {

--- a/adws/providers/github/githubCodeHost.ts
+++ b/adws/providers/github/githubCodeHost.ts
@@ -89,7 +89,7 @@ export class GitHubCodeHost implements CodeHost {
       // If the check fails, fall through to normal PR creation
     }
 
-    const prUrl = ctx.createPR(options.title, options.body, options.targetBranch);
+    const prUrl = ctx.createPR(options.title, options.body, options.sourceBranch, options.targetBranch);
 
     const numberMatch = prUrl.match(/\/pull\/(\d+)$/);
     if (!numberMatch) {

--- a/features/per-issue/step_definitions/feature-659.steps.ts
+++ b/features/per-issue/step_definitions/feature-659.steps.ts
@@ -49,7 +49,7 @@ function runOp(ctx: GitContext, opName: string): void {
       ctx.commentOnPR(1, 'test body');
       return;
     case 'pr-create':
-      ctx.createPR('Test PR', 'test body');
+      ctx.createPR('Test PR', 'test body', 'feature-test-branch');
       return;
     case 'pr-merge':
       ctx.mergePR(1);


### PR DESCRIPTION
## Summary

Fixes a regression where ADW opened PRs with the **wrong head branch**, producing empty "0 files changed" PRs (observed on PR #702 for issue #691: head=`main` → base=`dev`).

## Root cause

The gh-ops GitContext migration (`842e2bf`, the #663 slice) dropped the `--head` flag from `gh pr create`:

- **Before:** `gh pr create … --head "<sourceBranch>"` — head was always explicit.
- **After:** `createPRCmd` emitted no `--head`, and `GitContext.createPR(title, body, baseBranch?)` had no head parameter at all. `githubCodeHost.createPullRequest` passed only `options.targetBranch` (base), silently discarding `options.sourceBranch`.

With no `--head`, `gh pr create` infers the head from the spawned command's cwd — which `GitContext#run` defaults to the context **base path** (the framework root, checked out to the default branch). So self-host PRs got head=`main`.

## Why it wasn't caught

- No test asserted `--head` was present (the contract was dropped silently; `createPRCmd` had no head param to test).
- The only `createPR` caller in tests mocks it; real head resolution was never exercised.
- The BDD harness can't observe a real `gh pr create` against GitHub.
- `gh pr create` with an inferred head **succeeds** and returns a valid URL — no failure signal.
- Timeline masked it: the regression reached `main` only at the #689 back-merge; PRs created before that (#686/#687/#688) had correct heads, and #702 (minutes after) was the first casualty.

## Changes

| File | Change |
|---|---|
| `adws/gitContext/commands/prCommands.ts` | `createPRCmd` takes required `headBranch`, emits `--head "<headBranch>"` |
| `adws/gitContext/gitContext.ts` | `createPR` takes required `headBranch`, forwards it |
| `adws/providers/github/githubCodeHost.ts` | passes `options.sourceBranch` as the head |
| `adws/gitContext/__tests__/gitContextOperations.test.ts` | 3 tests locking in the `--head` contract |
| `features/per-issue/step_definitions/feature-659.steps.ts` | step-def smoke call updated to new signature |

## Verification

- `bunx tsc --noEmit` clean
- `bun run lint:git-guard` passes
- gitContext + provider unit tests green (29 passed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
