### PR TITLE
Merge dev into main

### DIFF
--- a/.adw/conditional_docs.md
+++ b/.adw/conditional_docs.md
@@ -1898,6 +1898,10 @@
     - adws/vcs/worktreeCleanup.ts
     - adws/vcs/worktreeOperations.ts
     - adws/gitContext/commands/**
+    - adws/triggers/concurrencyGuard.ts
+    - adws/triggers/perIssueScenarioSweep.ts
+    - adws/triggers/webhookGatekeeper.ts
+    - adws/phases/docsSelfCheck.ts
   - Conditions:
     - When working with `GitContext`, `GitContextOptions`, `GitIdentity`, `ExecFn`, or `GitContextDeps` in `adws/gitContext/`
     - When implementing or troubleshooting base-path resolution for self-host vs target repos (the single `resolveBasePath` authority)
@@ -1909,7 +1913,7 @@
     - When `commitChanges`, `pushBranch`, `getHeadTreeHash`, or `hasUncommittedChanges` run through GitContext
     - When `resetWorktree` (abort-merge/rebase + fetch/reset --hard/clean) is involved in takeover recovery
     - When `createWorktree`, `createWorktreeForNewBranch`, `ensureWorktree`, `getWorktreeForBranch`, `listWorktrees`, `findWorktreeForIssue`, `removeWorktree`, `removeWorktreesForIssue`, or `copyEnvToWorktree` are called as GitContext methods
-    - When `gitContextFor` or `gitContextForSync` from `adws/github/gitContextFactory.ts` is used to construct a context at a call site
+    - When `gitContextFor`, `gitContextForSync`, or `gitContextForRepo` from `adws/github/gitContextFactory.ts` is used to construct a context at a call site
     - When `adws/vcs/worktreeCreation.ts`, `worktreeQuery.ts`, `worktreeCleanup.ts`, or `worktreeOperations.ts` are referenced and symbols appear to be missing (they migrated to GitContext in #661)
     - When `adws/vcs/branchOperations.ts`, `commitOperations.ts`, or `worktreeReset.ts` are referenced and I/O functions appear to be missing (they migrated to GitContext)
     - When working with `adws/gitContext/commands/` pure command builders or parsers (issue, PR, label, board)
@@ -1920,6 +1924,9 @@
     - When `getMainRepoPath()` is called without a `cwd` argument and fails (the cwd-defaulting form was removed in #661)
     - When the "wrong-repo worktree" or `GH_TOKEN` bleed class of bugs (#23, #33, #52, #56, #62, #119, #217, #223, #187, #181) is being addressed structurally
     - When adding unit tests for `adws/gitContext/` (env-injection, non-mutation, `usePat`, lease-rejection, two-context isolation, worktree path correctness under `process.chdir`, or command builder/parser tests)
+    - When working with `listOpenIssues`, `issueComments`, or `fetchMergedPRs` on `GitContext` (added in #691 — covers residual gh-read consumers)
+    - When `concurrencyGuard.ts`, `webhookGatekeeper.ts`, `docsSelfCheck.ts`, or `perIssueScenarioSweep.ts` are making gh issue/PR reads (they now route through `gitContextForRepo`)
+    - When migrating a trigger or phase module off direct `execSync`/`execWithRetry` for gh reads and onto `GitContext` methods (the #691 migration pattern)
 
 - app_docs/feature-k817bh-persist-repo-identity-cross-check.md
   - Owns:

--- a/README.md
+++ b/README.md
@@ -572,8 +572,8 @@ adws/                   # ADW workflow system
 │   ├── targetRepoManager.ts
 │   ├── testReportParser.ts  # JUnit XML test report parser — reads xunit output into TestReport (total, passed, failed, skipped, per-case status)
 │   ├── testVerdict.ts  # Pure test verdict computation (enabled, hasFailures, testcaseCount, frameworkDetected → verdict)
-│   ├── repoIdentityCrossCheck.ts  # Persists repo identity at workflow init and cross-checks on resume (guards against wrong-repo restarts)
 │   ├── upgradeClaim.ts # Atomic upgrade-claim primitive via GitHub branch namespace (winner/loser resolution)
+│   ├── upgradeFailureCap.ts  # Pure helpers for counting bot-authored upgrade-failure comments — used by adwUpgrade to cap regeneration failures before escalating to human
 │   ├── utils.ts
 │   ├── workflowCommentParsing.ts  # Comment parsing utilities
 │   └── workflowMapping.ts  # Issue type → orchestrator mapping
@@ -839,6 +839,7 @@ adws/                   # ADW workflow system
 │   ├── proofArtifactHarvester.ts  # Pure recursive harvester of image artifacts from proof directory
 │   └── types.ts
 ├── known_issues.md     # Known issues and workarounds
+├── checkGitGhGuard.ts  # CI guard: scans all .ts/.tsx sources for direct git/gh shell-outs outside GitContext; fails build if any bypass the per-command auth chokepoint (`bun run lint:git-guard`)
 ├── checkLivingDocsIndex.ts  # Migration acceptance gate: validates conditional_docs.md ↔ app_docs/ bijection
 ├── adwBuild.tsx        # Orchestrators (individual & combined)
 ├── adwChore.tsx        # Chore pipeline with LLM diff gate (auto-merge)

--- a/adws/checkGitGhGuard.ts
+++ b/adws/checkGitGhGuard.ts
@@ -57,7 +57,6 @@ const ALLOWLIST: readonly string[] = [
   'adws/core/remoteReconcile.ts',                  // git ls-remote via execWithRetry
   'adws/adwPromotionSweep.tsx',                    // gh pr view/create, git <args> via execWithRetry
   'adws/phases/depauditSetup.ts',                  // gh secret set via injected execWithRetry
-  'adws/phases/docsSelfCheck.ts',                  // gh issue list via injected execWithRetry
   'adws/github/labelManager.ts',                   // gh label create, gh issue edit via injected exec
   'adws/triggers/autoMergeHandler.ts',             // git fetch, git merge
   'adws/github/githubApi.ts',                      // git remote get-url origin, gh api user
@@ -68,11 +67,7 @@ const ALLOWLIST: readonly string[] = [
   'adws/phases/worktreeSetup.ts',                  // git ls-files
   'adws/providers/github/githubBoardManager.ts',   // gh api graphql
   'adws/providers/repoContext.ts',                 // git remote get-url origin
-  'adws/triggers/concurrencyGuard.ts',             // gh issue list
-  'adws/triggers/perIssueScenarioSweep.ts',        // gh pr list
-  'adws/triggers/takeoverHandler.ts',              // gh issue view
   'adws/triggers/trigger_cron.ts',                 // gh issue list, git remote get-url origin
-  'adws/triggers/webhookGatekeeper.ts',            // gh issue list
 ];
 
 // ---------------------------------------------------------------------------
@@ -196,4 +191,5 @@ function main(): void {
   process.exit(1);
 }
 
-main();
+// Run main only when executed as a script, not when imported as a module.
+if (process.argv[1]?.includes('checkGitGhGuard')) main();

--- a/adws/gitContext/__tests__/gitContextOperations.test.ts
+++ b/adws/gitContext/__tests__/gitContextOperations.test.ts
@@ -273,3 +273,34 @@ describe('explicit cwd (not process.cwd())', () => {
     expect(calls[0].cwd).not.toBe('/tmp');
   });
 });
+
+// ── createPR() head-branch contract ──────────────────────────────────────────
+// Regression guard: gh pr create must carry an explicit --head. Without it, gh
+// infers the head from the cwd's current branch (the context base path, on the
+// default branch), producing an empty-diff PR against the wrong head. The
+// GitContext gh-ops migration dropped --head and shipped exactly that bug
+// (PR opened with head=main → "0 files changed").
+describe('createPR() head-branch contract', () => {
+  it('includes an explicit --head set to the source branch', () => {
+    const { exec, calls } = makeSpyExec('https://github.com/acme/webapp/pull/12\n');
+    const ctx = new GitContext(validOptions({ owner: 'acme', repo: 'webapp' }), { exec });
+    ctx.createPR('My title', 'body text', 'feature-issue-7-do-thing', 'dev');
+    expect(calls[0].command).toContain('--head "feature-issue-7-do-thing"');
+  });
+
+  it('does not rely on the cwd-inferred head (head differs from base path branch)', () => {
+    // Spy returns 'main' for any command; the head must still be the passed branch.
+    const { exec, calls } = makeSpyExec('main\n');
+    const ctx = new GitContext(validOptions(), { exec });
+    ctx.createPR('T', 'b', 'feature-issue-99-x', 'dev');
+    expect(calls[0].command).toContain('--head "feature-issue-99-x"');
+    expect(calls[0].command).toContain('--base dev');
+  });
+
+  it('passes the PR body via --body-file - on stdin', () => {
+    const { exec, calls } = makeSpyExec('https://github.com/acme/webapp/pull/1\n');
+    const ctx = new GitContext(validOptions(), { exec });
+    ctx.createPR('T', 'the body', 'feature-issue-1-y');
+    expect(calls[0].command).toContain('--body-file -');
+  });
+});

--- a/adws/gitContext/__tests__/gitContextOperations.test.ts
+++ b/adws/gitContext/__tests__/gitContextOperations.test.ts
@@ -95,6 +95,200 @@ describe('defaultBranch() env injection', () => {
   });
 });
 
+// ── listOpenIssues() ─────────────────────────────────────────────────────────
+
+describe('listOpenIssues() command and env', () => {
+  it('builds the exact command with required fields and limit', () => {
+    const { exec, calls } = makeSpyExec('[]');
+    const ctx = new GitContext(validOptions({ owner: 'acme', repo: 'webapp' }), { exec });
+    ctx.listOpenIssues({ fields: ['number', 'comments'], limit: 100 });
+    expect(calls[0].command).toBe(
+      'gh issue list --repo acme/webapp --state open --json number,comments --limit 100',
+    );
+  });
+
+  it('appends --search when provided', () => {
+    const { exec, calls } = makeSpyExec('[]');
+    const ctx = new GitContext(validOptions({ owner: 'acme', repo: 'webapp' }), { exec });
+    ctx.listOpenIssues({ fields: ['number', 'title'], search: 'docs-bloat: app_docs/foo.md', limit: 5 });
+    expect(calls[0].command).toBe(
+      'gh issue list --repo acme/webapp --state open --json number,title --search "docs-bloat: app_docs/foo.md" --limit 5',
+    );
+  });
+
+  it('omits --search and --limit when not provided', () => {
+    const { exec, calls } = makeSpyExec('[]');
+    const ctx = new GitContext(validOptions({ owner: 'acme', repo: 'webapp' }), { exec });
+    ctx.listOpenIssues({ fields: ['number'] });
+    expect(calls[0].command).toBe('gh issue list --repo acme/webapp --state open --json number');
+  });
+
+  it('passes cwd equal to the context base path', () => {
+    const { exec, calls } = makeSpyExec('[]');
+    const ctx = new GitContext(validOptions(), { exec });
+    ctx.listOpenIssues({ fields: ['number'] });
+    expect(calls[0].cwd).toBe(ctx.basePath);
+  });
+
+  it('injects GH_TOKEN from the context token in the child env', () => {
+    const { exec, calls } = makeSpyExec('[]');
+    const ctx = new GitContext(validOptions({ token: 'list-token' }), { exec });
+    ctx.listOpenIssues({ fields: ['number'] });
+    expect(calls[0].env.GH_TOKEN).toBe('list-token');
+  });
+
+  it('injects all four GIT_* identity vars', () => {
+    const { exec, calls } = makeSpyExec('[]');
+    const ctx = new GitContext(
+      validOptions({
+        gitIdentity: {
+          authorName: 'List Bot', authorEmail: 'list@bot.dev',
+          committerName: 'List Bot', committerEmail: 'list@bot.dev',
+        },
+      }),
+      { exec },
+    );
+    ctx.listOpenIssues({ fields: ['number'] });
+    expect(calls[0].env.GIT_AUTHOR_NAME).toBe('List Bot');
+    expect(calls[0].env.GIT_AUTHOR_EMAIL).toBe('list@bot.dev');
+  });
+
+  it('does not mutate process.env', () => {
+    const before = process.env.GH_TOKEN;
+    const { exec } = makeSpyExec('[]');
+    const ctx = new GitContext(validOptions({ token: 'injected' }), { exec });
+    ctx.listOpenIssues({ fields: ['number'] });
+    expect(process.env.GH_TOKEN).toBe(before);
+  });
+
+  it('returns trimmed stdout', () => {
+    const { exec } = makeSpyExec('[{"number":1}]\n');
+    const ctx = new GitContext(validOptions(), { exec });
+    expect(ctx.listOpenIssues({ fields: ['number'] })).toBe('[{"number":1}]');
+  });
+});
+
+// ── issueComments() ──────────────────────────────────────────────────────────
+
+describe('issueComments() command and env', () => {
+  it("builds the exact command with --jq '.comments'", () => {
+    const { exec, calls } = makeSpyExec('[]');
+    const ctx = new GitContext(validOptions({ owner: 'acme', repo: 'webapp' }), { exec });
+    ctx.issueComments(42);
+    expect(calls[0].command).toBe(
+      "gh issue view 42 --repo acme/webapp --json comments --jq '.comments'",
+    );
+  });
+
+  it('passes cwd equal to the context base path', () => {
+    const { exec, calls } = makeSpyExec('[]');
+    const ctx = new GitContext(validOptions(), { exec });
+    ctx.issueComments(1);
+    expect(calls[0].cwd).toBe(ctx.basePath);
+  });
+
+  it('injects GH_TOKEN from the context token', () => {
+    const { exec, calls } = makeSpyExec('[]');
+    const ctx = new GitContext(validOptions({ token: 'comments-token' }), { exec });
+    ctx.issueComments(1);
+    expect(calls[0].env.GH_TOKEN).toBe('comments-token');
+  });
+
+  it('injects GIT_* vars in the child env', () => {
+    const { exec, calls } = makeSpyExec('[]');
+    const ctx = new GitContext(
+      validOptions({
+        gitIdentity: {
+          authorName: 'Comments Bot', authorEmail: 'c@bot.dev',
+          committerName: 'Comments Bot', committerEmail: 'c@bot.dev',
+        },
+      }),
+      { exec },
+    );
+    ctx.issueComments(1);
+    expect(calls[0].env.GIT_AUTHOR_NAME).toBe('Comments Bot');
+  });
+
+  it('does not mutate process.env', () => {
+    const before = process.env.GH_TOKEN;
+    const { exec } = makeSpyExec('[]');
+    const ctx = new GitContext(validOptions({ token: 'injected' }), { exec });
+    ctx.issueComments(1);
+    expect(process.env.GH_TOKEN).toBe(before);
+  });
+
+  it('returns trimmed stdout', () => {
+    const { exec } = makeSpyExec('[{"body":"hello"}]\n');
+    const ctx = new GitContext(validOptions(), { exec });
+    expect(ctx.issueComments(1)).toBe('[{"body":"hello"}]');
+  });
+});
+
+// ── fetchMergedPRs() ─────────────────────────────────────────────────────────
+
+describe('fetchMergedPRs() command and env', () => {
+  it('defaults to --limit 200', () => {
+    const { exec, calls } = makeSpyExec('[]');
+    const ctx = new GitContext(validOptions({ owner: 'acme', repo: 'webapp' }), { exec });
+    ctx.fetchMergedPRs();
+    expect(calls[0].command).toBe(
+      'gh pr list --repo acme/webapp --state merged --json body,mergedAt --limit 200',
+    );
+  });
+
+  it('honors an explicit limit', () => {
+    const { exec, calls } = makeSpyExec('[]');
+    const ctx = new GitContext(validOptions({ owner: 'acme', repo: 'webapp' }), { exec });
+    ctx.fetchMergedPRs(50);
+    expect(calls[0].command).toBe(
+      'gh pr list --repo acme/webapp --state merged --json body,mergedAt --limit 50',
+    );
+  });
+
+  it('passes cwd equal to the context base path', () => {
+    const { exec, calls } = makeSpyExec('[]');
+    const ctx = new GitContext(validOptions(), { exec });
+    ctx.fetchMergedPRs();
+    expect(calls[0].cwd).toBe(ctx.basePath);
+  });
+
+  it('injects GH_TOKEN from the context token', () => {
+    const { exec, calls } = makeSpyExec('[]');
+    const ctx = new GitContext(validOptions({ token: 'prs-token' }), { exec });
+    ctx.fetchMergedPRs();
+    expect(calls[0].env.GH_TOKEN).toBe('prs-token');
+  });
+
+  it('injects GIT_* vars in the child env', () => {
+    const { exec, calls } = makeSpyExec('[]');
+    const ctx = new GitContext(
+      validOptions({
+        gitIdentity: {
+          authorName: 'PR Bot', authorEmail: 'pr@bot.dev',
+          committerName: 'PR Bot', committerEmail: 'pr@bot.dev',
+        },
+      }),
+      { exec },
+    );
+    ctx.fetchMergedPRs();
+    expect(calls[0].env.GIT_AUTHOR_NAME).toBe('PR Bot');
+  });
+
+  it('does not mutate process.env', () => {
+    const before = process.env.GH_TOKEN;
+    const { exec } = makeSpyExec('[]');
+    const ctx = new GitContext(validOptions({ token: 'injected' }), { exec });
+    ctx.fetchMergedPRs();
+    expect(process.env.GH_TOKEN).toBe(before);
+  });
+
+  it('returns trimmed stdout', () => {
+    const { exec } = makeSpyExec('[{"body":"Closes #1","mergedAt":"2024-01-01"}]\n');
+    const ctx = new GitContext(validOptions(), { exec });
+    expect(ctx.fetchMergedPRs()).toBe('[{"body":"Closes #1","mergedAt":"2024-01-01"}]');
+  });
+});
+
 // ── Return value ─────────────────────────────────────────────────────────────
 
 describe('defaultBranch() return value', () => {

--- a/adws/gitContext/commands/issueCommands.ts
+++ b/adws/gitContext/commands/issueCommands.ts
@@ -1,6 +1,23 @@
 const ISSUE_FIELDS =
   'number,title,body,state,author,assignees,labels,milestone,comments,createdAt,updatedAt,closedAt,url';
 
+export interface ListOpenIssuesOptions {
+  readonly fields: readonly string[];
+  readonly search?: string;
+  readonly limit?: number;
+}
+
+export function listOpenIssuesCmd(owner: string, repo: string, opts: ListOpenIssuesOptions): string {
+  let cmd = `gh issue list --repo ${owner}/${repo} --state open --json ${opts.fields.join(',')}`;
+  if (opts.search !== undefined) cmd += ` --search "${opts.search}"`;
+  if (opts.limit !== undefined) cmd += ` --limit ${opts.limit}`;
+  return cmd;
+}
+
+export function issueCommentsCmd(owner: string, repo: string, issueNumber: number): string {
+  return `gh issue view ${issueNumber} --repo ${owner}/${repo} --json comments --jq '.comments'`;
+}
+
 export function fetchIssueCmd(owner: string, repo: string, issueNumber: number): string {
   return `gh issue view ${issueNumber} --repo ${owner}/${repo} --json ${ISSUE_FIELDS}`;
 }

--- a/adws/gitContext/commands/prCommands.ts
+++ b/adws/gitContext/commands/prCommands.ts
@@ -42,3 +42,7 @@ export function createPRCmd(owner: string, repo: string, title: string, baseBran
   const baseArg = baseBranch ? ` --base ${baseBranch}` : '';
   return `gh pr create --repo ${owner}/${repo} --title '${title}' --body-file -${baseArg}`;
 }
+
+export function fetchMergedPRsCmd(owner: string, repo: string, limit = 200): string {
+  return `gh pr list --repo ${owner}/${repo} --state merged --json body,mergedAt --limit ${limit}`;
+}

--- a/adws/gitContext/commands/prCommands.ts
+++ b/adws/gitContext/commands/prCommands.ts
@@ -38,7 +38,10 @@ export function fetchAllPRsCmd(owner: string, repo: string): string {
   return `gh pr list --repo ${owner}/${repo} --state all --json number,body,state,mergedAt --limit 200`;
 }
 
-export function createPRCmd(owner: string, repo: string, title: string, baseBranch?: string): string {
+export function createPRCmd(owner: string, repo: string, title: string, headBranch: string, baseBranch?: string): string {
   const baseArg = baseBranch ? ` --base ${baseBranch}` : '';
-  return `gh pr create --repo ${owner}/${repo} --title '${title}' --body-file -${baseArg}`;
+  // --head must be explicit: gh otherwise infers it from the cwd's current
+  // branch (the context base path, on the default branch), producing an
+  // empty-diff PR against the wrong head.
+  return `gh pr create --repo ${owner}/${repo} --title '${title}' --head "${headBranch}" --body-file -${baseArg}`;
 }

--- a/adws/gitContext/gitContext.ts
+++ b/adws/gitContext/gitContext.ts
@@ -400,8 +400,8 @@ export class GitContext {
     return this.#run(fetchAllPRsCmd(this.#owner, this.#repo));
   }
 
-  createPR(title: string, body: string, baseBranch?: string): string {
-    return this.#run(createPRCmd(this.#owner, this.#repo, title, baseBranch), { input: body });
+  createPR(title: string, body: string, headBranch: string, baseBranch?: string): string {
+    return this.#run(createPRCmd(this.#owner, this.#repo, title, headBranch, baseBranch), { input: body });
   }
 
   createLabel(name: string, color: string, description: string): void {

--- a/adws/gitContext/gitContext.ts
+++ b/adws/gitContext/gitContext.ts
@@ -25,11 +25,13 @@ import {
   fetchIssueCmd, commentOnIssueCmd, issueStateCmd, closeIssueCmd, issueTitleCmd,
   fetchIssueCommentsCmd, issueHasLabelCmd, addIssueLabelCmd, createIssueCmd,
   updateIssueBodyCmd, findOpenUpgradeIssueCmd, deleteIssueCommentCmd,
+  listOpenIssuesCmd, issueCommentsCmd,
+  type ListOpenIssuesOptions,
 } from './commands/issueCommands';
 import {
   findPRByBranchCmd, fetchPRDetailsCmd, fetchPRReviewsCmd, fetchPRReviewCommentsCmd,
   commentOnPRCmd, mergePRCmd, approvePRCmd, prApprovalStateCmd,
-  fetchPRListCmd, fetchAllPRsCmd, createPRCmd,
+  fetchPRListCmd, fetchAllPRsCmd, createPRCmd, fetchMergedPRsCmd,
 } from './commands/prCommands';
 import { createLabelCmd, applyLabelCmd } from './commands/labelCommands';
 import {
@@ -353,6 +355,18 @@ export class GitContext {
 
   deleteIssueComment(commentId: number): void {
     this.#run(deleteIssueCommentCmd(this.#owner, this.#repo, commentId));
+  }
+
+  listOpenIssues(opts: ListOpenIssuesOptions): string {
+    return this.#run(listOpenIssuesCmd(this.#owner, this.#repo, opts));
+  }
+
+  issueComments(issueNumber: number): string {
+    return this.#run(issueCommentsCmd(this.#owner, this.#repo, issueNumber));
+  }
+
+  fetchMergedPRs(limit?: number): string {
+    return this.#run(fetchMergedPRsCmd(this.#owner, this.#repo, limit));
   }
 
   authenticatedUser(): string {

--- a/adws/phases/__tests__/docsSelfCheck.test.ts
+++ b/adws/phases/__tests__/docsSelfCheck.test.ts
@@ -1,0 +1,91 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('../../github/gitContextFactory', () => ({
+  gitContextForRepo: vi.fn(),
+}));
+
+vi.mock('../../core', () => ({
+  log: vi.fn(),
+  execWithRetry: vi.fn(),
+}));
+
+vi.mock('../../github', () => ({
+  createIssue: vi.fn(),
+}));
+
+vi.mock('fs', () => ({
+  default: { readFileSync: vi.fn() },
+  readFileSync: vi.fn(),
+}));
+
+import { buildDefaultDocsSelfCheckDeps } from '../docsSelfCheck';
+import { gitContextForRepo } from '../../github/gitContextFactory';
+
+const REPO_INFO = { owner: 'acme', repo: 'webapp' };
+
+function makeCtx(result: string) {
+  return { listOpenIssues: vi.fn(() => result) };
+}
+
+describe('findExistingRefactorIssueDefault (via buildDefaultDocsSelfCheckDeps)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('returns the matching issue number when title includes docPath', () => {
+    const issues = [
+      { number: 42, title: 'docs-bloat: app_docs/feature-foo.md exceeds 200 lines' },
+    ];
+    vi.mocked(gitContextForRepo).mockReturnValue(makeCtx(JSON.stringify(issues)) as never);
+
+    const deps = buildDefaultDocsSelfCheckDeps();
+    const result = deps.findExistingRefactorIssue(REPO_INFO, 'app_docs/feature-foo.md');
+
+    expect(gitContextForRepo).toHaveBeenCalledWith(REPO_INFO);
+    expect(result).toBe(42);
+  });
+
+  it('returns null when no issue title includes the docPath', () => {
+    const issues = [
+      { number: 10, title: 'docs-bloat: app_docs/other.md exceeds 200 lines' },
+    ];
+    vi.mocked(gitContextForRepo).mockReturnValue(makeCtx(JSON.stringify(issues)) as never);
+
+    const deps = buildDefaultDocsSelfCheckDeps();
+    const result = deps.findExistingRefactorIssue(REPO_INFO, 'app_docs/feature-foo.md');
+
+    expect(result).toBeNull();
+  });
+
+  it('returns null on empty result set', () => {
+    vi.mocked(gitContextForRepo).mockReturnValue(makeCtx('[]') as never);
+
+    const deps = buildDefaultDocsSelfCheckDeps();
+    const result = deps.findExistingRefactorIssue(REPO_INFO, 'app_docs/feature-foo.md');
+
+    expect(result).toBeNull();
+  });
+
+  it('returns null on throw (fail-open)', () => {
+    vi.mocked(gitContextForRepo).mockReturnValue({ listOpenIssues: vi.fn(() => { throw new Error('gh failed'); }) } as never);
+
+    const deps = buildDefaultDocsSelfCheckDeps();
+    const result = deps.findExistingRefactorIssue(REPO_INFO, 'app_docs/feature-foo.md');
+
+    expect(result).toBeNull();
+  });
+
+  it('calls listOpenIssues with correct options', () => {
+    const ctx = makeCtx('[]');
+    vi.mocked(gitContextForRepo).mockReturnValue(ctx as never);
+
+    const deps = buildDefaultDocsSelfCheckDeps();
+    deps.findExistingRefactorIssue(REPO_INFO, 'app_docs/feature-foo.md');
+
+    expect(ctx.listOpenIssues).toHaveBeenCalledWith({
+      fields: ['number', 'title'],
+      search: 'docs-bloat: app_docs/feature-foo.md',
+      limit: 5,
+    });
+  });
+});

--- a/adws/phases/docsSelfCheck.ts
+++ b/adws/phases/docsSelfCheck.ts
@@ -2,8 +2,9 @@ import * as fs from 'fs';
 import { parseConditionalDocs, type ConditionalDocsRegistry } from '../core/conditionalDocsRegistry';
 import { runDocsGuards, DOC_BLOAT_THRESHOLD_LINES, type DocSize, type GuardFlags, type BloatFlag } from '../core/docsGuards';
 import { createIssue } from '../github';
-import { execWithRetry, log as defaultLog, type LogLevel } from '../core';
+import { log as defaultLog, type LogLevel } from '../core';
 import type { RepoInfo } from '../github/githubApi';
+import { gitContextForRepo } from '../github/gitContextFactory';
 
 // ---------------------------------------------------------------------------
 // Types
@@ -39,11 +40,12 @@ export interface DocsSelfCheckParams {
 // ---------------------------------------------------------------------------
 
 function findExistingRefactorIssueDefault(repoInfo: RepoInfo, docPath: string): number | null {
-  const { owner, repo } = repoInfo;
   try {
-    const json = execWithRetry(
-      `gh issue list --repo ${owner}/${repo} --state open --search "docs-bloat: ${docPath}" --json number,title --limit 5`,
-    );
+    const json = gitContextForRepo(repoInfo).listOpenIssues({
+      fields: ['number', 'title'],
+      search: `docs-bloat: ${docPath}`,
+      limit: 5,
+    });
     const results = JSON.parse(json) as { number: number; title: string }[];
     const found = results.find((r) => r.title.includes(docPath));
     return found ? found.number : null;

--- a/adws/providers/github/githubCodeHost.ts
+++ b/adws/providers/github/githubCodeHost.ts
@@ -89,7 +89,7 @@ export class GitHubCodeHost implements CodeHost {
       // If the check fails, fall through to normal PR creation
     }
 
-    const prUrl = ctx.createPR(options.title, options.body, options.targetBranch);
+    const prUrl = ctx.createPR(options.title, options.body, options.sourceBranch, options.targetBranch);
 
     const numberMatch = prUrl.match(/\/pull\/(\d+)$/);
     if (!numberMatch) {

--- a/adws/triggers/__tests__/concurrencyGuard.test.ts
+++ b/adws/triggers/__tests__/concurrencyGuard.test.ts
@@ -1,0 +1,91 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('../../github/gitContextFactory', () => ({
+  gitContextForRepo: vi.fn(),
+}));
+
+vi.mock('../../core', () => ({
+  log: vi.fn(),
+  MAX_CONCURRENT_PER_REPO: 3,
+}));
+
+vi.mock('../../github/linkedPrDetector', () => ({
+  fetchLinkedPRs: vi.fn(() => []),
+  hasLinkedMergedOrClosedPR: vi.fn(() => false),
+}));
+
+vi.mock('../../core/workflowCommentParsing', () => ({
+  isAdwComment: vi.fn((body: string) => body.includes('ADW')),
+}));
+
+import { isConcurrencyLimitReached } from '../concurrencyGuard';
+import { gitContextForRepo } from '../../github/gitContextFactory';
+import { hasLinkedMergedOrClosedPR } from '../../github/linkedPrDetector';
+
+const REPO_INFO = { owner: 'acme', repo: 'webapp' };
+
+function makeCtx(listOpenIssuesResult: string) {
+  return { listOpenIssues: vi.fn(() => listOpenIssuesResult) };
+}
+
+describe('isConcurrencyLimitReached — routes through gitContextForRepo', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('returns false when there are no in-progress issues', async () => {
+    const issues = [
+      { number: 1, comments: [] },
+      { number: 2, comments: [{ body: 'normal comment' }] },
+    ];
+    vi.mocked(gitContextForRepo).mockReturnValue(makeCtx(JSON.stringify(issues)) as never);
+
+    const result = await isConcurrencyLimitReached(REPO_INFO);
+
+    expect(gitContextForRepo).toHaveBeenCalledWith(REPO_INFO);
+    expect(result).toBe(false);
+  });
+
+  it('counts in-progress issues (has ADW comment, no merged/closed PR)', async () => {
+    const issues = [
+      { number: 1, comments: [{ body: 'ADW workflow started' }] },
+      { number: 2, comments: [{ body: 'ADW workflow started' }] },
+      { number: 3, comments: [{ body: 'ADW workflow started' }] },
+    ];
+    vi.mocked(gitContextForRepo).mockReturnValue(makeCtx(JSON.stringify(issues)) as never);
+    vi.mocked(hasLinkedMergedOrClosedPR).mockReturnValue(false);
+
+    const result = await isConcurrencyLimitReached(REPO_INFO);
+
+    expect(result).toBe(true);
+  });
+
+  it('does not count issues with merged PRs', async () => {
+    const issues = [
+      { number: 1, comments: [{ body: 'ADW workflow started' }] },
+    ];
+    vi.mocked(gitContextForRepo).mockReturnValue(makeCtx(JSON.stringify(issues)) as never);
+    vi.mocked(hasLinkedMergedOrClosedPR).mockReturnValue(true);
+
+    const result = await isConcurrencyLimitReached(REPO_INFO);
+
+    expect(result).toBe(false);
+  });
+
+  it('returns false and logs on parse/throw error', async () => {
+    vi.mocked(gitContextForRepo).mockReturnValue({ listOpenIssues: vi.fn(() => { throw new Error('gh failed'); }) } as never);
+
+    const result = await isConcurrencyLimitReached(REPO_INFO);
+
+    expect(result).toBe(false);
+  });
+
+  it('calls listOpenIssues with number+comments fields and limit 100', async () => {
+    const ctx = makeCtx('[]');
+    vi.mocked(gitContextForRepo).mockReturnValue(ctx as never);
+
+    await isConcurrencyLimitReached(REPO_INFO);
+
+    expect(ctx.listOpenIssues).toHaveBeenCalledWith({ fields: ['number', 'comments'], limit: 100 });
+  });
+});

--- a/adws/triggers/__tests__/perIssueScenarioSweep.test.ts
+++ b/adws/triggers/__tests__/perIssueScenarioSweep.test.ts
@@ -14,8 +14,11 @@ vi.mock('fs', () => ({
 }));
 
 vi.mock('child_process', () => ({
-  execSync: vi.fn(),
   spawn: vi.fn(),
+}));
+
+vi.mock('../../github/gitContextFactory', () => ({
+  gitContextForRepo: vi.fn(),
 }));
 
 vi.mock('../../core', () => ({
@@ -24,11 +27,13 @@ vi.mock('../../core', () => ({
 
 vi.mock('../../github', () => ({
   getRepoInfo: vi.fn(() => ({ owner: 'test-owner', repo: 'test-repo' })),
+  bodyLinksIssue: vi.fn((body: string, num: number) => body.includes(`#${num}`)),
 }));
 
 // ── Imports (after mocks) ────────────────────────────────────────────────────
 
 import { isScenarioStale, runPerIssueScenarioSweep, RETENTION_DAYS } from '../perIssueScenarioSweep';
+import { gitContextForRepo } from '../../github/gitContextFactory';
 
 // ── Helpers ──────────────────────────────────────────────────────────────────
 
@@ -139,6 +144,37 @@ describe('runPerIssueScenarioSweep — integration', () => {
     expect(deleteFile).not.toHaveBeenCalledWith(failFile);
     expect(deleteFile).toHaveBeenCalledWith(staleFile);
     expect(logger).toHaveBeenCalledWith(expect.stringContaining('getMergedAt failed'), 'warn');
+  });
+
+  it('default getMergedAt routes through gitContextForRepo.fetchMergedPRs', async () => {
+    const mergedPRs = [{ body: 'Closes #55', mergedAt: '2026-01-01T00:00:00Z' }];
+    const mockCtx = { fetchMergedPRs: vi.fn(() => JSON.stringify(mergedPRs)) };
+    vi.mocked(gitContextForRepo).mockReturnValue(mockCtx as never);
+
+    const deleted = await runPerIssueScenarioSweep({
+      now: new Date('2026-02-15T00:00:00Z'),
+      listFeatures: () => ['features/per-issue/feature-55.feature'],
+      deleteFile: vi.fn(),
+      log: vi.fn(),
+    });
+
+    expect(gitContextForRepo).toHaveBeenCalled();
+    expect(mockCtx.fetchMergedPRs).toHaveBeenCalledWith(200);
+    expect(deleted).toEqual(['features/per-issue/feature-55.feature']);
+  });
+
+  it('default getMergedAt returns null on throw (fail-open)', async () => {
+    vi.mocked(gitContextForRepo).mockReturnValue({ fetchMergedPRs: vi.fn(() => { throw new Error('gh error'); }) } as never);
+    const deleteFile = vi.fn();
+
+    await runPerIssueScenarioSweep({
+      now: NOW,
+      listFeatures: () => ['features/per-issue/feature-99.feature'],
+      deleteFile,
+      log: vi.fn(),
+    });
+
+    expect(deleteFile).not.toHaveBeenCalled();
   });
 
   it('skips files whose names do not match the feature-{N}.feature pattern', async () => {

--- a/adws/triggers/__tests__/takeoverHandler.test.ts
+++ b/adws/triggers/__tests__/takeoverHandler.test.ts
@@ -777,3 +777,50 @@ describe('GitContext-based worktree path (phase_timeout)', () => {
     expect(deps.probeWorktree).toHaveBeenCalledWith(expectedWtPath, 'feature-issue-187-x', undefined, undefined);
   });
 });
+
+// ── buildDefaultTakeoverDeps — resolveAdwId routes through gitContextForRepo ─
+
+import { buildDefaultTakeoverDeps } from '../takeoverHandler';
+import { gitContextForRepo } from '../../github/gitContextFactory';
+
+vi.mock('../../github/gitContextFactory', () => ({
+  gitContextForRepo: vi.fn(),
+}));
+
+describe('buildDefaultTakeoverDeps — resolveAdwId default path', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('calls gitContextForRepo and issueComments then extracts the adwId', () => {
+    const comments = [
+      { body: '## ADW\n\nadwId: test-adwid-abc' },
+    ];
+    const mockCtx = { issueComments: vi.fn(() => JSON.stringify(comments)) };
+    vi.mocked(gitContextForRepo).mockReturnValue(mockCtx as never);
+
+    const deps = buildDefaultTakeoverDeps(REPO);
+    deps.resolveAdwId(99, REPO);
+
+    expect(gitContextForRepo).toHaveBeenCalledWith(REPO);
+    expect(mockCtx.issueComments).toHaveBeenCalledWith(99);
+  });
+
+  it('returns null on throw (fail-safe)', () => {
+    vi.mocked(gitContextForRepo).mockReturnValue({ issueComments: vi.fn(() => { throw new Error('gh failed'); }) } as never);
+
+    const deps = buildDefaultTakeoverDeps(REPO);
+    const result = deps.resolveAdwId(99, REPO);
+
+    expect(result).toBeNull();
+  });
+
+  it('returns null when issueComments returns unparseable JSON', () => {
+    vi.mocked(gitContextForRepo).mockReturnValue({ issueComments: vi.fn(() => 'not json') } as never);
+
+    const deps = buildDefaultTakeoverDeps(REPO);
+    const result = deps.resolveAdwId(99, REPO);
+
+    expect(result).toBeNull();
+  });
+});

--- a/adws/triggers/__tests__/webhookGatekeeper.test.ts
+++ b/adws/triggers/__tests__/webhookGatekeeper.test.ts
@@ -18,7 +18,10 @@ const { spawnMock, issueHasLabelMock, evaluateCandidateMock, releaseIssueSpawnLo
   releaseIssueSpawnLockMock: vi.fn(),
 }));
 
-vi.mock('child_process', () => ({ spawn: spawnMock, execSync: vi.fn() }));
+vi.mock('child_process', () => ({ spawn: spawnMock }));
+vi.mock('../../github/gitContextFactory', () => ({ gitContextForRepo: vi.fn() }));
+vi.mock('../issueDependencies', () => ({ parseDependencies: vi.fn() }));
+vi.mock('./issueEligibility', () => ({ checkIssueEligibility: vi.fn() }));
 vi.mock('../../github/issueApi', () => ({ issueHasLabel: issueHasLabelMock, closeIssue: vi.fn() }));
 vi.mock('../../github/labelManager', () => ({
   ADW_UPGRADE_LABEL: 'adw:upgrade',
@@ -46,7 +49,9 @@ vi.mock('../../core/agentState', () => ({
   AgentStateManager: { readTopLevelState: vi.fn(() => null) },
 }));
 
-import { classifyAndSpawnWorkflow } from '../webhookGatekeeper';
+import { classifyAndSpawnWorkflow, handleIssueClosedDependencyUnblock, closeAbandonedDependents } from '../webhookGatekeeper';
+import { gitContextForRepo } from '../../github/gitContextFactory';
+import { parseDependencies } from '../issueDependencies';
 
 const REPO_INFO = { owner: 'acme', repo: 'target' };
 const TARGET_ARGS = ['--target-repo', 'acme/target'];
@@ -92,5 +97,66 @@ describe('classifyAndSpawnWorkflow — adw:upgrade short-circuit (Bug C′)', ()
 
     expect(evaluateCandidateMock).toHaveBeenCalledTimes(1);
     expect(spawnedScripts().some((a) => a.endsWith('adws/adwUpgrade.tsx'))).toBe(false);
+  });
+});
+
+// ── handleIssueClosedDependencyUnblock — routes through gitContextForRepo ────
+
+describe('handleIssueClosedDependencyUnblock — listOpenIssues routing', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(parseDependencies).mockReturnValue([]);
+  });
+
+  it('uses the passed gitContext when provided (prefers it over factory)', async () => {
+    const issues = [{ number: 10, body: 'Blocked by #5' }];
+    const mockCtx = { listOpenIssues: vi.fn(() => JSON.stringify(issues)) };
+    vi.mocked(parseDependencies).mockReturnValue([5]);
+
+    await handleIssueClosedDependencyUnblock(5, REPO_INFO, [], mockCtx as never);
+
+    expect(mockCtx.listOpenIssues).toHaveBeenCalledWith({ fields: ['number', 'body'], limit: 100 });
+    expect(gitContextForRepo).not.toHaveBeenCalled();
+  });
+
+  it('falls back to gitContextForRepo when no gitContext is passed', async () => {
+    const issues: unknown[] = [];
+    const mockCtx = { listOpenIssues: vi.fn(() => JSON.stringify(issues)) };
+    vi.mocked(gitContextForRepo).mockReturnValue(mockCtx as never);
+
+    await handleIssueClosedDependencyUnblock(5, REPO_INFO, []);
+
+    expect(gitContextForRepo).toHaveBeenCalledWith(REPO_INFO);
+    expect(mockCtx.listOpenIssues).toHaveBeenCalledWith({ fields: ['number', 'body'], limit: 100 });
+  });
+
+  it('does not throw on listOpenIssues error', async () => {
+    vi.mocked(gitContextForRepo).mockReturnValue({ listOpenIssues: vi.fn(() => { throw new Error('gh failed'); }) } as never);
+
+    await expect(handleIssueClosedDependencyUnblock(5, REPO_INFO, [])).resolves.not.toThrow();
+  });
+});
+
+describe('closeAbandonedDependents — listOpenIssues routing', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(parseDependencies).mockReturnValue([]);
+  });
+
+  it('calls listOpenIssues with number+body fields via gitContextForRepo', async () => {
+    const issues: unknown[] = [];
+    const mockCtx = { listOpenIssues: vi.fn(() => JSON.stringify(issues)) };
+    vi.mocked(gitContextForRepo).mockReturnValue(mockCtx as never);
+
+    await closeAbandonedDependents(7, REPO_INFO);
+
+    expect(gitContextForRepo).toHaveBeenCalledWith(REPO_INFO);
+    expect(mockCtx.listOpenIssues).toHaveBeenCalledWith({ fields: ['number', 'body'], limit: 100 });
+  });
+
+  it('does not throw on listOpenIssues error', async () => {
+    vi.mocked(gitContextForRepo).mockReturnValue({ listOpenIssues: vi.fn(() => { throw new Error('gh failed'); }) } as never);
+
+    await expect(closeAbandonedDependents(7, REPO_INFO)).resolves.not.toThrow();
   });
 });

--- a/adws/triggers/concurrencyGuard.ts
+++ b/adws/triggers/concurrencyGuard.ts
@@ -5,11 +5,11 @@
  * and checks against MAX_CONCURRENT_PER_REPO.
  */
 
-import { execSync } from 'child_process';
 import { MAX_CONCURRENT_PER_REPO, log } from '../core';
 import type { RepoInfo } from '../github/githubApi';
 import { isAdwComment } from '../core/workflowCommentParsing';
 import { fetchLinkedPRs, hasLinkedMergedOrClosedPR } from '../github/linkedPrDetector';
+import { gitContextForRepo } from '../github/gitContextFactory';
 
 interface RawIssueWithComments {
   number: number;
@@ -21,10 +21,7 @@ interface RawIssueWithComments {
  */
 function fetchOpenIssuesWithComments(repoInfo: RepoInfo): RawIssueWithComments[] {
   try {
-    const json = execSync(
-      `gh issue list --repo ${repoInfo.owner}/${repoInfo.repo} --state open --json number,comments --limit 100`,
-      { encoding: 'utf-8' },
-    );
+    const json = gitContextForRepo(repoInfo).listOpenIssues({ fields: ['number', 'comments'], limit: 100 });
     return JSON.parse(json);
   } catch (error) {
     log(`Failed to fetch open issues for concurrency check: ${error}`, 'error');

--- a/adws/triggers/perIssueScenarioSweep.ts
+++ b/adws/triggers/perIssueScenarioSweep.ts
@@ -5,9 +5,9 @@
 
 import * as fs from 'fs';
 import * as path from 'path';
-import { execSync } from 'child_process';
 import { log } from '../core';
 import { getRepoInfo, bodyLinksIssue } from '../github';
+import { gitContextForRepo } from '../github/gitContextFactory';
 
 export const RETENTION_DAYS = 14;
 
@@ -51,14 +51,10 @@ function defaultListFeatures(): string[] {
 function defaultGetMergedAt(issueNum: number): Promise<Date | null> {
   try {
     const repoInfo = getRepoInfo();
-    const { owner, repo } = repoInfo;
     // GitHub search can't reliably express the "Closes owner/repo#N" body marker,
     // so fetch merged PRs and filter client-side with the canonical matcher.
     // gh returns newest-first, so the first linked PR is the most recent merge.
-    const json = execSync(
-      `gh pr list --repo ${owner}/${repo} --state merged --json body,mergedAt --limit 200`,
-      { encoding: 'utf-8' },
-    );
+    const json = gitContextForRepo(repoInfo).fetchMergedPRs(200);
     const prs = JSON.parse(json) as Array<{ body: string; mergedAt: string | null }>;
     const linked = prs.find((pr) => bodyLinksIssue(pr.body, issueNum) && pr.mergedAt);
     if (!linked?.mergedAt) return Promise.resolve(null);

--- a/adws/triggers/takeoverHandler.ts
+++ b/adws/triggers/takeoverHandler.ts
@@ -22,7 +22,6 @@
  * All I/O boundaries are injected via TakeoverDeps so every branch is unit-testable.
  */
 
-import { execSync } from 'child_process';
 import {
   acquireIssueSpawnLock,
   releaseIssueSpawnLock,
@@ -32,6 +31,7 @@ import { isProcessLive } from '../core/processLiveness';
 import { AgentStateManager } from '../core/agentState';
 import { deriveStageFromRemote } from '../core/remoteReconcile';
 import { gitContextForSync } from '../github';
+import { gitContextForRepo } from '../github/gitContextFactory';
 import { extractLatestAdwId } from './cronStageResolver';
 import { classifyStageString } from '../core/stageClassifier';
 import { nextResumeAction, MAX_RESUME_ATTEMPTS } from '../core/resumePolicy';
@@ -86,10 +86,7 @@ export function buildDefaultTakeoverDeps(repoInfo?: RepoInfo): TakeoverDeps {
       readSpawnLockRecord(repoInfo, issueNumber),
     resolveAdwId: (issueNumber, repoInfo) => {
       try {
-        const json = execSync(
-          `gh issue view ${issueNumber} --repo ${repoInfo.owner}/${repoInfo.repo} --json comments --jq '.comments'`,
-          { encoding: 'utf-8' },
-        );
+        const json = gitContextForRepo(repoInfo).issueComments(issueNumber);
         const comments = JSON.parse(json) as { body: string }[];
         return extractLatestAdwId(comments);
       } catch {

--- a/adws/triggers/webhookGatekeeper.ts
+++ b/adws/triggers/webhookGatekeeper.ts
@@ -5,7 +5,7 @@
  * classify-and-spawn workflow, and cron process management.
  */
 
-import { spawn, execSync } from 'child_process';
+import { spawn } from 'child_process';
 import * as fs from 'fs';
 import * as path from 'path';
 import { log, generateAdwId, REPO_ROOT, LOGS_DIR } from '../core';
@@ -27,6 +27,7 @@ import { evaluateCandidate } from './takeoverHandler';
 import type { CandidateDecision } from './takeoverHandler';
 import { readAuthGate } from '../core/authGate';
 import type { GitContext } from '../gitContext';
+import { gitContextForRepo } from '../github/gitContextFactory';
 
 /**
  * Spawns a detached child process for running ADW orchestrator workflows.
@@ -173,10 +174,8 @@ export async function handleIssueClosedDependencyUnblock(
   gitContext?: GitContext,
 ): Promise<void> {
   try {
-    const json = execSync(
-      `gh issue list --repo ${repoInfo.owner}/${repoInfo.repo} --state open --json number,body --limit 100`,
-      { encoding: 'utf-8' },
-    );
+    const ctx = gitContext ?? gitContextForRepo(repoInfo);
+    const json = ctx.listOpenIssues({ fields: ['number', 'body'], limit: 100 });
     const issues = JSON.parse(json) as { number: number; body: string }[];
 
     const dependents = issues.filter((issue) => {
@@ -243,10 +242,7 @@ export async function closeAbandonedDependents(
   repoInfo: RepoInfo,
 ): Promise<void> {
   try {
-    const json = execSync(
-      `gh issue list --repo ${repoInfo.owner}/${repoInfo.repo} --state open --json number,body --limit 100`,
-      { encoding: 'utf-8' },
-    );
+    const json = gitContextForRepo(repoInfo).listOpenIssues({ fields: ['number', 'body'], limit: 100 });
     const issues = JSON.parse(json) as { number: number; body: string }[];
 
     const dependents = issues.filter((issue) => {

--- a/app_docs/feature-oqb76h-gitcontext-base-path-authority.md
+++ b/app_docs/feature-oqb76h-gitcontext-base-path-authority.md
@@ -2,7 +2,7 @@
 
 ## Overview
 
-`adws/gitContext/` is the single deep module that answers "which repository's filesystem am I operating on?" and "which auth identity does every command run with?" A `GitContext` is constructed from a mandatory identity (`owner`, `repo`, `selfHost`, `token`, `gitIdentity`) plus injected resolution config (`frameworkRepoRoot`, `targetReposDir`) and an optional `pat` for PAT-requiring operations. Every operation — branch create/checkout/delete, commit/push (force-with-lease), fetch/reset, worktree create/ensure/remove/list/query, and all `gh`/GitHub-API operations (issue read/comment, PR read/create/merge/approve, label lifecycle, Projects V2 board) — is a method on `GitContext`, running through the single private `#run()` chokepoint that injects per-command auth and git identity into the child process environment without ever mutating `process.env`. This module implements PRD `specs/prd/git-context-repo-authority.md` and eliminates the historical "wrong-repo worktree" and `GH_TOKEN` bleed classes of bug structurally.
+`adws/gitContext/` is the single deep module that answers "which repository's filesystem am I operating on?" and "which auth identity does every command run with?" A `GitContext` is constructed from a mandatory identity (`owner`, `repo`, `selfHost`, `token`, `gitIdentity`) plus injected resolution config (`frameworkRepoRoot`, `targetReposDir`) and an optional `pat` for PAT-requiring operations. Every operation — branch create/checkout/delete, commit/push (force-with-lease), fetch/reset, worktree create/ensure/remove/list/query, all `gh`/GitHub-API operations (issue read/comment, PR read/create/merge/approve, label lifecycle, Projects V2 board), and gh issue/PR read operations (`listOpenIssues`, `issueComments`, `fetchMergedPRs`) — is a method on `GitContext`, running through the single private `#run()` chokepoint that injects per-command auth and git identity into the child process environment without ever mutating `process.env`. This module implements PRD `specs/prd/git-context-repo-authority.md` and eliminates the historical "wrong-repo worktree" and `GH_TOKEN` bleed classes of bug structurally.
 
 ## Responsibilities
 
@@ -16,6 +16,7 @@
 - Provide commit/push operations: `commitChanges`, `pushBranch` (force-with-lease + lease-rejection detection), `getHeadTreeHash`, `hasUncommittedChanges`
 - Provide worktree reset: `resetWorktree` (abort in-progress merge/rebase via fs then fetch/reset --hard/clean -fdx)
 - Provide full worktree management surface (slice #661): `createWorktree`, `createWorktreeForNewBranch`, `ensureWorktree`, `getWorktreeForBranch`, `listWorktrees`, `findWorktreeForIssue`, `removeWorktree`, `removeWorktreesForIssue`, `copyEnvToWorktree`
+- Provide gh read methods (slice #691): `listOpenIssues({ fields, search?, limit? })`, `issueComments(issueNumber)`, `fetchMergedPRs(limit?)` — covering the residual direct-`gh` consumers migrated off the ALLOWLIST
 - Delegate VCS operation orchestration to package-private modules (`branchOps.ts`, `commitOps.ts`, `worktreeResetOps.ts`, `worktreeCreateOps.ts`, `worktreeQueryOps.ts`, `worktreeRemoveOps.ts`, `processCleanup.ts`), each taking an injected runner — keeping the `GitContext` class thin and testable
 - Expose the full `gh` issue, PR, label, and board operation surface as thin methods that delegate to pure command-builder + parser modules in `adws/gitContext/commands/`
 - Accept an injectable `ExecFn` via `GitContextDeps` for hermetic testing (the ADW `Deps` idiom)
@@ -41,22 +42,33 @@ Each module is side-effect-free (no `exec`, no `process.env`) and stays under 30
 
 | Module | Exports |
 |---|---|
-| `issueCommands.ts` | Command builders + parsers for `gh issue …` / `gh api issues` (fetch, comment, state, close, title, comments, labels, create, update, find-upgrade, delete-comment) |
-| `prCommands.ts` | PR builders + parsers (find by branch, fetch details/reviews/comments, comment, merge, approve, approval state, list, create) |
+| `issueCommands.ts` | Command builders + parsers for `gh issue …` / `gh api issues` (fetch, comment, state, close, title, comments, labels, create, update, find-upgrade, delete-comment, **listOpenIssues** with `ListOpenIssuesOptions`, **issueComments**) |
+| `prCommands.ts` | PR builders + parsers (find by branch, fetch details/reviews/comments, comment, merge, approve, approval state, list, create, **fetchMergedPRs**) |
 | `labelCommands.ts` | Label create and apply (create-if-missing + add) command builders |
 | `boardCommands.ts` | Projects V2 GraphQL query/mutation builders + parsers (project id, issue item, status field, status update, `moveIssueToStatus`) |
 
 ## Boundary Factory (`adws/github/gitContextFactory.ts`)
 
-`gitContextFor({ owner, repo, selfHost })` and `gitContextForSync(...)` construct a `GitContext` from ambient ADW identity:
+`gitContextFor({ owner, repo, selfHost })`, `gitContextForSync(...)`, and `gitContextForRepo(repoInfo)` construct a `GitContext` from ambient ADW identity:
 - Token resolution order: GitHub App installation token → `GH_TOKEN` env var → `gh auth token` CLI
 - Git identity resolution order: `GIT_AUTHOR_NAME`/`GIT_AUTHOR_EMAIL` env vars → `GITHUB_APP_SLUG` bot identity → `git config user.*` → fallback defaults (`ADW Bot`)
 - Injects `REPO_ROOT` / `TARGET_REPOS_DIR` from `adws/core/environment`
 - Async export (`gitContextFor`) and sync export (`gitContextForSync`) — all resolution is `execSync` under the hood; async variant exists so callers can `await` at the scope boundary
+- `gitContextForRepo(repoInfo)` is a sync convenience for consumers that only have a `RepoInfo` object (e.g. trigger-layer modules); auto-detects self-host so the base path always resolves to a directory that exists
 
-## Migrated Call Sites (as of #661)
+## Migrated Call Sites (as of #691)
 
-`workflowInit.ts`, `prPhase.ts`, `buildPhase.ts`, `documentPhase.ts`, `reviewPhase.ts`, `scenarioFixPhase.ts`, `prReviewPhase.ts`, `takeoverHandler.ts`, `webhookHandlers.ts`, `cancelHandler.ts`, `devServerJanitor.ts`, `adwMerge.tsx`, `adwUpgrade.tsx`, and `adwPromotionSweep.tsx` all construct a `GitContext` via the factory or receive one threaded from the launch boundary, and delegate all git/gh/worktree calls through context methods. No call site passes an optional base-path/`cwd` to a worktree function; `getWorktreesDir`, `getWorktreePath`, and `worktreeExists` no longer exist.
+`workflowInit.ts`, `prPhase.ts`, `buildPhase.ts`, `documentPhase.ts`, `reviewPhase.ts`, `scenarioFixPhase.ts`, `prReviewPhase.ts`, `takeoverHandler.ts`, `webhookHandlers.ts`, `cancelHandler.ts`, `devServerJanitor.ts`, `adwMerge.tsx`, `adwUpgrade.tsx`, and `adwPromotionSweep.tsx` all construct a `GitContext` via the factory or receive one threaded from the launch boundary. Trigger-layer and phase modules that perform gh reads were migrated in #691:
+
+| Consumer | Previous | Now |
+|---|---|---|
+| `concurrencyGuard.ts` | `execSync('gh issue list …')` | `gitContextForRepo(repoInfo).listOpenIssues(...)` |
+| `webhookGatekeeper.ts` (×2) | `execSync('gh issue list …')` | `ctx.listOpenIssues(...)` (prefers injected `gitContext`; falls back to factory) |
+| `docsSelfCheck.ts` | `execWithRetry('gh issue list …')` | `gitContextForRepo(repoInfo).listOpenIssues(...)` |
+| `takeoverHandler.ts` | `execSync('gh issue view … --jq .comments')` | `gitContextForRepo(repoInfo).issueComments(issueNumber)` |
+| `perIssueScenarioSweep.ts` | `execSync('gh pr list …')` | `gitContextForRepo(repoInfo).fetchMergedPRs(200)` |
+
+All five files have been removed from the `ALLOWLIST` in `adws/checkGitGhGuard.ts`. The `bun run lint:git-guard` CI check now passes with no allowlisted trigger/phase files for gh reads.
 
 ## VCS Module End State (as of #661)
 
@@ -87,6 +99,7 @@ Each module is side-effect-free (no `exec`, no `process.env`) and stays under 30
 - `mergeLatestFromDefaultBranch` warns-don't-throw on fetch/merge failures — merge conflicts are non-fatal
 - All worktree create/ensure/remove/list/query methods resolve paths under `#basePath` via `#worktreesDir()` and `worktreePathFor()` — no caller-supplied base path
 - The package imports nothing from `adws/core`, `adws/providers`, or any ADW global — all config is injected at construction (`findWorktreeForIssue` takes a pre-resolved `prefixes` array so the package stays free of `branchPrefixMap`)
+- `listOpenIssues`, `issueComments`, and `fetchMergedPRs` are thin delegators through `#run()` — they do not mutate `process.env` and they use the context's token for per-command auth
 
 ## Configuration
 
@@ -125,6 +138,8 @@ Optional injectable dependency bag via `GitContextDeps` (second constructor para
 - **Board and approve ops require `GITHUB_PAT`** — `usePat: true` falls back to the context token when `GITHUB_PAT` is unset (user-owned repos degrade gracefully, matching prior behaviour from `feature-9tknkw`).
 - **Branch sanitization regex** — `worktreePathFor` sanitizes with `/[/\\:*?"<>|`]/g → '-'`, matching the historical `worktreeOperations.ts` helper for path compatibility post-migration.
 - **Injectable exec seam (`ExecFn` / `GitContextDeps`) is for tests, not config** — the seam exists so spy tests can assert per-call `{ cwd, env, input }` without spawning real processes. The default is a real `execSync` wrapper — the only real spawn site in the package.
-- **`gitContextForSync` vs `gitContextFor`** — use `gitContextForSync` when you're already in a synchronous initialization path; use `gitContextFor` when you can `await`. Both produce identical `GitContext` instances; the async variant is a thin wrapper.
+- **`gitContextForSync` vs `gitContextFor` vs `gitContextForRepo`** — use `gitContextForSync` when you're already in a synchronous initialization path; use `gitContextFor` when you can `await`; use `gitContextForRepo(repoInfo)` in trigger/phase modules that only have a `RepoInfo` object (the most common case in `adws/triggers/` and `adws/phases/`). All produce identical `GitContext` instances.
 - **No physical npm package** — the "importable package" guarantee is satisfied structurally by the zero-ADW-global dependency discipline; physical workspace extraction to `packages/git-context/` is deferred.
 - **`freeBranchFromMainRepo` preserves non-force push** — the known non-force-push deadlock risk on rewritten branches is tracked separately (#648); the ported semantics are unchanged from the prior vcs implementation.
+- **`listOpenIssues` shares command shape across three former allowlisted consumers** — `concurrencyGuard` projects `[number, comments]`, `webhookGatekeeper` projects `[number, body]`, and `docsSelfCheck` projects `[number, title]` with a `search` filter; the `ListOpenIssuesOptions` type captures all three variations.
+- **`checkGitGhGuard.ts` `main()` guard** — the guard is now exported as a module to support test imports; `main()` is called only when `process.argv[1]` includes `checkGitGhGuard` (i.e. when run as a script). Tests can import `scanFiles`/`ALLOWLIST` without side-effects.

--- a/features/per-issue/feature-691.feature
+++ b/features/per-issue/feature-691.feature
@@ -1,0 +1,339 @@
+@adw-691 @adw-96qtfe-gitcontext-migrate-g
+Feature: GitContext gh-read migration — the residual issue/PR read consumers route through the per-command-auth chokepoint, and the git/gh guard no longer exempts them
+
+  Issue #691 (parent PRD `specs/prd/git-context-repo-authority.md`, see the
+  **Enforcement** section) is the slice that drives the git/gh guard ALLOWLIST toward
+  zero for the read surface. The guard shipped as a RATCHET, not the spec'd invariant:
+  a handful of residual gh-READ consumers were parked on the ALLOWLIST while the write
+  surface migrated (#663) and the launch/webhook boundary constructors landed (#660,
+  #664). This slice removes the read consumers from that ratchet.
+
+  Earlier slices established the machinery this one consumes:
+
+    • #658 shipped the `GitContext` deep module — mandatory identity, the
+      one-constructor base-path decision, `worktreePathFor(branch)`, and the
+      `commandEnv()` per-command env overlay BUILDER carrying the token + git
+      author/committer.
+    • #659 routed a representative READ op (default-branch) through the private
+      `#run` chokepoint, proving the spawn path end to end: a command launches with
+      cwd = base path and a child env carrying the token, the parent global untouched.
+    • #663 migrated the full gh-OPERATION surface (issue/PR/comment/label/board) onto
+      context methods, all through `#run`.
+
+  What this slice builds:
+
+    • New gh-READ method(s) on `GitContext`, going through the existing `#run`
+      chokepoint, covering the read shapes the residual consumers still need:
+        – an open-issue list read (the `gh issue list --state open --json …` shape
+          used by the concurrency guard, the webhook dependency-unblock/abandon
+          sweeps, and the docs self-check refactor-issue lookup),
+        – a single-issue comments read (the `gh issue view N --json comments` shape
+          the takeover handler uses to resolve the latest adwId from comments),
+        – a merged-PR list read (the `gh pr list --state merged --json …` shape the
+          per-issue scenario sweep uses to date a feature file's linked merge).
+      `fetchPRList` (open PRs) already exists; the merged-PR read is the only PR-list
+      shape still missing.
+    • The five residual consumers — `concurrencyGuard`, `webhookGatekeeper`,
+      `docsSelfCheck`, `takeoverHandler`, `perIssueScenarioSweep` — stop shelling out
+      to raw `gh` and route their reads through the context instead. With their last
+      raw `gh` call gone, each is REMOVED from the guard ALLOWLIST in
+      `adws/checkGitGhGuard.ts`, so the guard scans them like any other file.
+
+  Why this slice exists — the defect it forecloses:
+
+    A consumer that shells out to raw `gh` authenticates against whatever repo last
+    wrote the process-global `GH_TOKEN`. While such a consumer sits on the ALLOWLIST,
+    the guard cannot catch a NEW raw `gh` read sneaking in beside it, and the read
+    itself rides the bleeding global rather than a per-command token — the exact
+    "could not resolve to a repository" shape the PRD mined ~13 times. Routing the
+    reads through `#run` binds each read's auth to the command (no shared global to
+    clobber), and de-allowlisting the file re-arms the guard so any future raw `gh`
+    read in it is a build failure, not a silent regression. Behaviour is unchanged;
+    only token APPLICATION (per-command vs process-global) and guard COVERAGE change.
+
+  Contract pinned here (the OBSERVABLE behaviour, not the field/signature shape):
+
+    • read goes through #run   → each new gh-read method spawns its command with
+                                 cwd = the context base path and a child env carrying
+                                 the context's token + git author/committer (AC1).
+    • per-command auth          → a new read method's auth token lives in the spawned
+                                 child's environment; running it leaves the parent
+                                 process environment byte-for-byte unchanged — no
+                                 reintroduced global mutation on the last read path
+                                 (AC1; stories 5, 18).
+    • consumer de-allowlisted   → the guard, run against each of the five migrated
+                                 consumer files, SCANS the file (it is no longer
+                                 exempt) and finds NO direct git/gh shell-out in it
+                                 (AC2, AC3; story 8).
+    • guard still passes        → with the five files removed from the ALLOWLIST, the
+                                 guard run across the whole repository reports zero
+                                 violations — the de-allowlisting introduced no new
+                                 violation, the ratchet simply sits lower (AC4;
+                                 story 8).
+
+  Observability / rot-prevention note:
+
+    Every assertion below targets a runtime OUTPUT of the system under test, never the
+    static text of a source file. No step opens `concurrencyGuard.ts`,
+    `webhookGatekeeper.ts`, `docsSelfCheck.ts`, `takeoverHandler.ts`,
+    `perIssueScenarioSweep.ts`, `checkGitGhGuard.ts`, or the GitContext package as
+    text, substring-matches its contents, or parses it as JSON/AST.
+
+      • §1 runs each new read method through a RECORDING RUNNER injected as the
+        context's command boundary (the `GitContextDeps.exec` seam #659 established —
+        the same recorder category as the registered `git-mock`/`mock server`
+        collaborators in `vocabulary.md`) and asserts the RECORDED `cwd` and child
+        `env` the context handed that runner. The recorded `(cwd, env)` is the
+        command's actual launch parameters — a runtime artefact, not a source read.
+        The "parent env unchanged" step compares the LIVE `process.env` before and
+        after the read; `process.env` is live runtime state, the canonical observable
+        for "was the global mutated," which the Rot-Detection Rubric permits.
+      • §2 and §3 assert the GUARD'S VERDICT, where the guard tool IS the system under
+        test. The guard's exported scan returns a `{ violations, scannedCount }`
+        result — a value computed at runtime, the guard's OUTPUT — and the steps
+        assert that result. This is the SAME artefact category as registry T22 ("the
+        ADW TypeScript type-check passes"), which runs `tsc` over the whole source
+        tree and asserts its verdict: the analyzer reads source, but the SCENARIO
+        asserts the analyzer's OUTPUT, never source text. Critically, "removed from
+        the ALLOWLIST" is NOT asserted by grepping `checkGitGhGuard.ts` for the path —
+        it is proven only through its OBSERVABLE CONSEQUENCE: the guard now SCANS the
+        file (its `scannedCount` counts it; an allowlisted file is skipped and never
+        counted), and finds it violation-free. A refactor that renames a consumer or
+        restructures the guard leaves these assertions valid as long as the BEHAVIOUR
+        holds — the file is scanned and clean.
+
+    The file paths, owners/repos, tokens, authors, and op names in the steps are INPUT
+    test data; the recorded `(cwd, env)`, the live `process.env`, the guard's
+    `{ violations, scannedCount }`, and the type-check exit code are the system's
+    OUTPUTS — exactly the artefact category the rubric permits. The recording runner
+    means no real `gh` is spawned and no network is touched in §1, so those scenarios
+    are hermetic.
+
+  Scope notes:
+
+    • This slice pins TWO observable contracts: (a) the new gh-read methods route
+      their spawn through the per-command-auth `#run` chokepoint (§1), and (b) the
+      five consumer files are now scanned by the guard and are violation-free (§2),
+      with the whole-repo guard still passing (§3). Together these prove the reads
+      moved off raw `gh` and onto the context: the consumers contain no raw `gh`
+      (guard-clean, §2) and the context's read methods that replace them carry
+      per-command auth (§1). The exact threading of a `GitContext` into each consumer
+      (constructor param, function arg, or an injected dep's default) is an
+      implementer's choice and is deliberately NOT pinned, consistent with the sibling
+      slices' "pin the decision, not the shape" stance (#658/#659/#663). Re-asserting
+      the per-consumer call wiring would require coupling to signatures the issue
+      leaves open and would rot on a harmless refactor.
+    • The new read methods' NAMES and decomposition (one parameterised `listOpenIssues`
+      vs several; whether the merged-PR read is a new method or the existing
+      `fetchAllPRs` filtered; whether the takeover comments read reuses `fetchIssue`)
+      are NOT pinned — the friendly op names in §1 map to whatever methods the
+      implementer adds, inside the step definitions.
+    • Parent-global isolation and two-context isolation for the `#run` spawn path are
+      already proven exhaustively by #659 (§3–§5) and #663 (§2–§4); the new read
+      methods route through the SAME chokepoint, so this slice re-pins only ONE
+      representative parent-env-unchanged check (§1c) — an anti-regression that the
+      LAST read consumers do not reintroduce a global mutation — and does not restate
+      the full isolation matrix.
+    • Auth ACQUISITION is unchanged: token minting/refresh is untouched; only token
+      APPLICATION (per-command vs process-global) changes. No scenario here drives the
+      minting path, an orchestrator, or the webhook as a subprocess.
+    • Behaviour of the consumers themselves (the concurrency count, the staleness
+      retention window, the takeover decision tree, the docs-bloat routing) is
+      unchanged and already covered by their existing unit suites; this slice adds
+      coverage for the read-path migration and the guard de-allowlisting, it does not
+      relax those suites.
+    • The @regression maintenance sweep is SKIPPED for this issue: `.adw/scenarios.md`
+      configures a `## Regression Scenario Directory`, so promotion is a deliberate
+      human decision and the agent never auto-promotes.
+
+  Vocabulary note:
+
+    Registered phrases reused (`features/regression/vocabulary.md`):
+      G18 `the ADW codebase is checked out`              (background + §2/§3 + type-check)
+      T22 `the ADW TypeScript type-check passes`          (backstop)
+
+    Phrases reused verbatim from the GitContext per-issue corpus (established by
+    feature-659, globally registered via `gitContextSharedWorld.ts`, NOT yet in the
+    registry) so the §1 step definitions share #659's recording-runner and parent-env
+    machinery:
+      • `a GitContext for owner {string} repo {string} with auth token {string} and git author {string}`
+      • `the context's git and gh commands are captured by a recording runner`
+      • `a baseline snapshot of the parent process environment is captured`
+      • `the captured command ran with auth token {string} in its child environment`
+      • `the captured command ran with git author {string} in its child environment`
+      • `the captured command ran with cwd equal to the context base path`
+      • `the parent process environment matches the baseline snapshot`
+
+    Novel phrasing introduced here — the registry has no phrase for running a NEW
+    gh-read method through the context, nor for asserting the git/gh guard's scan
+    verdict. Phrased DISTINCTLY from #659's `read operation` and #663's `gh operation`
+    runner phrases (this uses `gh-read operation`) so the step files do not collide as
+    Cucumber loads them all globally. Surfaced to the maintainer in the agent Output:
+      Running a new read method through the context:
+        • `the {string} gh-read operation runs through the context`
+      Guard scan verdict:
+        • `the git/gh guard scans the file {string}`
+        • `the git/gh guard scanned that file`
+        • `the git/gh guard reports no violation in that file`
+        • `the git/gh guard is run across the repository`
+        • `the git/gh guard reports no violations`
+
+    Step-definition note for the maintainer:
+      • §1 steps phase-import `GitContext` and REUSE the shared `gitContextSharedWorld.ts`
+        machinery (`makeFullOptions`, `makeSpyExec`, the shared `W`) exactly as
+        `feature-662.steps.ts` does, so #659's globally-registered assertion steps
+        (`the captured command ran with auth token …`, `… git author …`, `… cwd equal
+        to the context base path`, `a baseline snapshot …`, `… matches the baseline
+        snapshot`) apply to the recorded calls without redefinition.
+      • `the {string} gh-read operation runs through the context` extends the shared
+        `runOpOnContext(ctx, opName)` dispatcher with the new read methods:
+          "list-open-issues"    → the new open-issue list read method
+          "view-issue-comments" → the new single-issue comments read method
+          "list-merged-prs"     → the merged-PR list read (new method, or existing
+                                  `fetchAllPRs` filtered to merged — both route via #run)
+        Construct the context via `makeFullOptions(owner, repo, token, authorName,
+        authorEmail)` + `new GitContext(opts, { exec: makeSpyExec(W.responseMap).exec,
+        fsDeps: makeNoOpFsDeps() })`, store it on `W.ctx` and the recorder's `calls`
+        on `W.spyCalls`. Seed `W.responseMap` so the spy returns canned PARSEABLE
+        output for each read (e.g. `[]` for the list reads) so the method completes;
+        no real subprocess, no network. The token/author/cwd assertions are
+        value-based comparisons against the recorded child `env`/`cwd`
+        (`recorded.env.GH_TOKEN === token`, `recorded.cwd === ctx.basePath`).
+      • `the git/gh guard scans the file {string}` phase-imports the EXPORTED pure
+        `scanFiles(relPaths, repoRoot)` from `adws/checkGitGhGuard.ts` and calls
+        `scanFiles([path], process.cwd())`, storing the returned `{ violations,
+        scannedCount }` on the World. `the git/gh guard scanned that file` asserts
+        `scannedCount === 1` (the file is NOT on the ALLOWLIST — an allowlisted file is
+        skipped and `scannedCount` stays 0; this is the de-allowlisting discriminator,
+        RED before this slice because the file is still exempt). `the git/gh guard
+        reports no violation in that file` asserts `violations.length === 0` (no raw
+        git/gh). Both reference only the returned value — never source text.
+      • `the git/gh guard is run across the repository` runs the guard over the whole
+        tree and captures its verdict — either by spawning `bun run lint:git-guard`
+        (= `bunx tsx adws/checkGitGhGuard.ts`) with `cwd: process.cwd()` and capturing
+        the exit code + stdout (registry surfaces 4 + 5), or by re-walking the tree and
+        calling `scanFiles`. `the git/gh guard reports no violations` asserts the run
+        reported a clean result (exit 0 / PASS, or `violations.length === 0`). This is
+        the safe-de-allowlisting backstop: it fails if a file is removed from the
+        ALLOWLIST while a raw git/gh call still lives in it.
+
+  Background:
+    Given the ADW codebase is checked out
+
+  # ═══════════════ §1  NEW gh-READ METHODS ROUTE THROUGH #run (AC1; stories 5, 18) ═
+  #
+  # Surface: each new read method actually spawns its `gh` command through the private
+  # `#run` chokepoint. Its observable output is the command's launch parameters — the
+  # cwd and the child environment the context handed the recording runner. #659 proved
+  # this for the default-branch read; here it is the residual read shapes the migrated
+  # consumers need (open-issue list, single-issue comments, merged-PR list).
+
+  # ── §1a  A new open-issue list read carries token + git identity + base-path cwd ──
+  #
+  # The headline read op. The concurrency guard / webhook sweeps / docs self-check all
+  # need the `gh issue list --state open --json …` shape; routed through the context it
+  # spawns with the context's token AND git author/committer in the child env, with
+  # cwd = the context base path — never the ambient process cwd the legacy
+  # `execSync`/`execWithRetry` inherited.
+
+  @adw-691 @adw-96qtfe-gitcontext-migrate-g
+  Scenario: A new open-issue list read supplies the context token, git identity, and base-path cwd to its child command
+    Given a GitContext for owner "acme" repo "webapp" with auth token "token-acme" and git author "Acme Bot <bot@acme.dev>"
+    And the context's git and gh commands are captured by a recording runner
+    When the "list-open-issues" gh-read operation runs through the context
+    Then the captured command ran with auth token "token-acme" in its child environment
+    And the captured command ran with git author "Acme Bot <bot@acme.dev>" in its child environment
+    And the captured command ran with cwd equal to the context base path
+
+  # ── §1b  Every new gh-read method carries the context token + base-path cwd ────────
+  #
+  # Breadth proof across the residual read surface: each read the five consumers needed
+  # now routes through the per-command spawn path. cwd = base path is itself a strong
+  # migration signal — the legacy reads ran under the ambient process cwd; a migrated
+  # read runs under the context base path.
+
+  @adw-691 @adw-96qtfe-gitcontext-migrate-g
+  Scenario Outline: Each new GitContext gh-read method runs with the context token and the base-path cwd
+    Given a GitContext for owner "acme" repo "webapp" with auth token "token-acme" and git author "Acme Bot <bot@acme.dev>"
+    And the context's git and gh commands are captured by a recording runner
+    When the "<op>" gh-read operation runs through the context
+    Then the captured command ran with auth token "token-acme" in its child environment
+    And the captured command ran with cwd equal to the context base path
+
+    Examples:
+      | op                  |
+      | list-open-issues    |
+      | view-issue-comments |
+      | list-merged-prs     |
+
+  # ── §1c  A new read method does not reintroduce a process-global mutation ──────────
+  #
+  # These five are the LAST raw-`gh` readers. The whole epic exists to kill the
+  # process-global `GH_TOKEN` bleed; a sloppy new read method that wrote
+  # `process.env.GH_TOKEN` would silently reopen it. Running a representative new read
+  # leaves the parent environment byte-for-byte unchanged — the token rode the child
+  # env only.
+
+  @adw-691 @adw-96qtfe-gitcontext-migrate-g
+  Scenario: A new open-issue list read leaves the parent process environment byte-for-byte unchanged
+    Given a GitContext for owner "acme" repo "webapp" with auth token "token-acme" and git author "Acme Bot <bot@acme.dev>"
+    And the context's git and gh commands are captured by a recording runner
+    And a baseline snapshot of the parent process environment is captured
+    When the "list-open-issues" gh-read operation runs through the context
+    Then the parent process environment matches the baseline snapshot
+
+  # ═══════════════ §2  CONSUMERS DE-ALLOWLISTED AND GUARD-CLEAN (AC2, AC3; story 8) ═
+  #
+  # The headline for this slice. The git/gh guard tool IS the system under test; its
+  # observable output is the `{ violations, scannedCount }` it computes for a file. An
+  # ALLOWLISTED file is SKIPPED — the guard never scans it, so `scannedCount` stays 0.
+  # After this slice each consumer is removed from the ALLOWLIST, so the guard SCANS it
+  # (`scannedCount` counts it) and, because its raw `gh` read is gone, finds NO
+  # violation. The "scanned" assertion is the de-allowlisting discriminator: RED before
+  # this slice (the file is still exempt → not scanned), GREEN after.
+
+  # ── §2  Each migrated consumer is scanned by the guard and is free of raw git/gh ───
+
+  @adw-691 @adw-96qtfe-gitcontext-migrate-g
+  Scenario Outline: The git/gh guard scans the migrated consumer (no longer allowlisted) and finds no direct git/gh shell-out
+    Given the ADW codebase is checked out
+    When the git/gh guard scans the file "<file>"
+    Then the git/gh guard scanned that file
+    And the git/gh guard reports no violation in that file
+
+    Examples:
+      | file                                    |
+      | adws/triggers/concurrencyGuard.ts       |
+      | adws/triggers/webhookGatekeeper.ts      |
+      | adws/phases/docsSelfCheck.ts            |
+      | adws/triggers/takeoverHandler.ts        |
+      | adws/triggers/perIssueScenarioSweep.ts  |
+
+  # ═══════════════ §3  WHOLE-REPO GUARD STILL PASSES (AC4; story 8) ════════════════
+  #
+  # The safe-de-allowlisting backstop. Removing the five files from the ALLOWLIST must
+  # not surface a violation: each one's last raw `gh` read is genuinely gone. Running
+  # the guard across the whole repository reports zero violations. This fails loudly if
+  # a consumer is de-allowlisted while a raw git/gh call still lives in it — the precise
+  # incomplete-migration mistake this AC guards against.
+
+  # ── §3  The git/gh guard reports no violations across the repository ───────────────
+
+  @adw-691 @adw-96qtfe-gitcontext-migrate-g
+  Scenario: The git/gh guard passes across the whole repository after the read consumers are de-allowlisted
+    Given the ADW codebase is checked out
+    When the git/gh guard is run across the repository
+    Then the git/gh guard reports no violations
+
+  # ═══════════════ §4  TYPE-CHECK BACKSTOP (registry T22) ══════════════════════════
+  #
+  # ── §4  The migrated read surface keeps the ADW codebase type-clean ────────────────
+  #
+  # A backstop consistent with the sibling per-issue features (feature-659 §6,
+  # feature-663 §5, feature-664 §6): the new gh-read context methods and the now
+  # raw-`gh`-free consumers compile within the ADW codebase's type-check.
+
+  @adw-691 @adw-96qtfe-gitcontext-migrate-g
+  Scenario: The ADW TypeScript type-check passes with the migrated gh-read surface in place
+    Given the ADW codebase is checked out
+    Then the ADW TypeScript type-check passes

--- a/features/per-issue/step_definitions/feature-659.steps.ts
+++ b/features/per-issue/step_definitions/feature-659.steps.ts
@@ -49,7 +49,7 @@ function runOp(ctx: GitContext, opName: string): void {
       ctx.commentOnPR(1, 'test body');
       return;
     case 'pr-create':
-      ctx.createPR('Test PR', 'test body');
+      ctx.createPR('Test PR', 'test body', 'feature-test-branch');
       return;
     case 'pr-merge':
       ctx.mergePR(1);

--- a/features/per-issue/step_definitions/feature-691.steps.ts
+++ b/features/per-issue/step_definitions/feature-691.steps.ts
@@ -1,0 +1,97 @@
+/**
+ * BDD step definitions for feature-691.feature
+ *
+ * GitContext gh-read migration — new read methods route through #run;
+ * migrated consumers are de-allowlisted and guard-clean.
+ *
+ * §1  New gh-read methods carry token + identity + base-path cwd (via shared world)
+ * §2  Each migrated consumer is scanned by the guard and violation-free
+ * §3  Whole-repo guard still passes after de-allowlisting
+ * §4  TypeScript type-check passes → feature-504.steps.ts (T22)
+ *
+ * Setup / assertion steps for §1 are provided by feature-659.steps.ts (shared world W).
+ * Guard steps §2–§3 use module-scope state for the scan result.
+ */
+
+import { execSync } from 'child_process';
+import { When, Then } from '@cucumber/cucumber';
+import assert from 'assert';
+import { scanFiles } from '../../../adws/checkGitGhGuard.ts';
+import { W } from './gitContextSharedWorld.ts';
+
+// ── Guard world state ─────────────────────────────────────────────────────────
+
+interface GuardScanResult {
+  violations: { file: string; line: number; command: string }[];
+  scannedCount: number;
+}
+
+let lastGuardResult: GuardScanResult | null = null;
+let guardPassedRepo: boolean | null = null;
+
+// ── §1 — new gh-read operation dispatcher ─────────────────────────────────────
+
+When('the {string} gh-read operation runs through the context', function (opName: string) {
+  assert.ok(W.ctx !== null, 'Expected a GitContext to be set up with a recording runner');
+  // Seed parseable default responses so each op completes (spy returns these by default)
+  W.responseMap.set('issue list', '[]');
+  W.responseMap.set('issue view', '[]');
+  W.responseMap.set('pr list', '[]');
+
+  switch (opName) {
+    case 'list-open-issues':
+      W.ctx.listOpenIssues({ fields: ['number', 'comments'], limit: 100 });
+      break;
+    case 'view-issue-comments':
+      W.ctx.issueComments(1);
+      break;
+    case 'list-merged-prs':
+      W.ctx.fetchMergedPRs();
+      break;
+    default:
+      throw new Error(`Unknown gh-read op: "${opName}"`);
+  }
+});
+
+// ── §2 — guard scan per-file ──────────────────────────────────────────────────
+
+When('the git\\/gh guard scans the file {string}', function (filePath: string) {
+  lastGuardResult = scanFiles([filePath], process.cwd());
+});
+
+Then('the git\\/gh guard scanned that file', function () {
+  assert.ok(lastGuardResult !== null, 'Expected a guard scan result to be set');
+  assert.strictEqual(
+    lastGuardResult.scannedCount,
+    1,
+    `Expected scannedCount=1 (file not allowlisted) but got ${lastGuardResult.scannedCount}`,
+  );
+});
+
+Then('the git\\/gh guard reports no violation in that file', function () {
+  assert.ok(lastGuardResult !== null, 'Expected a guard scan result to be set');
+  assert.strictEqual(
+    lastGuardResult.violations.length,
+    0,
+    `Expected no violations but got: ${lastGuardResult.violations.map(v => `${v.file}:${v.line} ${v.command}`).join(', ')}`,
+  );
+});
+
+// ── §3 — whole-repo guard ─────────────────────────────────────────────────────
+
+When('the git\\/gh guard is run across the repository', function () {
+  try {
+    execSync('bunx tsx adws/checkGitGhGuard.ts', { cwd: process.cwd(), encoding: 'utf-8', stdio: 'pipe' });
+    guardPassedRepo = true;
+  } catch {
+    guardPassedRepo = false;
+  }
+});
+
+Then('the git\\/gh guard reports no violations', function () {
+  assert.strictEqual(
+    guardPassedRepo,
+    true,
+    'Expected the git/gh guard to report no violations (exit 0) across the repository',
+  );
+});

--- a/specs/issue-691-adw-96qtfe-gitcontext-migrate-g-sdlc_planner-migrate-gh-read-consumers.md
+++ b/specs/issue-691-adw-96qtfe-gitcontext-migrate-g-sdlc_planner-migrate-gh-read-consumers.md
@@ -1,0 +1,214 @@
+# Feature: GitContext — migrate residual gh issue/PR read consumers (triggers/phases)
+
+## Metadata
+issueNumber: `691`
+adwId: `96qtfe-gitcontext-migrate-g`
+issueJson: `{"number":691,"title":"GitContext: migrate gh issue/PR read sites (triggers/phases)","body":"## Parent PRD\n`specs/prd/git-context-repo-authority.md` — completes the Enforcement section (drive the guard ALLOWLIST to zero; the guard shipped as a ratchet, not the spec'd invariant).\n\n## What to build\nAdd gh-read methods to GitContext (e.g. `listOpenIssues`, issue/PR `view` as needed; `fetchPRList` exists) and migrate the residual gh-read consumers onto them, removing each from the guard ALLOWLIST. Behavior unchanged; per-command auth via the existing `#run` chokepoint.\n\n## Acceptance criteria\n- [ ] New gh-read method(s) on GitContext, going through `#run`\n- [ ] concurrencyGuard, webhookGatekeeper, docsSelfCheck, takeoverHandler, perIssueScenarioSweep route through GitContext (no raw `gh`)\n- [ ] Those files removed from `ALLOWLIST` in checkGitGhGuard.ts\n- [ ] `bun run lint:git-guard` passes; unit tests green\n\n## Blocked by\nNone - can start immediately\n\n## Touched Files\n- adws/gitContext/gitContext.ts\n- adws/gitContext/commands/issueCommands.ts\n- adws/gitContext/commands/prCommands.ts\n- adws/triggers/concurrencyGuard.ts\n- adws/triggers/webhookGatekeeper.ts\n- adws/phases/docsSelfCheck.ts\n- adws/triggers/takeoverHandler.ts\n- adws/triggers/perIssueScenarioSweep.ts\n- adws/checkGitGhGuard.ts\n\n## User stories addressed\n- User story 5\n- User story 8\n- User story 18","state":"OPEN","author":"paysdoc","labels":["adw:feature"],"createdAt":"2026-06-23T11:45:25Z","comments":[],"actionableComment":null}`
+
+## Feature Description
+
+The `GitContext` deep module (`adws/gitContext/`) is ADW's single authority for every `git` and `gh` interaction: it bakes in the repo identity, resolves the filesystem base path in one constructor, and injects per-command auth (token/PAT + git identity) through a single private `#run()` chokepoint that never mutates `process.env`. A CI/lint guard (`adws/checkGitGhGuard.ts`, run via `bun run lint:git-guard`) fails the build on any direct `git`/`gh` shell-out outside the package.
+
+That guard shipped as a **ratchet** rather than the invariant the PRD specifies: it carries an `ALLOWLIST` of files still permitted to shell out directly. The PRD's Enforcement section is only complete when that allowlist is driven to zero (excluding the permanent bootstrap/diagnostic entries that genuinely cannot use a context before it exists).
+
+This feature migrates the five residual **gh-read** consumers off raw `gh` and onto new `GitContext` read methods, then removes each from the `ALLOWLIST`:
+
+- `adws/triggers/concurrencyGuard.ts` — `gh issue list … --json number,comments` (in-progress issue count)
+- `adws/triggers/webhookGatekeeper.ts` — `gh issue list … --json number,body` (×2: dependency unblock + abandoned-dependent close)
+- `adws/phases/docsSelfCheck.ts` — `gh issue list … --search … --json number,title` (existing-refactor-issue dedup)
+- `adws/triggers/takeoverHandler.ts` — `gh issue view … --json comments --jq '.comments'` (adwId resolution from issue comments)
+- `adws/triggers/perIssueScenarioSweep.ts` — `gh pr list … --state merged --json body,mergedAt` (PR merge date lookup)
+
+Behavior is unchanged end-to-end. The value is the structural guarantee: per-command auth (killing the `GH_TOKEN`-bleed class), correct base-path/repo scoping (killing the wrong-repo class), and a mechanically-enforced invariant rather than a convention-plus-allowlist.
+
+## User Story
+
+As an **ADW maintainer** (PRD user stories 5, 8, 18)
+I want every residual issue/PR **read** site to go through `GitContext` and be removed from the guard allowlist
+So that the `gh` target repo is never ambiguous, auth is applied per command rather than via a process-global, and a new call site cannot reintroduce the wrong-repo / token-bleed class of bug because direct `gh` reads become unrepresentable outside the package.
+
+## Problem Statement
+
+Five files still shell out to `gh` directly for issue/PR reads. They are tolerated only because they sit on the guard's `ALLOWLIST`. Each is an independent ad-hoc derivation of "which repo am I authenticated against and operating on": they call `gh … --repo ${owner}/${repo}` from the ambient `process.cwd()` with the ambient `process.env` (i.e. whatever `GH_TOKEN` the long-lived process last set). This is exactly the surface the GitContext PRD was written to eliminate:
+
+- In a long-lived webhook process handling interleaved multi-repo events, the ambient token can be the wrong repo's (the `GH_TOKEN`-bleed class, PRD story 7).
+- `takeoverHandler.resolveAdwId` failing to read comments against the right repo returns `null`, which silently degrades a *takeover* into a *fresh spawn* — a real correctness hazard for self-hosted issues.
+
+Until these are migrated and de-allowlisted, the PRD's Enforcement invariant ("the build fails when someone shells out to git or gh directly", story 8) is not actually in force — it is a ratchet with five open exceptions.
+
+## Solution Statement
+
+Add three thin gh-**read** methods to `GitContext`, each delegating to a pure command-string builder under `adws/gitContext/commands/` and routed through the existing `#run()` chokepoint (per-command auth, explicit `cwd`, no `process.env` mutation) — mirroring the established thin-method + command-builder pattern (`fetchIssue`, `fetchPRList`, `fetchAllPRs`):
+
+1. `listOpenIssues({ fields, search?, limit? })` — `gh issue list --repo o/r --state open --json <fields> [--search "…"] [--limit N]`. Covers concurrencyGuard, webhookGatekeeper (×2), and docsSelfCheck (the three differ only by projected fields / search / limit).
+2. `issueComments(issueNumber)` — `gh issue view N --repo o/r --json comments --jq '.comments'`. Covers takeoverHandler.
+3. `fetchMergedPRs(limit?)` — `gh pr list --repo o/r --state merged --json body,mergedAt --limit N`. Covers perIssueScenarioSweep.
+
+Then migrate each consumer to construct a context via **`gitContextForRepo(repoInfo)`** (the established factory used throughout `adws/github/`, which auto-detects self-host so the base path always resolves to a directory that exists) and call the new method — preserving every existing function signature, `try/catch`, and JSON-parse shape so behavior is unchanged. `webhookGatekeeper.handleIssueClosedDependencyUnblock` already receives an optional per-event `gitContext`; it will prefer that and fall back to the factory.
+
+Finally, remove the five files from the `ALLOWLIST` in `checkGitGhGuard.ts` and clean up the now-unused `execSync` / `execWithRetry` imports so `bun run lint:git-guard`, `lint`, type-check, and unit tests all pass.
+
+## Relevant Files
+
+Use these files to implement the feature:
+
+### Core module — new read methods land here
+- `adws/gitContext/gitContext.ts` — the `GitContext` class. Add `listOpenIssues`, `issueComments`, `fetchMergedPRs` as thin methods routed through `#run()` (mirroring `fetchIssue` / `fetchPRList`). Import the new command builders.
+- `adws/gitContext/commands/issueCommands.ts` — pure `gh` issue command-string builders (no I/O). Add `listOpenIssuesCmd` (with a `ListOpenIssuesOptions` type) and `issueCommentsCmd`.
+- `adws/gitContext/commands/prCommands.ts` — pure `gh` PR command-string builders. Add `fetchMergedPRsCmd`.
+
+### Consumers to migrate (remove raw `gh`)
+- `adws/triggers/concurrencyGuard.ts` — `fetchOpenIssuesWithComments` → `gitContextForRepo(repoInfo).listOpenIssues({ fields: ['number','comments'], limit: 100 })`. Drop the `execSync` import.
+- `adws/triggers/webhookGatekeeper.ts` — `handleIssueClosedDependencyUnblock` (prefer the passed `gitContext`, else factory) and `closeAbandonedDependents` (factory) → `listOpenIssues({ fields: ['number','body'], limit: 100 })`. Change `import { spawn, execSync }` → `import { spawn }` (spawn is still used by `spawnDetached`/`ensureCronProcess`).
+- `adws/phases/docsSelfCheck.ts` — `findExistingRefactorIssueDefault` → `gitContextForRepo(repoInfo).listOpenIssues({ fields: ['number','title'], search: \`docs-bloat: ${docPath}\`, limit: 5 })`. Drop `execWithRetry` from the `../core` import (note: this drops the per-call retry wrapper — acceptable, see Notes).
+- `adws/triggers/takeoverHandler.ts` — `buildDefaultTakeoverDeps().resolveAdwId` → `gitContextForRepo(repoInfo).issueComments(issueNumber)` then `JSON.parse` → `extractLatestAdwId`. Drop the `execSync` import (its only use is `resolveAdwId`; `killProcess` uses `process.kill`, `resetWorktree` already uses a context).
+- `adws/triggers/perIssueScenarioSweep.ts` — `defaultGetMergedAt` → `gitContextForRepo(getRepoInfo()).fetchMergedPRs(200)`. Drop the `execSync` import.
+
+### Enforcement
+- `adws/checkGitGhGuard.ts` — remove these five `ALLOWLIST` entries (and only these): `adws/phases/docsSelfCheck.ts`, `adws/triggers/concurrencyGuard.ts`, `adws/triggers/perIssueScenarioSweep.ts`, `adws/triggers/takeoverHandler.ts`, `adws/triggers/webhookGatekeeper.ts`. Leave all bootstrap/diagnostic/other-residual entries (e.g. `trigger_cron.ts`) untouched.
+
+### Supporting context (read, do not necessarily modify)
+- `adws/github/gitContextFactory.ts` — `gitContextForRepo(repoInfo)` (auto self-host detection + per-repo token); the construction helper every migrated consumer uses. Import it directly from `'../github/gitContextFactory'` (its established import path; it is **not** re-exported from `adws/github/index.ts`).
+- `adws/triggers/cronStageResolver.ts` — `extractLatestAdwId(comments: { body: string }[])` consumes only `.body`, confirming `issueComments` need only preserve the comment `body` shape.
+- `adws/github/issueApi.ts` / `adws/github/prApi.ts` — reference implementations of the `gitContextForRepo(repoInfo).method()` consumption pattern and its test mocking.
+- `specs/prd/git-context-repo-authority.md` — the parent PRD (Solution, Enforcement, stories 5/7/8/18).
+
+### Conditional docs (matched conditions — read before editing the relevant files)
+- `app_docs/feature-oqb76h-gitcontext-base-path-authority.md` — owns `adws/gitContext/**`, `adws/gitContext/commands/**`, `adws/github/gitContextFactory.ts`. Condition: "When adding a new `gh` operation method or worktree method to `GitContext` (follow the thin-method + package-private-op pattern)" and "When working with `adws/gitContext/commands/` pure command builders or parsers".
+- `app_docs/feature-bq1f45-git-gh-cli-guard.md` — owns `adws/checkGitGhGuard.ts`, `.github/workflows/git-cli-guard.yml`. Condition: "When migrating a residual allowlisted file to GitContext methods and removing it from the ALLOWLIST" and "When the `bun run lint:git-guard` script exits 1".
+- `app_docs/feature-9gjajh-webhook-triggers.md` — owns `webhookGatekeeper.ts`. Condition: "When `classifyAndSpawnWorkflow`'s optional `gitContext` parameter … is relevant".
+- `app_docs/feature-9gjajh-takeover-and-coordination.md` — owns `takeoverHandler.ts`, `concurrencyGuard.ts`.
+- `app_docs/feature-9gjajh-issue-routing-and-eligibility.md` — owns `perIssueScenarioSweep.ts` (and `issueEligibility.ts`, which calls `isConcurrencyLimitReached`).
+- `app_docs/feature-ih6ju7-app-docs-living-docs-post-write-guards.md` — owns `docsSelfCheck.ts`. Condition: "When implementing or troubleshooting `executeDocsPostWriteSelfCheck` or `DocsSelfCheckDeps`".
+- `app_docs/feature-k2tkdn-gitcontext-boundary-constructor.md` / `app_docs/feature-d0hv98-exhaustive-stage-classifier.md` — also own `takeoverHandler.ts` (`EvaluateCandidateInput.gitContext`, `evaluateCandidate` recovery branches); read before touching `resolveAdwId`/deps.
+
+### Existing test files to extend
+- `adws/gitContext/__tests__/gitContextOperations.test.ts` — `makeSpyExec` pattern (asserts command string, `cwd === basePath`, injected `GH_TOKEN`/`GIT_*`, trimmed return). Add cases for the three new methods.
+- `adws/triggers/__tests__/takeoverHandler.test.ts` — extensive; deps are injected so existing cases stay green. Add a default-path case for `resolveAdwId`.
+- `adws/triggers/__tests__/webhookGatekeeper.test.ts` — extend for the two `listOpenIssues` paths.
+- `adws/triggers/__tests__/perIssueScenarioSweep.test.ts` — injects `getMergedAt`; add a default-path case routing through `fetchMergedPRs`.
+
+### New Files
+- `adws/triggers/__tests__/concurrencyGuard.test.ts` — no test exists today; add coverage for the `listOpenIssues` routing + in-progress count.
+- `adws/phases/__tests__/docsSelfCheck.test.ts` — no test exists today; add coverage for `findExistingRefactorIssueDefault` routing through `gitContextForRepo(...).listOpenIssues` (mock the factory).
+
+## Implementation Plan
+
+### Phase 1: Foundation — add read methods to the GitContext package
+Extend the pure command-builders, then add three thin methods on `GitContext` that route through `#run()`. This is purely additive; no consumer or guard change yet, so the codebase stays green throughout. After this phase the new methods exist and are unit-tested in isolation.
+
+### Phase 2: Core Implementation — migrate the five consumers
+Replace each raw `execSync`/`execWithRetry` `gh` call with `gitContextForRepo(repoInfo).<newMethod>(...)`, preserving every signature, `try/catch`, default-return, and JSON shape. Clean up the now-unused `child_process`/`core` imports. The webhook dependency-unblock path prefers its already-threaded per-event `gitContext`.
+
+### Phase 3: Integration — flip the enforcement and validate
+Remove the five entries from the guard `ALLOWLIST`, then run the full validation suite (`lint:git-guard`, `lint`, type-checks, unit tests, build) to confirm the invariant now holds with zero regressions.
+
+## Step by Step Tasks
+Execute every step in order, top to bottom.
+
+### Step 1 — Read context
+- Read `specs/prd/git-context-repo-authority.md` (Solution + Enforcement), `app_docs/feature-oqb76h-gitcontext-base-path-authority.md`, and `app_docs/feature-bq1f45-git-gh-cli-guard.md`.
+- Re-read `adws/gitContext/gitContext.ts`, `adws/gitContext/commands/issueCommands.ts`, `adws/gitContext/commands/prCommands.ts`, and `adws/github/gitContextFactory.ts` to lock in the thin-method + command-builder + `gitContextForRepo` patterns.
+
+### Step 2 — Add issue command builders
+- In `adws/gitContext/commands/issueCommands.ts`, add an exported `ListOpenIssuesOptions` interface (`readonly fields: readonly string[]; readonly search?: string; readonly limit?: number`) and `listOpenIssuesCmd(owner, repo, opts)` that builds `gh issue list --repo o/r --state open --json <fields.join(',')>`, appending `--search "<search>"` and `--limit <limit>` only when provided.
+- Add `issueCommentsCmd(owner, repo, issueNumber)` returning `gh issue view ${issueNumber} --repo ${owner}/${repo} --json comments --jq '.comments'`.
+
+### Step 3 — Add PR command builder
+- In `adws/gitContext/commands/prCommands.ts`, add `fetchMergedPRsCmd(owner, repo, limit = 200)` returning `gh pr list --repo ${owner}/${repo} --state merged --json body,mergedAt --limit ${limit}`.
+
+### Step 4 — Add GitContext methods
+- In `adws/gitContext/gitContext.ts`, import the new builders + `ListOpenIssuesOptions` from `./commands/issueCommands` and `fetchMergedPRsCmd` from `./commands/prCommands`.
+- Add `listOpenIssues(opts: ListOpenIssuesOptions): string { return this.#run(listOpenIssuesCmd(this.#owner, this.#repo, opts)); }`.
+- Add `issueComments(issueNumber: number): string { return this.#run(issueCommentsCmd(this.#owner, this.#repo, issueNumber)); }`.
+- Add `fetchMergedPRs(limit?: number): string { return this.#run(fetchMergedPRsCmd(this.#owner, this.#repo, limit)); }`.
+- Place them alongside the existing issue/PR read methods; keep them thin (no parsing — callers `JSON.parse`, matching `fetchIssue`/`fetchPRList`).
+
+### Step 5 — Unit-test the new methods
+- In `adws/gitContext/__tests__/gitContextOperations.test.ts`, using `makeSpyExec`, add cases asserting, for each new method: exact command string (including `--search`/`--limit` presence/absence and the `--jq '.comments'` form), `cwd === ctx.basePath`, injected `GH_TOKEN` + `GIT_*` env, no `process.env` mutation, and trimmed return value. Include `fetchMergedPRs()` defaulting to `--limit 200`.
+- Run `bun run test:unit` (gitContext suite) — expect green.
+
+### Step 6 — Migrate `concurrencyGuard.ts`
+- Replace the `execSync('gh issue list … --json number,comments --limit 100')` in `fetchOpenIssuesWithComments` with `gitContextForRepo(repoInfo).listOpenIssues({ fields: ['number', 'comments'], limit: 100 })`.
+- Add `import { gitContextForRepo } from '../github/gitContextFactory';`; remove the now-unused `import { execSync } from 'child_process';`. Keep the existing `try/catch` returning `[]`.
+
+### Step 7 — Migrate `webhookGatekeeper.ts`
+- In `handleIssueClosedDependencyUnblock`, build `const ctx = gitContext ?? gitContextForRepo(repoInfo);` and replace the `execSync` list with `ctx.listOpenIssues({ fields: ['number', 'body'], limit: 100 })`.
+- In `closeAbandonedDependents`, replace the `execSync` list with `gitContextForRepo(repoInfo).listOpenIssues({ fields: ['number', 'body'], limit: 100 })` (signature unchanged → no `webhookHandlers.ts` change).
+- Add `import { gitContextForRepo } from '../github/gitContextFactory';`; change `import { spawn, execSync } from 'child_process';` → `import { spawn } from 'child_process';`. Preserve both `try/catch` blocks.
+
+### Step 8 — Migrate `docsSelfCheck.ts`
+- In `findExistingRefactorIssueDefault`, replace the `execWithRetry('gh issue list … --search "docs-bloat: ${docPath}" --json number,title --limit 5')` with `gitContextForRepo(repoInfo).listOpenIssues({ fields: ['number', 'title'], search: \`docs-bloat: ${docPath}\`, limit: 5 })`.
+- Add `import { gitContextForRepo } from '../github/gitContextFactory';`; remove `execWithRetry` from the `import { execWithRetry, log as defaultLog, type LogLevel } from '../core';` line. Keep the `try/catch` returning `null` and the `results.find(...title.includes(docPath))` filter.
+
+### Step 9 — Migrate `takeoverHandler.ts`
+- In `buildDefaultTakeoverDeps`, rewrite `resolveAdwId` to `const json = gitContextForRepo(repoInfo).issueComments(issueNumber); const comments = JSON.parse(json) as { body: string }[]; return extractLatestAdwId(comments);` inside the existing `try/catch` returning `null`.
+- Add `import { gitContextForRepo } from '../github/gitContextFactory';`; remove `import { execSync } from 'child_process';` (no other use). Leave `resetWorktree`/`gitContextForSync` and all injected-deps seams untouched.
+
+### Step 10 — Migrate `perIssueScenarioSweep.ts`
+- In `defaultGetMergedAt`, replace the `execSync('gh pr list … --state merged --json body,mergedAt --limit 200')` with `gitContextForRepo(getRepoInfo()).fetchMergedPRs(200)`, keeping the `bodyLinksIssue` filter, `mergedAt` parsing, and `Promise.resolve(...)` returns intact.
+- Add `import { gitContextForRepo } from '../github/gitContextFactory';`; remove `import { execSync } from 'child_process';`. Keep `getRepoInfo`/`bodyLinksIssue` imports.
+
+### Step 11 — Add/extend consumer unit tests
+- New `adws/triggers/__tests__/concurrencyGuard.test.ts`: `vi.mock('../../github/gitContextFactory')` with `gitContextForRepo` returning a fake ctx whose `listOpenIssues` returns canned JSON; assert in-progress count and the empty/throw → `[]` fallback (mirror `adws/github/__tests__/prApi.test.ts`).
+- New `adws/phases/__tests__/docsSelfCheck.test.ts`: mock the factory; assert `findExistingRefactorIssueDefault` returns the matching issue number, `null` when none matches, and `null` on throw.
+- Extend `webhookGatekeeper.test.ts`, `takeoverHandler.test.ts` (default-`resolveAdwId` path), and `perIssueScenarioSweep.test.ts` (default-`getMergedAt` path) to cover the factory-routed defaults.
+
+### Step 12 — Remove the five ALLOWLIST entries
+- In `adws/checkGitGhGuard.ts`, delete exactly the `adws/phases/docsSelfCheck.ts`, `adws/triggers/concurrencyGuard.ts`, `adws/triggers/perIssueScenarioSweep.ts`, `adws/triggers/takeoverHandler.ts`, and `adws/triggers/webhookGatekeeper.ts` lines from `ALLOWLIST`. Do not remove any other entry.
+
+### Step 13 — Validate (zero regressions)
+- Run every command in **Validation Commands**. All must exit 0. In particular `bun run lint:git-guard` must PASS with the five files now scanned (proving no residual raw `git`/`gh` remains in them), and `bun run test:unit` must be green.
+
+## Testing Strategy
+
+### Unit Tests
+Unit tests are enabled (`.adw/project.md` → `## Unit Tests: enabled`).
+
+- **GitContext read methods** (`adws/gitContext/__tests__/gitContextOperations.test.ts`, highest value — mirrors existing `defaultBranch` cases via `makeSpyExec`):
+  - `listOpenIssues`: builds `gh issue list --repo o/r --state open --json number,comments --limit 100`; omits `--search`/`--limit` when not supplied; includes `--search "docs-bloat: <path>"` and `--limit 5` when supplied; runs with `cwd === basePath`; injects context `GH_TOKEN` + four `GIT_*` vars; does not mutate `process.env`; returns trimmed stdout.
+  - `issueComments`: builds `gh issue view N --repo o/r --json comments --jq '.comments'`; same env/cwd/non-mutation assertions.
+  - `fetchMergedPRs`: builds `gh pr list --repo o/r --state merged --json body,mergedAt --limit 200` (default) and honors an explicit limit.
+- **Consumer routing** (mock `gitContextForRepo` per the `adws/github/__tests__/prApi.test.ts` precedent):
+  - `concurrencyGuard`: in-progress count over canned issues/PRs; `[]` fallback on parse/throw.
+  - `docsSelfCheck.findExistingRefactorIssueDefault`: match by title-contains, `null` when absent, `null` on throw.
+  - `webhookGatekeeper`: `handleIssueClosedDependencyUnblock` prefers the passed `gitContext`; both paths parse `number,body` and filter dependents.
+  - `takeoverHandler` default `resolveAdwId`: parses `issueComments` JSON → `extractLatestAdwId`; `null` on throw.
+  - `perIssueScenarioSweep` default `getMergedAt`: parses `fetchMergedPRs` JSON, applies `bodyLinksIssue`, returns the parsed `mergedAt` date.
+
+### Edge Cases
+- **Self-host vs target repo base path**: `gitContextForRepo` auto-detects self-host, so `basePath` always resolves to an existing directory (framework root for self-host, `targetReposDir/owner/repo` for targets). This is why the factory (not a hardcoded `selfHost: false`) is used — a wrong base path would make `#run`'s `cwd` nonexistent and throw `ENOENT`. The correct `--repo owner/repo` argument keeps the gh target explicit regardless.
+- **Empty result sets**: `listOpenIssues`/`fetchMergedPRs` returning `[]` → `JSON.parse('[]')` → no dependents / zero count / `null` merge date (unchanged).
+- **Read failure (auth, transient, nonexistent cwd)**: every migrated site keeps its `try/catch` returning the prior safe default (`[]`, `null`), so a throw degrades exactly as before.
+- **`takeoverHandler.resolveAdwId` → `null`**: still yields `spawn_fresh` (unchanged); correct self-host scoping via the factory prevents the *new* failure mode of mis-scoped reads silently turning a takeover into a fresh spawn.
+- **`docsSelfCheck` retry loss**: the old call used `execWithRetry`; `#run` does not retry. A transient `gh` failure now resolves to `null` (dedup fails open → at worst a duplicate refactor issue is filed) — consistent with the existing fail-open `catch`. Documented in Notes.
+- **Search quoting**: `--search "docs-bloat: ${docPath}"` preserves the original double-quoting; `docPath` is a repo-relative `app_docs/…md` path.
+- **Guard exactness**: only the five entries are removed; `trigger_cron.ts` and all bootstrap/diagnostic entries remain allowlisted (verified by `lint:git-guard` still passing).
+
+## Acceptance Criteria
+- `GitContext` exposes `listOpenIssues`, `issueComments`, and `fetchMergedPRs`, each delegating to a pure command builder and routed through the `#run()` chokepoint (per-command auth, explicit cwd, no `process.env` mutation).
+- `concurrencyGuard.ts`, `webhookGatekeeper.ts` (both call sites), `docsSelfCheck.ts`, `takeoverHandler.ts`, and `perIssueScenarioSweep.ts` contain no direct `git`/`gh` shell-outs; all issue/PR reads go through `gitContextForRepo(...)` methods.
+- The five files are removed from `ALLOWLIST` in `adws/checkGitGhGuard.ts`; no other entry is changed.
+- Now-unused `execSync` / `execWithRetry` imports are removed (no lint/unused-import failures); `webhookGatekeeper` retains `spawn`.
+- Behavior is unchanged: every migrated function keeps its signature, `try/catch`, default return, and parsed shape.
+- `bun run lint:git-guard` passes with the five files scanned; `bun run lint`, `bunx tsc --noEmit`, `bunx tsc --noEmit -p adws/tsconfig.json`, `bun run test:unit`, and `bun run build` all succeed.
+
+## Validation Commands
+Execute every command to validate the feature works correctly with zero regressions.
+
+- `bun run lint:git-guard` — Git/GH CLI guard; must PASS (`✔ PASS No direct git/gh shell-outs outside GitContext`) with the five de-allowlisted files now scanned. This is the primary acceptance gate.
+- `bun run test:unit` — Vitest (`vitest run`); all unit tests green, including the new GitContext-method and consumer-routing tests.
+- `bun run lint` — ESLint (`eslint .`); zero errors, including no unused-import warnings from the removed `execSync`/`execWithRetry`.
+- `bunx tsc --noEmit` — root type-check; zero errors.
+- `bunx tsc --noEmit -p adws/tsconfig.json` — ADW project type-check (additional type checks from `.adw/commands.md`); zero errors.
+- `bun run build` — `tsc` build; no build errors.
+
+## Notes
+- **Coding guidelines** (`.adw/coding_guidelines.md`): keep new methods pure/thin (clarity over cleverness, single responsibility, immutability — build command strings, return raw stdout, let callers parse). Use guard clauses, avoid `any`, prefer explicit types (`ListOpenIssuesOptions`, `readonly` fields). Remove unused imports (code hygiene). No new libraries required — this is internal refactoring using existing `child_process`/`gh` plumbing inside the package.
+- **Library install command** (`.adw/commands.md`): `bun add <package>` — not needed here (no new dependencies).
+- **Import path for the factory**: `gitContextForRepo` is imported directly from `'../github/gitContextFactory'` (its established convention across `adws/github/`); it is intentionally **not** re-exported from `adws/github/index.ts`, so no index change is in scope.
+- **Why `gitContextForRepo`, not `gitContextForSync({…, selfHost: false})`**: the latter hardcodes a target base path; for self-hosted ADW issues that directory does not exist and `#run`'s `cwd` would throw `ENOENT`. `gitContextForRepo` auto-detects self-host, matching how `issueApi`/`prApi` already consume the context.
+- **Generic `listOpenIssues` vs three named methods**: the three issue-list sites differ only by projected fields / search / limit, so one parameterized read method (a clean projection of "list open issues") is preferred over three near-duplicates while still owning all `gh`-flag assembly in the pure builder. `issueComments` and `fetchMergedPRs` are distinct enough to warrant their own methods, consistent with the existing `fetchPRList`/`fetchAllPRs` split.
+- **`issueComments` vs the existing `fetchIssueComments`**: `fetchIssueComments` uses the REST endpoint (`gh api …/comments --paginate`), a different command and JSON shape from takeover's `gh issue view … --json comments --jq '.comments'`. A dedicated `issueComments` method preserves takeover's exact command (behavior unchanged); both ultimately expose a `body` field, which is all `extractLatestAdwId` reads.
+- **Scope discipline**: do not modify `issueEligibility.ts`, `webhookHandlers.ts`, or `adws/github/index.ts` — all five consumer signatures are preserved so no out-of-scope caller edits are required. Per the recurring "worktree born with dependency reversion" hazard, diff the full `.claude/`/doc tree against `origin/dev` before finalizing and revert any out-of-scope command-file or doc changes that appear in the working tree.
+- **Future work (not this issue)**: the remaining `ALLOWLIST` residual entries that perform writes or git operations (e.g. `trigger_cron.ts`, `autoMergeHandler.ts`, `branchOperations.ts`) are separate migration slices toward the PRD's zero-allowlist goal.


### PR DESCRIPTION
## Summary

Promotes the current `dev` branch into `main`. Brings in 7 commits since the last sync.

### Notable changes
- **#704 / #691** — Migrate `gh`-read consumers to GitContext (plan, build, and document agents) with spec + scenarios.
- **#703** — Fix PR-create missing `--head` branch; restore explicit `--head` in GitContext PR creation.

## Test plan
- [ ] CI green on dev

🤖 Generated with [Claude Code](https://claude.com/claude-code)