### PR TITLE
fix: stop swallowing hook block signals with || true

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -27,7 +27,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "bunx tsx $CLAUDE_PROJECT_DIR/.claude/hooks/pre-tool-use.ts || true"
+            "command": "bunx tsx $CLAUDE_PROJECT_DIR/.claude/hooks/pre-tool-use.ts"
           }
         ]
       }
@@ -38,7 +38,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "bunx tsx $CLAUDE_PROJECT_DIR/.claude/hooks/post-tool-use.ts || true"
+            "command": "bunx tsx $CLAUDE_PROJECT_DIR/.claude/hooks/post-tool-use.ts"
           }
         ]
       }
@@ -49,7 +49,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "bunx tsx $CLAUDE_PROJECT_DIR/.claude/hooks/notification.ts --notify || true"
+            "command": "bunx tsx $CLAUDE_PROJECT_DIR/.claude/hooks/notification.ts --notify"
           }
         ]
       }
@@ -60,7 +60,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "bunx tsx $CLAUDE_PROJECT_DIR/.claude/hooks/stop.ts --chat || true"
+            "command": "bunx tsx $CLAUDE_PROJECT_DIR/.claude/hooks/stop.ts --chat"
           }
         ]
       }
@@ -71,7 +71,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "bunx tsx $CLAUDE_PROJECT_DIR/.claude/hooks/subagent-stop.ts || true"
+            "command": "bunx tsx $CLAUDE_PROJECT_DIR/.claude/hooks/subagent-stop.ts"
           }
         ]
       }


### PR DESCRIPTION
## Summary
- Remove `|| true` from all five hook registrations in `.claude/settings.json`.
- The suffix rewrote exit code 2 — the PreToolUse blocking signal — to 0, so the env-file-access and destructive-command blocks in `pre-tool-use.ts` were never enforced (verified live: reads of the env file sailed through; after this change they are blocked).
- The guard is unnecessary for resilience: any exit code other than 2 is a non-blocking hook error and the tool call proceeds anyway.

## Remaining gap (not in this PR)
`adws/core/guardrailsPayload.ts:60` builds the injected target-repo hook commands with the same `|| true`, so guardrails injected into target-repo agent spawns still cannot block. Needs a follow-up with test updates in `guardrailsPayload.test.ts`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)