### PR TITLE
fix: throw contextual non-auth error in gitAgent

### DIFF
--- a/adws/agents/__tests__/gitAgent.test.ts
+++ b/adws/agents/__tests__/gitAgent.test.ts
@@ -67,7 +67,7 @@ describe('runCommitAgent — result.success guard', () => {
     });
 
     await expect(runCommitAgent('build-agent', '/feature', '{}', '/tmp/logs'))
-      .rejects.toThrow("Commit agent 'build-agent' failed:");
+      .rejects.toThrow("Commit agent 'build-agent' (/feature) failed:");
   });
 
   it('includes agent name in the thrown error', async () => {
@@ -248,5 +248,38 @@ describe('runGenerateBranchNameAgent — AuthRequiredError propagation', () => {
     }
 
     expect(thrownError).toBeInstanceOf(AuthRequiredError);
+  });
+
+  it('throws a plain Error (not AuthRequiredError) with issue context on a non-auth failure', async () => {
+    mockRunAgent.mockResolvedValueOnce({
+      success: false,
+      output: 'spawn claude ENOENT',
+      ...baseAgentResult,
+    });
+
+    let thrownError: unknown;
+    try {
+      await runGenerateBranchNameAgent('/feature', mockIssue, '/tmp/logs');
+    } catch (err) {
+      thrownError = err;
+    }
+
+    expect(thrownError).toBeInstanceOf(Error);
+    expect(thrownError).not.toBeInstanceOf(AuthRequiredError);
+    expect((thrownError as Error).message).toContain('#42');
+    expect((thrownError as Error).message).toContain('/feature');
+    expect((thrownError as Error).message).toContain('spawn claude ENOENT');
+  });
+
+  it('reports "(no agent output)" when a non-auth failure has empty output', async () => {
+    mockRunAgent.mockResolvedValueOnce({
+      success: false,
+      output: '',
+      ...baseAgentResult,
+    });
+
+    await expect(
+      runGenerateBranchNameAgent('/feature', mockIssue, '/tmp/logs')
+    ).rejects.toThrow('(no agent output)');
   });
 });

--- a/adws/agents/gitAgent.ts
+++ b/adws/agents/gitAgent.ts
@@ -75,8 +75,16 @@ export async function runGenerateBranchNameAgent(
     launchContext,
   );
 
-  if (!result.success || result.authExpired) {
+  if (result.authExpired) {
     throw new AuthRequiredError('Branch Name');
+  }
+  if (!result.success) {
+    // A non-auth failure must NOT be an AuthRequiredError — callers route that
+    // class to the auth-pause path instead of the deterministic branch fallback.
+    throw new Error(
+      `Branch Name agent failed for issue #${issue.number} (${issueType}): ` +
+        `${result.output.trim().slice(0, 200) || '(no agent output)'}`,
+    );
   }
   const slug = extractSlugFromOutput(result.output);
   const branchName = generateBranchName(issue.number, slug, issueType);
@@ -203,7 +211,10 @@ export async function runCommitAgent(
   );
 
   if (!result.success) {
-    throw new Error(`Commit agent '${agentName}' failed: ${result.output.slice(0, 200)}`);
+    throw new Error(
+      `Commit agent '${agentName}' (${issueClass}) failed: ` +
+        `${result.output.trim().slice(0, 200) || '(no agent output)'}`,
+    );
   }
 
   const rawMessage = extractCommitMessageFromOutput(result.output);


### PR DESCRIPTION
## Summary

`runGenerateBranchNameAgent` threw `AuthRequiredError('Branch Name')` for **any** failure (`!result.success || result.authExpired`), which had two problems:

1. **Useless message** — a spawn failure or malformed agent output surfaced as "Authentication required for agent: Branch Name", discarding the real cause.
2. **Wrong recovery routing** — `branchNameResolution.ts` re-throws `AuthRequiredError` specifically to trigger the auth-pause path (`paused_auth` + Slack alert), while all other errors fall back to the deterministic slug-free branch name. A plain agent failure was therefore pausing the workflow for auth instead of taking the documented fallback.

Splitting the guard is safe because `claudeAgent.ts` already throws `AuthRequiredError` itself on real auth detection — a returned `success: false` without `authExpired` is genuinely non-auth.

## Changes

- `adws/agents/gitAgent.ts` — split the guard: `authExpired` still throws `AuthRequiredError`; a non-auth failure now throws a plain `Error` carrying the issue number, issue type, and the first 200 chars of agent output (or `(no agent output)` when empty).
- `adws/agents/gitAgent.ts` (`runCommitAgent`) — added issue class and the same empty-output fallback to the existing commit-agent throw so it never ends in a bare colon.
- `adws/agents/__tests__/gitAgent.test.ts` — two new tests pinning the routing fix; one existing assertion updated to the new message shape.

## Testing

- `bunx vitest run adws/agents/__tests__/gitAgent.test.ts adws/phases/__tests__/branchNameResolution.test.ts` — 38 passed
- `bun run test` (typecheck) — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)