### PR TITLE
docs: promote-regression-vocabulary skill + automated promotion sweep PRD

### DIFF
--- a/.claude/skills/promote-regression-vocabulary/SKILL.md
+++ b/.claude/skills/promote-regression-vocabulary/SKILL.md
@@ -1,0 +1,72 @@
+---
+name: promote-regression-vocabulary
+description: Scan per-issue BDD features for regression-promotion candidates and analyse each Given/When/Then phrase against the regression vocabulary's rot-detection rubric and existing phrase registry. Advisory only — produces per-phrase reuse and rot verdicts to inform a collaborative promotion decision; writes nothing. Use when the user wants to promote a scenario to the regression suite, vet phrases for @features/regression/vocabulary.md, check for phrase reuse/collision, or asks about "promotion candidates", "vocabulary rot", or "regression phrase audit".
+---
+
+# Promote Regression Vocabulary (advisory)
+
+Analyse BDD phrases for promotion into `features/regression/vocabulary.md` and the regression
+suite. **You produce verdicts, not edits.** Do not write files, move features, or touch the
+registry — the human owns the promotion decision. Surface the analysis and stop.
+
+## Two verdicts per phrase
+
+1. **Reuse / collision** — is this phrase already registered? Reusing an existing phrase is
+   strongly preferred over minting a near-duplicate.
+2. **Rot** — would this phrase, as backed by its step definition, assert an *observable system
+   behaviour* (valid) or a *source-code property* (rot, rejected)?
+
+`features/regression/vocabulary.md` is the source of truth for the rubric; the summary below is a
+working copy.
+
+### Rot rubric (from vocabulary.md)
+A phrase is **ROT** if its step definition asserts any of:
+- File shape — exists? line count? extension?
+- File content by substring — `readFileSync(...).includes(...)`
+- Structural source read — `JSON.parse(readFileSync(config.ts))`
+
+A phrase is **VALID** when it asserts an *artefact* the system-under-test produced: state files
+written by an orchestrator, recorded mock-server requests, git artefacts (branches/commits/pushes),
+subprocess exit codes, or captured stdout/stderr. The Gherkin text alone can't tell you which —
+**you must read the backing step definition** to judge rot.
+
+## Workflow
+
+1. **Scope the candidates.** Default: scenarios in `features/per-issue/*.feature` tagged
+   `@promotion-suggested-<date>` (the promotion pipeline pre-tags aged, high-scoring scenarios).
+   If the user names a file or pastes phrases, use those. List the candidates and confirm scope
+   before analysing — this is a collaborative review, not a batch job.
+
+2. **Load the registry.** Run once from the repo root:
+   ```
+   bun .claude/skills/promote-regression-vocabulary/scripts/list-registered-phrases.ts
+   ```
+   Output is `SOURCE⇥NORMALISED_PHRASE` (SOURCE = `vocab` or a step-def basename). Normalisation
+   maps `"..."`→`{string}` and integers→`{int}`, matching cucumber-expression shape.
+
+3. **Per candidate scenario, per Given/When/Then step:**
+   - **Reuse check** — normalise the step the same way (quotes→`{string}`, ints→`{int}`) and match
+     against the registry. Exact match ⇒ *reuse verbatim*. Close semantic match ⇒ *reuse existing,
+     don't mint a variant* (name the existing phrase). No match ⇒ *new phrase*.
+   - **Rot check** — locate the backing step definition (grep the phrase across
+     `features/**/step_definitions/*.ts`) and read its assertion body. Judge it against the rubric.
+     If the phrase is new (no step def yet), judge from intent and flag that its implementation
+     **must** assert an observable artefact, not a source-file read.
+
+4. **Report.** One table per candidate scenario:
+
+   | Step (G/W/T) | Reuse | Rot | Note |
+   |---|---|---|---|
+   | `the state file for adwId {string} records ...` | reuse T1 (vocab) | VALID | verbatim |
+   | `feature-729.steps.ts asserts file exists` | new | **ROT** | asserts file shape — rework to assert a produced artefact |
+
+   Close with a recommendation: which phrases are promotion-ready, which need rewording to reuse an
+   existing entry, and which are rot and must be reworked or dropped. **Then stop — no edits.**
+
+## Guardrails
+- Never edit `vocabulary.md`, never `git mv` a feature or its step defs, never add `@regression`.
+- A phrase's rot verdict lives in its **step definition**, not its Gherkin text — always read the
+  implementation before ruling.
+- Prefer reuse. A near-duplicate phrase is a finding, not a convenience.
+- The automated promotion *mover* (`adws/promotion/`) is effectively dead; real regression tests are
+  hand-placed. This skill informs that human step — it does not perform it.

--- a/.claude/skills/promote-regression-vocabulary/scripts/list-registered-phrases.ts
+++ b/.claude/skills/promote-regression-vocabulary/scripts/list-registered-phrases.ts
@@ -1,0 +1,78 @@
+#!/usr/bin/env bun
+/**
+ * Dump every phrase already registered in the regression suite, normalised, so a
+ * candidate step can be checked for reuse/collision against it.
+ *
+ * Sources:
+ *   1. features/regression/vocabulary.md  — the G/W/T registry tables (2nd column)
+ *   2. features/**\/step_definitions/*.ts  — string literals passed to Given/When/Then
+ *
+ * Output: one phrase per line, `SOURCE\tPHRASE`, deduped, sorted.
+ *   SOURCE is `vocab` or the step-def file basename.
+ * A candidate step matches when its normalised form (see normalise()) equals a
+ * printed PHRASE — that means "already covered, reuse verbatim".
+ *
+ * Usage:  bun .claude/skills/promote-regression-vocabulary/scripts/list-registered-phrases.ts
+ *         (run from the repo root)
+ */
+import { readFileSync, readdirSync, statSync } from 'node:fs';
+import { join } from 'node:path';
+
+/** Collapse a raw phrase to its cucumber-expression shape for comparison. */
+function normalise(p: string): string {
+  return p
+    .replace(/\\\//g, '/') // unescape \/ used in step-def literals
+    .replace(/"[^"]*"/g, '{string}')
+    .replace(/'[^']*'/g, '{string}')
+    .replace(/\b\d+\b/g, '{int}')
+    .replace(/\s+/g, ' ')
+    .trim();
+}
+
+const rows = new Map<string, string>(); // normalised phrase -> source label
+
+function addVocab(path: string) {
+  let md: string;
+  try {
+    md = readFileSync(path, 'utf8');
+  } catch {
+    return;
+  }
+  for (const line of md.split('\n')) {
+    // Registry table rows: | id | `phrase` | semantics | pattern | target |
+    const m = line.match(/^\s*\|[^|]*\|\s*`([^`]+)`/);
+    if (m) rows.set(normalise(m[1]), 'vocab');
+  }
+}
+
+function addStepDefs(dir: string) {
+  let entries: string[];
+  try {
+    entries = readdirSync(dir);
+  } catch {
+    return;
+  }
+  for (const name of entries) {
+    const full = join(dir, name);
+    if (statSync(full).isDirectory()) {
+      addStepDefs(full);
+      continue;
+    }
+    if (!name.endsWith('.ts')) continue;
+    const src = readFileSync(full, 'utf8');
+    // Given/When/Then( 'phrase' | "phrase" | `phrase`  — may span lines.
+    const re = /\b(?:Given|When|Then)\(\s*(['"`])((?:\\.|(?!\1).)*)\1/gs;
+    let m: RegExpExecArray | null;
+    while ((m = re.exec(src))) rows.set(normalise(m[2]), name);
+  }
+}
+
+addVocab('features/regression/vocabulary.md');
+addStepDefs('features/regression/step_definitions');
+addStepDefs('features/step_definitions');
+
+const out = [...rows.entries()]
+  .sort((a, b) => a[0].localeCompare(b[0]))
+  .map(([phrase, source]) => `${source}\t${phrase}`);
+console.log(out.join('\n'));
+console.error(`\n${rows.size} registered phrases`);

--- a/specs/prd/automated-scenario-promotion-sweep.md
+++ b/specs/prd/automated-scenario-promotion-sweep.md
@@ -1,0 +1,185 @@
+# PRD: Automated Scenario Promotion Sweep
+
+> Status: draft (design grilled 2026-07-08). Supersedes the "no automated promotion"
+> governance stance by moving human curation from *candidate discovery* to a `hitl`
+> PR **merge gate** — candidates are found and prepared automatically; a human still
+> approves every promotion.
+
+## Problem Statement
+
+As an ADW maintainer, per-issue BDD scenarios that would make good permanent regression
+tests get **silently lost**. A scenario authored under `features/per-issue/feature-N.feature`
+is input-only and never executed. If it scores well and receives a `@promotion-suggested-<date>`
+tag, nothing ever moves it into the executed `@regression` suite — and the live 14-day
+per-issue sweep deletes it purely on age, tag or no tag. So a scenario I was invited to promote
+disappears 14 days after its issue's PR merged, and I never get a reviewable moment to say
+"yes, keep this."
+
+The documented promotion pipeline that was supposed to prevent this does not run: the
+`adwPromotionSweep` orchestrator (commenter + mover) is wired into no trigger, and even when
+invoked by hand it produces a broken regression test — it moves only the `.feature` scenario
+block, not the backing step-definitions, never adds the `@regression` tag, and never registers
+vocabulary. The one successful promotion to date (#734, promoting #729) was done entirely by
+hand through a bespoke `/feature` issue.
+
+## Solution
+
+As a maintainer, I want a periodic cron sweep that finds high-scoring per-issue scenarios,
+records them as in-flight, and files a self-contained `adw:feature` promotion issue that the
+**existing SDLC pipeline** turns into a `hitl`-gated PR — one that moves the whole feature file
+plus its step-definitions into `features/regression/`, adds `@regression`, registers rubric-
+compliant vocabulary, and proves the `@regression` suite green before asking for my approval.
+I review the PR (with an advisory rot/reuse analysis posted as a comment), and merging it
+promotes the scenario. If I close it without merging, the sweep records a declined marker and
+lets the file age out normally. Until I decide, the source file is protected from the 14-day
+deletion.
+
+Crucially, this reuses ADW's normal plan → build → test → PR pipeline (proven viable by #734)
+rather than building a dedicated promotion orchestrator. The sweep's only jobs are: **score,
+reconcile, originate**.
+
+## User Stories
+
+1. As a maintainer, I want the cron loop to periodically score tracked per-issue scenarios against the regression vocabulary registry, so that promotion candidates are found without me running anything.
+2. As a maintainer, I want scoring to be deterministic and cheap (no LLM), so that running it on every eligible cron cycle costs nothing.
+3. As a maintainer, I want a high-scoring candidate to receive a durable `@promotion-suggested-<date>` marker committed to the per-issue file on the default branch, so that the candidate's in-flight status survives across cron cycles and process restarts.
+4. As a maintainer, I want a candidate's `@promotion-suggested-*` marker to exempt its file from the 14-day per-issue deletion sweep, so that a scenario under active promotion consideration is never deleted out from under me.
+5. As a maintainer, I want the sweep to file a single `adw:feature` promotion issue per qualifying per-issue **file** (whole-file granularity, matching #734), so that all of a file's scenarios move as a coherent unit.
+6. As a maintainer, I want the promotion issue body to be a precise, #734-shaped instruction (source feature + step-def paths, the scenario's phrases, destination regression directory, vocabulary registry path, and an explicit "prove `@regression` green" acceptance), so that the normal build agent performs a correct relocation without wandering.
+7. As a maintainer, I want the promotion issue labelled `adw:feature` (routing), `regression-promotion` (reconciliation key + authoring skip-flag), and `hitl` (merge gate), so that it routes through the normal pipeline but never merges without my approval.
+8. As a maintainer, I want the promotion issue body to carry a `Promotes: feature-N` marker, so that the sweep can durably link a tagged per-issue file back to its tracking issue.
+9. As a maintainer, I want the existing SDLC pipeline to move the whole feature file and its step-definitions into `features/regression/`, add a feature-level `@regression` tag, and register vocabulary, so that the promoted scenario is actually executed by the regression runner.
+10. As a maintainer, I want the pipeline's `@regression` test pass to serve as the green-proof for the moved scenarios, so that a broken promotion fails the workflow and drops into the normal fix-loop / human-gated state instead of opening a red PR.
+11. As a maintainer, I want the scenario-authoring phase to be skipped for promotion issues, so that the pipeline never invents junk `feature-<promotionIssueN>.feature` scenarios that would redden the run or become their own future promotion candidates.
+12. As a maintainer, I want an advisory rot/reuse analysis of the promoted scenario's phrases posted as a comment on the promotion PR, so that I review the vocabulary changes with per-phrase verdicts in hand rather than eyeballing raw Gherkin.
+13. As a maintainer, I want the rot analysis to be non-blocking, so that a fallible automated rot verdict cannot block a legitimate promotion — the decision stays mine.
+14. As a maintainer, I want each cron sweep to reconcile the in-flight set (files tagged `@promotion-suggested-*`) against their tracking issues, so that the sweep is idempotent and self-healing.
+15. As a maintainer, when a promotion PR merges, I want the sweep to recognise the candidate as done (its file has left `features/per-issue/`), so that it is no longer re-processed.
+16. As a maintainer, when I close a promotion issue/PR without merging (rejection), I want the sweep to write a terminal `@promotion-declined` marker to the source file and let the 14-day TTL resume, so that the rejected candidate is not re-suggested every cycle and is eventually swept normally.
+17. As a maintainer, I want `@promotion-declined` to suppress all future re-suggestion of that file, so that rejecting a promotion is durable and I am not asked twice.
+18. As a maintainer, when a tracking issue exists but its promotion workflow died before opening a healthy PR (stranded), I want the sweep to re-file/re-drive it, so that a crash between tagging and PR-open does not permanently strand a tagged, TTL-exempt, unpromoted file.
+19. As a maintainer, when re-driving a stranded candidate, I want the sweep to re-score it first and withdraw (strip the tag, resume TTL) if it no longer meets threshold, so that stale candidates whose scores have drifted below the bar are not promoted.
+20. As a maintainer, when a promotion workflow exhausts its retries and escalates to `adw:blocked`, I want the sweep to treat that as a decline for the *source* file (write `@promotion-declined`, resume TTL) while leaving the blocked tracking issue as the normal human-escalation artifact, so that an un-promotable candidate does not sit TTL-exempt and unpromoted forever.
+21. As a maintainer, on the first run I want the existing backlog of `@promotion-suggested-*` files (whose PRs merged long ago) to be re-scored and promotion issues filed for those still above threshold, so that the stranded backlog is either promoted or cleanly withdrawn rather than lost.
+22. As a maintainer, I want promotion issues to inherit ADW's existing resilience (takeover, hung-detector, `## Retry`, the stateless `(no hitl) OR (approved)` merge gate), so that no promotion-specific recovery machinery is built.
+23. As a maintainer, I want the dead promotion modules (commenter, mover, approval-detector, `adwPromotionSweep.tsx`) deleted and the README's "Scenario Promotion" section rewritten, so that the documentation stops describing a flow that never worked.
+24. As a maintainer, I want the sweep to be non-fatal (a transient git/gh error is logged and swallowed), so that a promotion-sweep failure can never crash the cron loop.
+25. As a maintainer, I want the sweep interval-gated (like the per-issue sweep), so that the git/gh *actions* (commit-to-default, issue creation, reconciliation queries) run on a generous cadence rather than every 20-second tick.
+
+## Implementation Decisions
+
+**Architecture: reuse the SDLC pipeline (Architecture Y), not a dedicated orchestrator.**
+#734 demonstrated that a promotion is just a precise `adw:feature` issue run through the normal
+plan → build → test → PR pipeline. Therefore no promotion orchestrator, no new green-proof phase,
+no promotion-specific redrive/claim primitive. The sweep files an issue; the pipeline does the rest.
+
+**New deep modules (pure — no I/O, unit-testable in isolation):**
+
+- **`promotionSweepDecider`** — the lifecycle decision function. For each per-issue file, given its promotion tag state, whether it currently scores ≥ threshold, and a reconciliation fact (`no-issue | open | merged | closed-unmerged | blocked`), it returns exactly one action: `originate | leave | done | decline | redrive | withdraw`. All rules from the design live here (see User Stories 14-20). No git/gh access.
+- **`promotionTagState`** — pure parse/serialize of the on-file markers `@promotion-suggested-<date>` and `@promotion-declined`, modelling the state machine `none → suggested → declined`. Reuses the pure marker logic salvaged from `promotionTagWriter`.
+- **`promotionReconcileLink`** — pure matcher mapping tagged per-issue files to open promotion issues via the `Promotes: feature-N` body marker; the `gh issue list --label regression-promotion` call is injected by the shell.
+- **`isPromotionExempt`** — pure predicate composed into the per-issue TTL sweep: a file is exempt while `@promotion-suggested-*`; `@promotion-declined` and untagged files are not.
+- **`promotionIssueBody`** — pure builder producing the #734-shaped issue title/body (including the `Promotes: feature-N` marker) and the label set `[adw:feature, regression-promotion, hitl]`.
+- **`shouldSkipScenarioAuthoring(labels)`** — trivial pure gate: true when `regression-promotion` is present.
+
+**Imperative shell (dependency-injected, non-fatal — mirrors `runPerIssueScenarioSweep`):**
+
+- **`runPromotionSweep(deps)`** — lists tracked `features/per-issue/feature-N.feature` on the default branch; scores them via the retained deterministic scorer; runs the injected reconciliation query; calls `promotionSweepDecider`; executes each action (write/strip marker + commit-scoped-to-those-paths to default, file the issue). Scoped commits only (never `git add -A`). Persists via `GitContext`, only when on the default branch, swallowing transient failures.
+
+**Reused (not rewritten):** `promotionScorer` (pure regex phrase-match, no LLM), `promotionThreshold` (auto-ramping), `scenarioParser`, `vocabularyParser`, `promotionStatsLoader`.
+
+**Deleted:** `promotionCommenter`, `promotionMover`, `promotionApprovalDetector`, `adwPromotionSweep.tsx`, plus their tests and JSONL/feature fixtures. The README "Scenario Promotion" section is rewritten to describe the sweep.
+
+**Pipeline modifications (minimal):**
+
+- `scenarioPhase` gains a guard: if `shouldSkipScenarioAuthoring(issueLabels)`, the scenario-authoring phases (scenario_writer and the dependent alignment / validation / gherkin-freeze / fidelity steps) no-op. This removes the reliance on LLM discretion that #734 got away with (n=1).
+- A rot-comment step runs the `promote-regression-vocabulary` analysis on the promoted scenario's phrases and posts the per-phrase reuse/rot verdicts as a PR comment. Advisory, non-blocking.
+
+**Trigger wiring:** `runPromotionSweep()` is invoked from `trigger_cron` under a new interval gate `cycleCount % PROMOTION_SWEEP_INTERVAL_CYCLES === 0`, adjacent to the existing per-issue sweep.
+
+**TTL sweep change:** `perIssueScenarioSweep` composes `isPromotionExempt(promotionTagState(fileContent))` into its staleness decision. `isScenarioStale` stays a pure age predicate; exemption is a separate composed predicate.
+
+**Labels / classification (verified):** `regression-promotion` is not an `adw:*` label, so it is invisible to `LABEL_TO_COMMAND`; `adw:feature` deterministically routes the issue and bypasses AI classification. The `regression-promotion` label already exists in the repo (legacy from the deleted mover).
+
+**Green-proof (verified):** `scenarioTestPhase` runs both `@adw-{issueNumber}` and the full `@regression` pass. After the build moves the scenario into `features/regression/` with `@regression`, the regression pass executes it; a red result flows into the normal scenario fix-loop and, on exhaustion, a human-gated state.
+
+**Empty-target-tag invariant (verified, must preserve):** a promotion issue has zero
+`@adw-{promotionIssueN}` scenarios. Because `.adw/review_proof.md` has no `## Tags` table,
+`parseReviewProofMd` falls back to defaults where `@adw-{issueNumber}` is `severity: blocker,
+optional: true`. A zero-scenario run of an optional tag is classified `{passed:true, skipped:true}`,
+so it does not contribute to `hasBlockerFailures` and the workflow does not redden. **Invariant:**
+`@adw-{issueNumber}` must remain optional (or promotion issues must be explicitly exempted); a
+future `## Tags` table marking it non-optional would hard-fail every promotion.
+
+**Merge:** the stateless `gate_open = (no hitl) OR (PR approved)` gate applies unchanged. `hitl`
+defers the merge until the maintainer approves the promotion PR, at which point the existing
+`adwMerge` path merges it.
+
+## Testing Decisions
+
+**What makes a good test here:** exercise externally-observable behaviour, not implementation
+detail. For the pure deciders that means: given an input state, assert the returned decision/marker
+— never assert on internal control flow, private helpers, or the shape of intermediate values.
+For markers, assert on the resulting file content string, not on the parsing internals. The shells
+and pipeline wiring are validated behaviourally (BDD), not unit-tested against mocks of git/gh
+internals.
+
+**Modules to unit-test (selected):**
+
+- **`promotionSweepDecider`** — the highest-value target. Table-driven tests over the full cross
+  product of `{tag state} × {score ≥ threshold?} × {reconciliation fact}` asserting the single
+  correct action, including every lifecycle edge: originate on fresh high-scorer, leave while open,
+  done on merged, decline on closed-unmerged, decline on `adw:blocked`, redrive on stranded-missing,
+  and withdraw on stranded-missing-below-threshold (score drop).
+- **`promotionTagState`** — parse and serialize round-trips for `none → suggested → declined`;
+  date-format handling; idempotent re-tagging; correct stripping on withdraw/decline.
+- **`promotionReconcileLink` + `isPromotionExempt`** — the linkage matcher (`Promotes: feature-N`
+  across a set of open issues, including no-match and multi-candidate cases) and the TTL exemption
+  predicate (exempt while suggested; not exempt when declined or untagged). This is the direct test
+  of the root-cause fix — the previously tag-blind sweep.
+
+**Not unit-tested (integration-covered):** `promotionIssueBody`, `shouldSkipScenarioAuthoring`,
+and the `runPromotionSweep` shell — exercised via BDD/pipeline behaviour rather than isolated units.
+
+**Prior art:** the pure-decider-with-table-tests pattern is well established — `worktreeReuseGate`,
+`resolveResumeSpawn`, `decideUpgradeRedrive`/`upgradeFailureCap`, `resumePolicy`/`nextResumeAction`,
+`resolveVerdict`, and `stageClassifier` are all pure functions with exhaustive case tests. The
+dependency-injected, non-fatal shell pattern mirrors `runPerIssueScenarioSweep`
+(`perIssueScenarioSweep.ts`) and its tests.
+
+## Out of Scope
+
+- **Per-scenario (sub-file) promotion.** Granularity is whole-file; splitting a feature file and its
+  shared step-definitions is explicitly not built.
+- **A dedicated promotion orchestrator, green-proof phase, redrive cron, or claim primitive** — the
+  design deliberately reuses the SDLC pipeline and inherits existing resilience.
+- **Automated authoring of rot-compliant vocabulary as a *gate*.** The build agent authors vocabulary;
+  rot is surfaced advisorily on the PR and judged by the human. No blocking rot check.
+- **Cross-host coordination.** Inherits the single-host constraint; the sweep runs only in cron.
+- **Auto-merge of promotion PRs without human approval.** `hitl` is always applied; a maintainer
+  approves every promotion.
+- **Changing the deterministic scorer or the auto-ramping threshold logic.** Reused as-is.
+- **Investigating or fixing the pre-existing red per-issue scenarios** surfaced by the earlier
+  green-run sweep (504/524/565/572/577/614) — unrelated to this feature.
+
+## Further Notes
+
+- **Root cause restated:** "files with `@promotion-suggested-*` get lost" = (1) nothing ever moved a
+  suggested candidate into the executed suite, and (2) `perIssueScenarioSweep.isScenarioStale` is
+  age-only and tag-blind, so it deletes candidates on the 14-day TTL. This PRD fixes both: the sweep
+  moves them (via the pipeline) and the TTL sweep becomes promotion-aware.
+- **Idempotency of record:** the `@promotion-suggested-<date>` marker on the default branch is the
+  durable in-flight marker (chosen over an open-PR check). The reconciliation query over the small
+  tagged set resolves redrive vs decline vs done each cycle — a single cheap pass that unifies
+  re-drive and rejection detection.
+- **Residual to finalise during implementation:** the exact skip-gate cascade scope (confirm that
+  suppressing scenario_writer cleanly no-ops the dependent alignment/validation/gherkin-freeze/
+  fidelity steps), the rot-comment's wiring point in the pipeline, and the value of
+  `PROMOTION_SWEEP_INTERVAL_CYCLES`.
+- **Reference implementation:** `specs/issue-734-...promote-729-regression-scenario.md` is the
+  hand-done promotion this automates; its glob-neutrality, import-depth, and `@regression` mock-infra
+  observations are the concrete gotchas the build agent must handle per candidate (a candidate can
+  score high yet be un-promotable without adaptation — which is why the `@regression` green-proof gate
+  is non-negotiable).
+- **Governance shift:** this reverses the "no automated promotion" stance to "automated discovery +
+  preparation, human-gated merge." Human curation is preserved at the `hitl` PR gate.


### PR DESCRIPTION
Adds two docs/tooling artifacts (no runtime code):

- **`.claude/skills/promote-regression-vocabulary/`** — advisory skill that scans per-issue BDD features for promotion candidates and produces per-phrase reuse/rot verdicts against the regression vocabulary registry. Writes nothing; informs the human promotion decision.
- **`specs/prd/automated-scenario-promotion-sweep.md`** — PRD for automating scenario promotion: a cron sweep that scores per-issue scenarios, marks candidates, and files `hitl`-gated `adw:feature` promotion issues driven through the existing SDLC pipeline (Architecture Y). Also makes the 14-day per-issue TTL sweep promotion-aware, fixing the root cause of `@promotion-suggested-*` files getting silently deleted.

Docs/PRD only — no behavioural change to ADW.

🤖 Generated with [Claude Code](https://claude.com/claude-code)