### PR TITLE
fix: mark /workspace as a git safe.directory in the BDD runner image

### DIFF
--- a/test/Dockerfile
+++ b/test/Dockerfile
@@ -18,6 +18,12 @@ RUN apt-get update && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*
 
+# The mounted repo is owned by the host user (e.g. the CI runner's UID),
+# which differs from the container user — git >= 2.35.2 refuses to read
+# such a repo ("dubious ownership"). System-level config covers every
+# container user and survives env-sanitized subprocess spawns.
+RUN git config --system --add safe.directory /workspace
+
 # /workspace — ADW repo root, mounted read-only at run time
 # /tmp/bdd   — writable scratch space for fixture repos and mock artifacts
 RUN mkdir -p /workspace /tmp/bdd


### PR DESCRIPTION
## Summary
- The regression workflow's Docker pass fails with `fatal: detected dubious ownership in repository at '/workspace'`: `actions/checkout` creates the repo owned by the runner user (UID 1001), `docker-run.sh` mounts it read-only into a container running as root, and git >= 2.35.2 refuses to operate on a repo owned by a different user.
- First failure point is the module-scope `readLocalRepoInfo` bootstrap (`adws/gitContext/bootstrapIdentity.ts`) when a scenario imports `trigger_cron.ts`.
- Fix: bake `git config --system --add safe.directory /workspace` into the runner image at build time. System-level config (`/etc/gitconfig`) covers any container user and survives env-sanitized subprocess spawns; the image is hermetic test infra that always mounts the repo at `/workspace`, so the exemption is safe by construction.

## Verification
- Rebuilt the image locally: `git config --system --get-all safe.directory` inside the container returns `/workspace`.
- The ownership mismatch itself can't be reproduced on macOS (Docker Desktop masks mount ownership) — end-to-end confirmation comes from the next scheduled regression run or a `workflow_dispatch` with runtime `docker`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)