### PR TITLE
chore: configure observability logs for workers

### DIFF
--- a/workers/cost-api/wrangler.toml
+++ b/workers/cost-api/wrangler.toml
@@ -27,3 +27,7 @@ secret_name = "COST_API_TOKEN"
 
 # Required Worker secrets (set via `wrangler secret put`):
 #   ALLOWED_ORIGINS
+
+[observability.logs]
+enabled = false
+invocation_logs = true

--- a/workers/screenshot-router/wrangler.toml
+++ b/workers/screenshot-router/wrangler.toml
@@ -24,3 +24,7 @@ crons = ["0 3 * * *"]
 #   CLOUDFLARE_ACCOUNT_ID
 #   R2_ACCESS_KEY_ID
 #   R2_SECRET_ACCESS_KEY
+
+[observability.logs]
+enabled = false
+invocation_logs = true


### PR DESCRIPTION
## Summary
- Enable invocation logs (with general logs disabled) for the screenshot-router worker
- Apply the same observability logs configuration to the cost-api worker

🤖 Generated with [Claude Code](https://claude.com/claude-code)